### PR TITLE
Fix issue #76: Input method is reactivated after entering a backslash…

### DIFF
--- a/lib/js/src/InputMethod/IM.bs.js
+++ b/lib/js/src/InputMethod/IM.bs.js
@@ -272,6 +272,12 @@ function updateInstances(instances, changes) {
         ];
 }
 
+function bufferIsEmpty(im) {
+  return Belt_Array.every(im.instances, (function (instance) {
+                return Buffer$AgdaModeVscode.isEmpty(instance.buffer);
+              }));
+}
+
 function isActivated(self) {
   return self.activated;
 }
@@ -440,6 +446,7 @@ function run(self, editor, input) {
 var Module = {
   make: make,
   isActivated: isActivated,
+  bufferIsEmpty: bufferIsEmpty,
   run: run
 };
 
@@ -449,5 +456,6 @@ exports.Log = Log;
 exports.Module = Module;
 exports.make = make;
 exports.isActivated = isActivated;
+exports.bufferIsEmpty = bufferIsEmpty;
 exports.run = run;
 /* vscode Not a pure module */

--- a/lib/js/src/State/State__InputMethod.bs.js
+++ b/lib/js/src/State/State__InputMethod.bs.js
@@ -199,11 +199,15 @@ function activateEditorIM(state) {
   var match = isActivated(state);
   switch (match) {
     case /* Editor */0 :
-        Belt_Array.forEach(Editor$AgdaModeVscode.Cursor.getMany(state.editor), (function (point) {
-                Editor$AgdaModeVscode.$$Text.insert(state.document, point, activationKey);
-                
-              }));
-        return runAndHandle(state, /* Deactivate */0);
+        if (IM$AgdaModeVscode.bufferIsEmpty(state.editorIM)) {
+          Belt_Array.forEach(Editor$AgdaModeVscode.Cursor.getMany(state.editor), (function (point) {
+                  Editor$AgdaModeVscode.$$Text.insert(state.document, point, activationKey);
+                  
+                }));
+        }
+        return $$Promise.flatMap(runAndHandle(state, /* Deactivate */0), (function (param) {
+                      return activate(state);
+                    }));
     case /* Prompt */1 :
         return $$Promise.flatMap(runAndHandle$1(state, /* Deactivate */0), (function (param) {
                       return activate(state);

--- a/lib/js/test/tests/Test__EditorIM.bs.js
+++ b/lib/js/test/tests/Test__EditorIM.bs.js
@@ -180,6 +180,7 @@ var IM = {
   Module: IM$AgdaModeVscode.Module,
   make: IM$AgdaModeVscode.make,
   isActivated: IM$AgdaModeVscode.isActivated,
+  bufferIsEmpty: IM$AgdaModeVscode.bufferIsEmpty,
   run: IM$AgdaModeVscode.run,
   equal: equal,
   deep_equal: deep_equal,

--- a/src/InputMethod/IM.res
+++ b/src/InputMethod/IM.res
@@ -84,6 +84,11 @@ module type Module = {
   let make: Chan.t<Log.t> => t
   let isActivated: t => bool
 
+  // To enable input '\' in editor, 
+  // we need to check whether buffer is empty when input method is activated
+  // (Actually, we don't need this function, but I somehow can't get field instances from IM.t in State__InputMethod.res)
+  let bufferIsEmpty: t => bool
+
   let run: (t, option<VSCode.TextEditor.t>, Input.t) => Output.t
   // let deviseChange: (t, string, string) => option<Input.t>
 }
@@ -311,6 +316,11 @@ module Module: Module = {
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////
+
+  let bufferIsEmpty = (im: t): bool => {
+    open Buffer
+    im.instances->Array.every(instance => instance.buffer->isEmpty)
+  }
 
   let isActivated = self => self.activated
 

--- a/src/State/State__InputMethod.res
+++ b/src/State/State__InputMethod.res
@@ -187,13 +187,16 @@ module Module: Module = {
   let activateEditorIM = (state: State.t): Promise.t<unit> =>
     switch isActivated(state) {
     | Editor =>
-      
-      // already activated, insert the activation key (default: "\") instead
-      Editor.Cursor.getMany(state.editor)->Array.forEach(point =>
-        Editor.Text.insert(state.document, point, activationKey)->ignore
-      )
-      // and then deactivate it
+      // Input method is already activated.
+      // If buffer is empty, insert the activation key (default: "\")
+      if state.editorIM->IM.bufferIsEmpty {
+        Editor.Cursor.getMany(state.editor)->Array.forEach(point =>
+          Editor.Text.insert(state.document, point, activationKey)->ignore
+        )
+      }
+      // else reactivate it
       EditorIM.deactivate(state)
+      ->Promise.flatMap(() => EditorIM.activate(state))
     | Prompt =>
       // deactivate the prompt IM
       PromptIM.deactivate(state)->Promise.flatMap(() => {


### PR DESCRIPTION
When input method is activated, entering a backslash will reactivate input method.
If the buffer is empty, it will insert a backslash into the editor instead.