### PR TITLE
[ fix ] Update language-server-mule to 0.2.4 (Fixes LSP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agda-mode",
-	"version": "0.3.10",
+	"version": "0.3.11",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agda-mode",
-			"version": "0.3.10",
+			"version": "0.3.11",
 			"dependencies": {
 				"@datastructures-js/binary-search-tree": "^4.3.0",
 				"@glennsl/bs-json": "github:banacorn/bs-json#0c900d3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"compare-versions": "^3.5.1",
 				"eventemitter3": ">=4.0.0",
 				"getos": "^3.2.1",
-				"language-server-mule": "github:banacorn/language-server-mule#v0.2.3",
+				"language-server-mule": "github:banacorn/language-server-mule#731475993ee538218cb12c501b12b0ef21e0c821",
 				"react": "^16.9.0",
 				"react-dom": "^16.9.0",
 				"reason-nodejs": "github:banacorn/reason-nodejs#temp",
@@ -116,13 +116,13 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"version": "0.3.17",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/resolve-uri": "3.1.0",
+				"@jridgewell/sourcemap-codec": "1.4.14"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -202,9 +202,9 @@
 			}
 		},
 		"node_modules/@types/eslint": {
-			"version": "8.4.5",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-			"integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+			"version": "8.4.8",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.8.tgz",
+			"integrity": "sha512-zUCKQI1bUCTi+0kQs5ZQzQ/XILWRLIlh15FXWNykJ+NG3TMKMVvwwC6GP3DR1Ylga15fB7iAExSzc4PNlR5i3w==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -234,9 +234,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.6.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+			"version": "18.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
+			"integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
 			"dev": true
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -434,9 +434,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -697,9 +697,9 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+			"version": "4.21.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
 			"dev": true,
 			"funding": [
 				{
@@ -712,10 +712,10 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001370",
-				"electron-to-chromium": "^1.4.202",
+				"caniuse-lite": "^1.0.30001400",
+				"electron-to-chromium": "^1.4.251",
 				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.5"
+				"update-browserslist-db": "^1.0.9"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -935,9 +935,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001374",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+			"version": "1.0.30001426",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+			"integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
 			"dev": true,
 			"funding": [
 				{
@@ -1287,9 +1287,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.211",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-			"integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
+			"version": "1.4.284",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -1346,31 +1346,32 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+			"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.1",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.7",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.0",
+				"object-inspect": "^1.12.2",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
+				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
@@ -1383,9 +1384,9 @@
 			}
 		},
 		"node_modules/es-abstract/node_modules/object.assign": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-			"integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
@@ -1530,9 +1531,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -1733,9 +1734,9 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-			"integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
 			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
@@ -2181,9 +2182,9 @@
 			}
 		},
 		"node_modules/is-callable": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
@@ -2193,9 +2194,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -2493,13 +2494,14 @@
 		},
 		"node_modules/language-server-mule": {
 			"version": "0.2.3",
-			"resolved": "git+ssh://git@github.com/banacorn/language-server-mule.git#2caa861918e2bceda9f6c004a8a01b69c9dc8cce",
+			"resolved": "git+ssh://git@github.com/banacorn/language-server-mule.git#731475993ee538218cb12c501b12b0ef21e0c821",
+			"integrity": "sha512-ICXzKYmErCGMIZqISPI2p/p7HL8LYKnsZEAxub17IaSeACifYtx9tFPzN9bYUpcBCglOw5m1E9OuHP2iNpRUzw==",
 			"license": "MIT",
 			"dependencies": {
 				"@glennsl/bs-json": "github:banacorn/bs-json#0c900d3",
 				"eventemitter3": "^4.0.7",
 				"unzipper": "^0.10.11",
-				"vscode-languageclient": "^8.0.0-next.1"
+				"vscode-languageclient": "^7.0.0"
 			}
 		},
 		"node_modules/less": {
@@ -2606,9 +2608,9 @@
 			}
 		},
 		"node_modules/loader-utils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-			"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+			"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -2779,9 +2781,12 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minipass": {
 			"version": "3.3.4",
@@ -3612,6 +3617,20 @@
 				}
 			]
 		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dev": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3654,9 +3673,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -3929,9 +3948,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.15.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -3947,16 +3966,16 @@
 			}
 		},
 		"node_modules/terser-webpack-plugin": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-			"integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.7",
+				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
 				"serialize-javascript": "^6.0.0",
