### PR TITLE
[ fix ] Revert "Bump tar from 6.1.8 to 6.1.11"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "agda-mode",
-	"version": "0.2.19",
+	"version": "0.2.17",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1735,12 +1735,6 @@
 				"eventemitter3": "^4.0.7",
 				"unzipper": "^0.10.11",
 				"vscode-languageclient": "^8.0.0-next.1"
-			},
-			"dependencies": {
-				"@glennsl/bs-json": {
-					"version": "github:banacorn/bs-json#0c900d3ad5c06eb2e6513a677096f1ec0411d282",
-					"from": "github:banacorn/bs-json#0c900d3"
-				}
 			}
 		},
 		"less": {
@@ -2795,9 +2789,9 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "6.1.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
-			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+			"version": "6.1.8",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
+			"integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
 			"dev": true,
 			"requires": {
 				"chownr": "^2.0.0",


### PR DESCRIPTION
Reverts banacorn/agda-mode-vscode#64