### PR TITLE
Disable activating input method inside the search box, which is related to issue #79

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,12 +453,12 @@
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "\\",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.quit",


### PR DESCRIPTION
I adjust the condition of activating input method to enable inputting '\\' into the search box.