-				"terser": "^5.7.2"
+				"terser": "^5.14.1"
 			},
 			"engines": {
 				"node": ">= 10.13.0"
@@ -4080,9 +4099,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-			"integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -4126,39 +4145,39 @@
 			"deprecated": "This package is deprecated, please use @vscode/codicons https://www.npmjs.com/package/@vscode/codicons"
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
 			"engines": {
-				"node": ">=14.0.0"
+				"node": ">=8.0.0 || >=10.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
 			"dependencies": {
 				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.2"
+				"semver": "^7.3.4",
+				"vscode-languageserver-protocol": "3.16.0"
 			},
 			"engines": {
-				"vscode": "^1.67.0"
+				"vscode": "^1.52.0"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
 			"dependencies": {
-				"vscode-jsonrpc": "8.0.2",
-				"vscode-languageserver-types": "3.17.2"
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
 			}
 		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
 		},
 		"node_modules/vscode-test": {
 			"version": "1.6.1",
@@ -4611,13 +4630,13 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"version": "0.3.17",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/resolve-uri": "3.1.0",
+				"@jridgewell/sourcemap-codec": "1.4.14"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -4679,9 +4698,9 @@
 			"dev": true
 		},
 		"@types/eslint": {
-			"version": "8.4.5",
-			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-			"integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+			"version": "8.4.8",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.8.tgz",
+			"integrity": "sha512-zUCKQI1bUCTi+0kQs5ZQzQ/XILWRLIlh15FXWNykJ+NG3TMKMVvwwC6GP3DR1Ylga15fB7iAExSzc4PNlR5i3w==",
 			"dev": true,
 			"requires": {
 				"@types/estree": "*",
@@ -4711,9 +4730,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.6.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+			"version": "18.11.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.7.tgz",
+			"integrity": "sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -4898,9 +4917,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "8.8.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"version": "8.8.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
 			"dev": true
 		},
 		"acorn-import-assertions": {
@@ -5096,15 +5115,15 @@
 			"dev": true
 		},
 		"browserslist": {
-			"version": "4.21.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+			"version": "4.21.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001370",
-				"electron-to-chromium": "^1.4.202",
+				"caniuse-lite": "^1.0.30001400",
+				"electron-to-chromium": "^1.4.251",
 				"node-releases": "^2.0.6",
-				"update-browserslist-db": "^1.0.5"
+				"update-browserslist-db": "^1.0.9"
 			}
 		},
 		"bs-mocha": {
@@ -5275,9 +5294,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001374",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+			"version": "1.0.30001426",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+			"integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
 			"dev": true
 		},
 		"chainsaw": {
@@ -5547,9 +5566,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.211",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-			"integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
+			"version": "1.4.284",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -5591,40 +5610,41 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
+			"integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"function.prototype.name": "^1.1.5",
-				"get-intrinsic": "^1.1.1",
+				"get-intrinsic": "^1.1.3",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
 				"has-property-descriptors": "^1.0.0",
 				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
-				"is-callable": "^1.2.4",
+				"is-callable": "^1.2.7",
 				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
 				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
 				"is-weakref": "^1.0.2",
-				"object-inspect": "^1.12.0",
+				"object-inspect": "^1.12.2",
 				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
+				"object.assign": "^4.1.4",
 				"regexp.prototype.flags": "^1.4.3",
+				"safe-regex-test": "^1.0.0",
 				"string.prototype.trimend": "^1.0.5",
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
 			},
 			"dependencies": {
 				"object.assign": {
-					"version": "4.1.3",
-					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-					"integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+					"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 					"dev": true,
 					"requires": {
 						"call-bind": "^1.0.2",
@@ -5733,9 +5753,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -5885,9 +5905,9 @@
 			"dev": true
 		},
 		"get-intrinsic": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-			"integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+			"integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
 			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
@@ -6199,15 +6219,15 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-			"integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -6416,13 +6436,14 @@
 			"dev": true
 		},
 		"language-server-mule": {
-			"version": "git+ssh://git@github.com/banacorn/language-server-mule.git#2caa861918e2bceda9f6c004a8a01b69c9dc8cce",
-			"from": "language-server-mule@github:banacorn/language-server-mule#v0.2.3",
+			"version": "git+ssh://git@github.com/banacorn/language-server-mule.git#731475993ee538218cb12c501b12b0ef21e0c821",
+			"integrity": "sha512-ICXzKYmErCGMIZqISPI2p/p7HL8LYKnsZEAxub17IaSeACifYtx9tFPzN9bYUpcBCglOw5m1E9OuHP2iNpRUzw==",
+			"from": "language-server-mule@github:banacorn/language-server-mule#731475993ee538218cb12c501b12b0ef21e0c821",
 			"requires": {
 				"@glennsl/bs-json": "github:banacorn/bs-json#0c900d3",
 				"eventemitter3": "^4.0.7",
 				"unzipper": "^0.10.11",
-				"vscode-languageclient": "^8.0.0-next.1"
+				"vscode-languageclient": "^7.0.0"
 			}
 		},
 		"less": {
@@ -6500,9 +6521,9 @@
 			"dev": true
 		},
 		"loader-utils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-			"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+			"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
 			"dev": true,
 			"requires": {
 				"big.js": "^5.2.2",
@@ -6630,9 +6651,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
 		},
 		"minipass": {
 			"version": "3.3.4",
@@ -7233,6 +7254,17 @@
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"dev": true
 		},
+		"safe-regex-test": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+			"integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+			"dev": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.1.3",
+				"is-regex": "^1.1.4"
+			}
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7268,9 +7300,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -7482,9 +7514,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.14.2",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
-			"integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+			"version": "5.15.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
+			"integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -7502,16 +7534,16 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-			"integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.7",
+				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
 				"serialize-javascript": "^6.0.0",
-				"terser": "^5.7.2"
+				"terser": "^5.14.1"
 			},
 			"dependencies": {
 				"serialize-javascript": {
@@ -7598,9 +7630,9 @@
 			}
 		},
 		"update-browserslist-db": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-			"integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
 			"dev": true,
 			"requires": {
 				"escalade": "^3.1.1",
@@ -7627,33 +7659,33 @@
 			"integrity": "sha512-xqYypi4Ihth3bZgoE6961FYJBrmFErC+YouSC5Tn0pHqv0QSrP0PK++EIVNBi0I9Ted1OetZ3aWlNUWq1QaMBA=="
 		},
 		"vscode-jsonrpc": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-			"integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
 		},
 		"vscode-languageclient": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-			"integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
 			"requires": {
 				"minimatch": "^3.0.4",
-				"semver": "^7.3.5",
-				"vscode-languageserver-protocol": "3.17.2"
+				"semver": "^7.3.4",
+				"vscode-languageserver-protocol": "3.16.0"
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-			"integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
 			"requires": {
-				"vscode-jsonrpc": "8.0.2",
-				"vscode-languageserver-types": "3.17.2"
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
 			}
 		},
 		"vscode-languageserver-types": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
 		},
 		"vscode-test": {
 			"version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -72,14 +72,6 @@
 				"configuration": "./language-configuration.json"
 			}
 		],
