### PR TITLE
Define auto indentation rules

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -54,4 +54,27 @@
             "\""
         ]
     ],
+    "onEnterRules": [
+        {
+          // Indent if a line ends with any of `=` `:` `⦃`
+          "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]([=:⦃]\\s*$",
+          "action": {
+            "indent": "indent"
+          }
+        },
+        {
+          // Indent if a line starts with any of the following words
+          "beforeText": "^\\s*(module|data|record)($|[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"])",
+          "action": {
+            "indent": "indent"
+          }
+        },
+        {
+          // Indent if a line ends with any of the following keywords
+          "beforeText": "(^|\\s)(abstract|constructor|import|infix[lr]?|field|instance|interleaved|macro|mutual|open|pattern|postulate|primitive|private|syntax|tactic|variable)\\s*$",
+          "action": {
+            "indent": "indent"
+          }
+        }
+      ]
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -46,7 +46,7 @@
   "onEnterRules": [
     {
       // Indent if a line ends with any of `=` `:` `⦃`
-      "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]([=:⦃]\\s*$",
+      "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"][=:⦃]\\s*$",
       "action": {
         "indent": "indent"
       }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -71,7 +71,7 @@
         },
         {
           // Indent if a line ends with any of the following keywords
-          "beforeText": "(^|\\s)(abstract|constructor|import|infix[lr]?|field|instance|interleaved|macro|mutual|open|pattern|postulate|primitive|private|syntax|tactic|variable)\\s*$",
+          "beforeText": "(^|\\s)(abstract|constructor|import|infix[lr]?|field|instance|interleaved|macro|mutual|opaque|open|pattern|postulate|primitive|private|syntax|tactic|variable)\\s*$",
           "action": {
             "indent": "indent"
           }


### PR DESCRIPTION
Defines rules for auto indenting common scenarios where the code must be indented to type check regardless. The only exception where the code doesn't strictly have to be indented is after a `⦃`, but having this indentation rule makes it consistent with the behavior of `(` and `{` and so on.