### PR TITLE
Apply `Parser.filepath` to normalise path retrieved from Editor

### DIFF
--- a/src/Editor.re
+++ b/src/Editor.re
@@ -47,7 +47,7 @@ let editorType = Sig.VsCode;
 let getExtensionPath = context => context->ExtensionContext.extensionPath;
 
 let getFileName = editor =>
-  Some(editor->TextEditor.document->TextDocument.fileName);
+  Some(editor->TextEditor.document->TextDocument.fileName->Parser.filepath);
 
 let save = editor => editor->TextEditor.document->TextDocument.save;
 


### PR DESCRIPTION
This fixes the "Load" command on Windows - and presumably all the other commands relying on this too.

I can't tell if this breaks anything else though - hopefully not!