### PR TITLE
Jump to the middle of goals

### DIFF
--- a/lib/js/src/State/State__Goal.bs.js
+++ b/lib/js/src/State/State__Goal.bs.js
@@ -16,7 +16,9 @@ var State__View$AgdaModeVscode = require("./State__View.bs.js");
 
 function getOffsets(state) {
   return Belt_Array.map(state.goals, (function (goal) {
-                return goal.interval[0] + 3 | 0;
+                var match = goal.interval;
+                var from = match[0];
+                return from + ((match[1] - from | 0) / 2 | 0) | 0;
               }));
 }
 

--- a/src/State/State__Goal.res
+++ b/src/State/State__Goal.res
@@ -17,7 +17,10 @@ module type Module = {
 module Module: Module = {
   // return an array of Offsets of Goals
   let getOffsets = (state: State.t): array<int> =>
-    state.goals->Array.map(goal => fst(goal.interval) + 3)
+    state.goals->Array.map(goal => {
+      let (from, to) = goal.interval
+      from + (to - from)/2
+    })
 
   // There are two kinds of lambda abstraction
   //  1.  λ { x → ? }


### PR DESCRIPTION
Currently the next/previous goal commands jump 3 characters after the opening curly brace, which is a problem if some space was deleted in the placeholder.

Jump to the middle of the interval instead.

Tested.