### PR TITLE
Re #90: Debug buffer won't print modules checked and verbosity

### DIFF
--- a/lib/js/src/State/State__Response.bs.js
+++ b/lib/js/src/State/State__Response.bs.js
@@ -459,20 +459,11 @@ function handle$1(state, dispatchCommand, response) {
                   }));
           } else {
             var message$1 = removeNewlines(response._1);
-            state.runningInfoLog.push([
-                  1,
-                  message$1
-                ]);
-            handleResponse = $$Promise.map($$Promise.flatMap(State__View$AgdaModeVscode.Panel.displayInAppendMode(state, {
-                          TAG: 0,
-                          _0: "Type-checking",
-                          [Symbol.for("name")]: "Plain"
-                        }, [Item$AgdaModeVscode.plainText(message$1)]), (function (param) {
-                        return State__View$AgdaModeVscode.DebugBuffer.displayInAppendMode([[
-                                      1,
-                                      message$1
-                                    ]]);
-                      })), (function (param) {
+            handleResponse = $$Promise.map(State__View$AgdaModeVscode.Panel.displayInAppendMode(state, {
+                      TAG: 0,
+                      _0: "Type-checking",
+                      [Symbol.for("name")]: "Plain"
+                    }, [Item$AgdaModeVscode.plainText(message$1)]), (function (param) {
                     return {
                             TAG: 0,
                             _0: undefined,

--- a/lib/js/src/State/State__View.bs.js
+++ b/lib/js/src/State/State__View.bs.js
@@ -186,16 +186,13 @@ function sendEvent$1($$event) {
 
 function display$1(msgs) {
   var body = Belt_Array.map(msgs, (function (param) {
-          var verbosity = String(param[0]);
           var body = RichText$AgdaModeVscode.string(param[1]);
           return {
-                  TAG: 0,
-                  _0: verbosity,
-                  _1: "",
-                  _2: body,
-                  _3: undefined,
-                  _4: undefined,
-                  [Symbol.for("name")]: "Labeled"
+                  TAG: 1,
+                  _0: body,
+                  _1: undefined,
+                  _2: undefined,
+                  [Symbol.for("name")]: "Unlabeled"
                 };
         }));
   return sendEvent$1({
@@ -212,16 +209,13 @@ function display$1(msgs) {
 
 function displayInAppendMode$1(msgs) {
   var body = Belt_Array.map(msgs, (function (param) {
-          var verbosity = String(param[0]);
           var body = RichText$AgdaModeVscode.string(param[1]);
           return {
-                  TAG: 0,
-                  _0: verbosity,
-                  _1: "",
-                  _2: body,
-                  _3: undefined,
-                  _4: undefined,
-                  [Symbol.for("name")]: "Labeled"
+                  TAG: 1,
+                  _0: body,
+                  _1: undefined,
+                  _2: undefined,
+                  [Symbol.for("name")]: "Unlabeled"
                 };
         }));
   return sendEvent$1({

--- a/src/State/State__Response.res
+++ b/src/State/State__Response.res
@@ -205,10 +205,7 @@ let rec handle = (
   | DisplayInfo(info) => DisplayInfo.handle(state, info)->Promise.map(() => Ok())
   | RunningInfo(1, message) =>
     let message = removeNewlines(message)
-    state.runningInfoLog->Js.Array2.push((1, message))->ignore
-    State.View.Panel.displayInAppendMode(state, Plain("Type-checking"), [Item.plainText(message)])
-    ->Promise.flatMap(() => State.View.DebugBuffer.displayInAppendMode([(1, message)]))
-    ->Promise.map(() => Ok())
+    State.View.Panel.displayInAppendMode(state, Plain("Type-checking"), [Item.plainText(message)])->Promise.map(() => Ok())
   | RunningInfo(verbosity, message) =>
     let message = removeNewlines(message)
     state.runningInfoLog->Js.Array2.push((verbosity, message))->ignore

--- a/src/State/State__View.res
+++ b/src/State/State__View.res
@@ -138,21 +138,17 @@ module DebugBuffer: DebugBuffer = {
 
   let display = msgs => {
     let header = View.Header.Plain("Agda Debug Buffer")
-    let body = msgs->Array.map(((verbosity, msg)) => {
-      let verbosity = string_of_int(verbosity)
-      let style = ""
+    let body = msgs->Array.map(((_, msg)) => {
       let body = RichText.string(msg)
-      Item.Labeled(verbosity, style, body, None, None)
+      Item.Unlabeled(body, None, None)
     })
     sendEvent(Display(header, body))
   }
   let displayInAppendMode = msgs => {
     let header = View.Header.Plain("Agda Debug Buffer")
-    let body = msgs->Array.map(((verbosity, msg)) => {
-      let verbosity = string_of_int(verbosity)
-      let style = ""
+    let body = msgs->Array.map(((_, msg)) => {
       let body = RichText.string(msg)
-      Item.Labeled(verbosity, style, body, None, None)
+      Item.Unlabeled(body, None, None)
     })
     sendEvent(Append(header, body))
   }


### PR DESCRIPTION
The verbosity is removed and the modules being checked are only printed in the Agda buffer.