### PR TITLE
remove "machine-overridable" scope from some settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -799,7 +799,6 @@
 						"bottom",
 						"right"
 					],
-					"scope": "machine-overridable",
 					"description": "Where to mount the panel"
 				},
 				"agdaMode.libraryPath": {
@@ -821,7 +820,6 @@
 				"agdaMode.highlighting.getHighlightWithThemeColors": {
 					"type": "boolean",
 					"default": true,
-					"scope": "machine-overridable",
 					"description": "Highlight stuff with theme colors"
 				},
 				"agdaMode.backend": {
@@ -838,13 +836,11 @@
 				"agdaMode.inputMethod.enable": {
 					"type": "boolean",
 					"default": true,
-					"scope": "machine-overridable",
 					"description": "Enable Unicode input method"
 				},
 				"agdaMode.inputMethod.activationKey": {
 					"type": "string",
 					"default": "\\",
-					"scope": "machine-overridable",
 					"description": "Key for activating Unicode input method"
 				}
 			}


### PR DESCRIPTION
These settings are user interface settings and should probably not be marked `"machine-overridable"`, so that they can be synced. This makes this extension more consistent with other extensions.