-		"grammars": [
-			{
-				"language": "agda",
-				"scopeName": "text.html.markdown",
-				"path": "./syntaxes/markdown.tmLanguage.json",
-				"injectTo": ["source.agda"]
-			}
-		],
 		"commands": [
 			{
 				"command": "agda-mode.load",
@@ -854,7 +846,7 @@
 			}
 		},
 		"grammars": [
-		    {
+			{
 				"language": "agda",
 				"scopeName": "source.agda",
 				"path": "./syntaxes/agda.tmLanguage.json",
@@ -862,7 +854,15 @@
 					"meta.embedded.block.haskell": "haskell",
 					"meta.embedded.block.javascript": "javascript"
 				}
-		    }
+			},
+			{
+				"language": "agda",
+				"scopeName": "text.html.markdown",
+				"path": "./syntaxes/markdown.tmLanguage.json",
+				"injectTo": [
+					"source.agda"
+				]
+			}
 		]
 	},
 	"__metadata": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"compare-versions": "^3.5.1",
 		"eventemitter3": ">=4.0.0",
 		"getos": "^3.2.1",
-		"language-server-mule": "github:banacorn/language-server-mule#v0.2.3",
+		"language-server-mule": "github:banacorn/language-server-mule#731475993ee538218cb12c501b12b0ef21e0c821",
 		"react": "^16.9.0",
 		"react-dom": "^16.9.0",
 		"reason-nodejs": "github:banacorn/reason-nodejs#temp",


### PR DESCRIPTION
Closes #116 #122. And possibly fixes #86.

Before merging this, it's probably better to get the upstream fixed https://github.com/banacorn/language-server-mule/pull/1 and then update the dependency ref to "v0.2.4" instead of pinning it to a specific commit (like how it is now).