### PR TITLE
[ fix ] "go to definition" on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Yarn cache
+.yarn/*
+yarn.lock

--- a/lib/js/src/Main.bs.js
+++ b/lib/js/src/Main.bs.js
@@ -122,8 +122,9 @@ function initialize(debugChan, extensionPath, globalStoragePath, editor, fileNam
           }));
   subscribe(Editor$AgdaModeVscode.Provider.registerDefinitionProvider(function (fileName, position) {
             var currentFileName = Parser$AgdaModeVscode.filepath(state.document.fileName);
+            var normalizedFileName = Parser$AgdaModeVscode.filepath(fileName);
             var offset = Editor$AgdaModeVscode.Position.toOffset(state.document, position);
-            if (fileName === currentFileName) {
+            if (normalizedFileName === currentFileName) {
               return Tokens$AgdaModeVscode.lookupSrcLoc(state.tokens, offset);
             }
             

--- a/lib/js/src/Tokens.bs.js
+++ b/lib/js/src/Tokens.bs.js
@@ -247,10 +247,14 @@ function make(param) {
 
 function insert(self, editor, tokens) {
   return Belt_Array.forEach(tokens, (function (info) {
-                var existing = AVLTree$AgdaModeVscode.find(self.tokens, info.start);
+                var $$document = editor.document;
+                var text = Editor$AgdaModeVscode.$$Text.getAll($$document);
+                var offsetConverter = Agda$AgdaModeVscode.OffsetConverter.make(text);
+                var startOffset = Agda$AgdaModeVscode.OffsetConverter.convert(offsetConverter, info.start);
+                var existing = AVLTree$AgdaModeVscode.find(self.tokens, startOffset);
                 if (existing !== undefined) {
                   var old = existing[0];
-                  self.tokens.remove(info.start);
+                  self.tokens.remove(startOffset);
                   var newAspects = Caml_obj.caml_equal(old.aspects, info.aspects) ? old.aspects : Belt_Array.concat(old.aspects, info.aspects);
                   var new_start = old.start;
                   var new_end_ = old.end_;
@@ -265,19 +269,16 @@ function insert(self, editor, tokens) {
                     note: new_note,
                     source: new_source
                   };
-                  self.tokens.insert(info.start, [
+                  self.tokens.insert(startOffset, [
                         $$new,
                         existing[1]
                       ]);
                   return ;
                 }
-                var $$document = editor.document;
-                var text = Editor$AgdaModeVscode.$$Text.getAll($$document);
-                var offsetConverter = Agda$AgdaModeVscode.OffsetConverter.make(text);
-                var start = Editor$AgdaModeVscode.Position.fromOffset($$document, Agda$AgdaModeVscode.OffsetConverter.convert(offsetConverter, info.start));
+                var start = Editor$AgdaModeVscode.Position.fromOffset($$document, startOffset);
                 var end_ = Editor$AgdaModeVscode.Position.fromOffset($$document, Agda$AgdaModeVscode.OffsetConverter.convert(offsetConverter, info.end_));
                 var range = new Vscode.Range(start, end_);
-                self.tokens.insert(info.start, [
+                self.tokens.insert(startOffset, [
                       info,
                       range
                     ]);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"scripts": {
 		"clean": "npx rescript clean",
 		"build": "npx rescript build -with-deps && npx lessc style/style.less dist/style.css && webpack --mode development",
-		"dev": "npx less-watch-compiler style/ dist/ & webpack --mode development --watch",
+		"dev": "npx less-watch-compiler style/ dist/ && webpack --mode development --watch",
 		"vscode:prepublish": "npx rescript && npx lessc style/style.less dist/style.css && webpack --mode production",
 		"test": "node lib/js/test/RunTestFromCLI.bs.js",
 		"vfx-dry-run": "npm list --production --parseable --depth=99999 --loglevel=error"

--- a/src/Main.res
+++ b/src/Main.res
@@ -104,9 +104,10 @@ let initialize = (debugChan, extensionPath, globalStoragePath, editor, fileName)
   Editor.Provider.registerDefinitionProvider((fileName, position) => {
     // only provide source location, when the filename matched
     let currentFileName = state.document->VSCode.TextDocument.fileName->Parser.filepath
+    let normalizedFileName = Parser.filepath(fileName)
     let offset = Editor.Position.toOffset(state.document, position)
 
-    if fileName == currentFileName {
+    if normalizedFileName == currentFileName {
       state.tokens->Tokens.lookupSrcLoc(offset)
     } else {
       None


### PR DESCRIPTION
Solving #44 , tested on my machine
I worry that I could break something on other OSes now, so please check if the change is ok! 🥺

The normalizedFileName issue prevented even stepping into the main function. But then, the tokens were wrongly offset because of surrogate pairs. If I had the 𝕊 character inside my agda file it would break - have had it worked on Mac?