### PR TITLE
[  fix/Editor ] agda-mode for all .lagda.* files

### DIFF
--- a/lib/js/src/Editor.bs.js
+++ b/lib/js/src/Editor.bs.js
@@ -144,7 +144,7 @@ function onDidChangeActivation(callback) {
 
 function isAgda(filepath) {
   var filepath$1 = Parser$AgdaModeVscode.filepath(filepath);
-  return /\.agda$|\.lagda$/i.test(filepath$1);
+  return /\.agda$|\.lagda/i.test(filepath$1);
 }
 
 function registerCommand(name, callback) {

--- a/src/Editor.re
+++ b/src/Editor.re
@@ -90,7 +90,7 @@ let onDidChangeActivation = callback => {
 // if end with '.agda' or '.lagda'
 let isAgda = (filepath): bool => {
   let filepath = filepath->Parser.filepath;
-  Js.Re.test_([%re "/\\.agda$|\\.lagda$/i"], filepath);
+  Js.Re.test_([%re "/\\.agda$|\\.lagda/i"], filepath);
 };
 
 let registerCommand = (name, callback) =>


### PR DESCRIPTION
This small fix allows to load the agda-mode not only for 
.lagda files but also for .lagda.tex, among the others.
