### PR TITLE
Prevent expressions from being quoted twice

### DIFF
--- a/lib/js/src/Goal.bs.js
+++ b/lib/js/src/Goal.bs.js
@@ -63,7 +63,7 @@ function getOuterRange(self, $$document) {
 
 function getContent(self, $$document) {
   var innerRange = getInnerRange(self, $$document);
-  return Parser$AgdaModeVscode.userInput(Editor$AgdaModeVscode.$$Text.get($$document, innerRange));
+  return Editor$AgdaModeVscode.$$Text.get($$document, innerRange).trim();
 }
 
 function setContent(self, $$document, text) {

--- a/lib/js/src/Request.bs.js
+++ b/lib/js/src/Request.bs.js
@@ -146,7 +146,7 @@ function encode($$document, version, filepath, backend, libraryPath, highlightin
       case /* Give */4 :
           var goal = request._0;
           var index$1 = String(goal.index);
-          var content$1 = Goal$AgdaModeVscode.getContent(goal, $$document);
+          var content$1 = Parser$AgdaModeVscode.userInput(Goal$AgdaModeVscode.getContent(goal, $$document));
           var range = buildRange(goal);
           if (Util$AgdaModeVscode.Version.gte(version, "2.5.3")) {
             return commonPart(/* NonInteractive */1) + ("( Cmd_give WithoutForce " + index$1 + " " + range + " \"" + content$1 + "\" )");
@@ -156,7 +156,7 @@ function encode($$document, version, filepath, backend, libraryPath, highlightin
       case /* Refine */5 :
           var goal$1 = request._0;
           var index$2 = String(goal$1.index);
-          var content$2 = Goal$AgdaModeVscode.getContent(goal$1, $$document);
+          var content$2 = Parser$AgdaModeVscode.userInput(Goal$AgdaModeVscode.getContent(goal$1, $$document));
           var range$1 = buildRange(goal$1);
           return commonPart(/* NonInteractive */1) + ("( Cmd_refine_or_intro False " + index$2 + " " + range$1 + " \"" + content$2 + "\" )");
       case /* ElaborateAndGive */6 :
@@ -167,7 +167,7 @@ function encode($$document, version, filepath, backend, libraryPath, highlightin
       case /* Auto */7 :
           var goal$2 = request._0;
           var index$4 = String(goal$2.index);
-          var content$4 = Goal$AgdaModeVscode.getContent(goal$2, $$document);
+          var content$4 = Parser$AgdaModeVscode.userInput(Goal$AgdaModeVscode.getContent(goal$2, $$document));
           var range$2 = buildRange(goal$2);
           if (Util$AgdaModeVscode.Version.gte(version, "2.6.0.1")) {
             return commonPart(/* NonInteractive */1) + ("( Cmd_autoOne " + index$4 + " " + range$2 + " \"" + content$4 + "\" )");
@@ -177,7 +177,7 @@ function encode($$document, version, filepath, backend, libraryPath, highlightin
       case /* Case */8 :
           var goal$3 = request._0;
           var index$5 = String(goal$3.index);
-          var content$5 = Goal$AgdaModeVscode.getContent(goal$3, $$document);
+          var content$5 = Parser$AgdaModeVscode.userInput(Goal$AgdaModeVscode.getContent(goal$3, $$document));
           var range$3 = buildRange(goal$3);
           return commonPart(/* NonInteractive */1) + ("( Cmd_make_case " + index$5 + " " + range$3 + " \"" + content$5 + "\" )");
       case /* HelperFunctionType */9 :

--- a/src/Goal.res
+++ b/src/Goal.res
@@ -97,7 +97,7 @@ module Module: Module = {
 
   let getContent = (self, document) => {
     let innerRange = getInnerRange(self, document)
-    Editor.Text.get(document, innerRange)->Parser.userInput
+    Editor.Text.get(document, innerRange)->Js.String.trim
   }
 
   let setContent = (self, document, text) => {

--- a/src/Request.res
+++ b/src/Request.res
@@ -150,7 +150,7 @@ let encode = (
   // https://github.com/agda/agda/commit/021e6d24f47bac462d8bc88e2ea685d6156197c4
   | Give(goal) =>
     let index: string = string_of_int(goal.index)
-    let content: string = Goal.getContent(goal, document)
+    let content: string = Goal.getContent(goal, document)->Parser.userInput
     let range: string = buildRange(goal)
     if Util.Version.gte(version, "2.5.3") {
       j`${commonPart(NonInteractive)}( Cmd_give WithoutForce $(index) $(range) "$(content)" )`
@@ -160,7 +160,7 @@ let encode = (
 
   | Refine(goal) =>
     let index: string = string_of_int(goal.index)
-    let content: string = Goal.getContent(goal, document)
+    let content: string = Goal.getContent(goal, document)->Parser.userInput
     let range: string = buildRange(goal)
     j`${commonPart(NonInteractive)}( Cmd_refine_or_intro False $(index) $(range) "$(content)" )`
 
@@ -175,7 +175,7 @@ let encode = (
 
   | Auto(goal) =>
     let index: string = string_of_int(goal.index)
-    let content: string = Goal.getContent(goal, document)
+    let content: string = Goal.getContent(goal, document)->Parser.userInput
     let range: string = buildRange(goal)
     if Util.Version.gte(version, "2.6.0.1") {
       // after 2.6.0.1
@@ -187,7 +187,7 @@ let encode = (
 
   | Case(goal) =>
     let index: string = string_of_int(goal.index)
-    let content: string = Goal.getContent(goal, document)
+    let content: string = Goal.getContent(goal, document)->Parser.userInput
     let range: string = buildRange(goal)
     j`${commonPart(NonInteractive)}( Cmd_make_case $(index) $(range) "$(content)" )`
 


### PR DESCRIPTION
Hello! I ran into an issue a while ago, where trying to elaborate/give expressions in holes that contain strings resulted in lexical errors. These errors did not occur in `agda-mode` for Emacs.

<details>
  <summary>Screenshot</summary>

  ![A screenshot of Visual Studio Code, displaying the demo code and the lexical error](https://user-images.githubusercontent.com/17430732/170238815-26e5c6f1-14f9-483e-86ce-d547078786c1.png)

</details>

<details>
  <summary>Demo code in the screenshot</summary>

  ```agda
  open import Agda.Builtin.List
  open import Agda.Builtin.Nat
  open import Agda.Builtin.String
  open import Agda.Builtin.Reflection
  open import Agda.Builtin.Unit

  macro
    doAThing : String → Term → TC ⊤
    doAThing s h = typeError (strErr "Finished" ∷ [])

  thing : Nat
  thing = {! doAThing "x"  !}

  thing2 : String
  thing2 = {! "x"  !}
  ```
</details>

This only happens when the expression from the hole in the source code is used. If the hole is empty, `agda-mode-vscode` will prompt for an expression, and the same expression will work.

The error occurs because expressions that are obtained from holes in the source code are quoted twice, using `Parser.userInput`. The quoting happens in [`Goal.getContent`](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/Goal.res#L100) and again in the [request encoding](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/Request.res#L170). This results in string values such as `"x"` being turned into `"\\\"x\\\""`, and then into `"\\\\\\\"x\\\\\\\""` in the second phase.

This pull request makes the following changes:

1. Replaces `->Parser.userInput` with `JS.String.trim` in `Goal.getContent`. This means that `getContent` is no longer escaped properly. The reason `trim` is introduced is so that the matches on the empty string (such as [this one](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/State/State__Command.res#L83)) continue to work well.
2. Most applications of `getContent` have gotten an additional `->Parser.userInput`. Notable exceptions are:
    - The call in [`pointed`](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/State/State__Goal.res#L310). This one should be fine, since it's mostly used to find the selected goal and its contents. In these cases, we explicitly do not want quoting to occur.
    - The call in [`modify`](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/State/State__Goal.res#L310). I believe this one should be mostly fine, as the content is used as the argument to the `f` function. It is only used in [`GiveParen`](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/State/State__Response.res#L159) and in the [`input methods`](https://github.com/banacorn/agda-mode-vscode/blob/058c833a18908a29ff84ea67237e893df8a2b025/src/InputMethod/IM.res#L192). ⚠️ I am not sure how to test these cases myself, although I do not believe they would run into problems because of this change.