### PR TITLE
Add more detailed splitting command description

### DIFF
--- a/src/State/State__Command.res
+++ b/src/State/State__Command.res
@@ -111,7 +111,7 @@ let rec dispatchCommand = (state: State.t, command): Promise.t<
     | Some((goal, _)) => sendAgdaRequest(Auto(goal))
     }
   | Case => {
-      let placeholder = Some("variable to case split:")
+      let placeholder = Some("variable(s) to case split:")
       switch State__Goal.pointed(state) {
       | None => State.View.Panel.displayOutOfGoalError(state)->Promise.map(() => Ok())
       | Some((goal, "")) =>
@@ -119,7 +119,7 @@ let rec dispatchCommand = (state: State.t, command): Promise.t<
           state,
           header,
           {
-            body: Some("Please specify which variable you wish to split"),
+            body: Some("Please specify which variable(s) you wish to split, multiple variables are delimited by whitespaces"),
             placeholder,
             value: None,
           },


### PR DESCRIPTION
[Emacs-Mode](https://agda.readthedocs.io/en/latest/tools/emacs-mode.html) described about that multiple variables could be case-splitted and should be delimited by whitespaces, but on [plugin store page](https://marketplace.visualstudio.com/items?itemName=banacorn.agda-mode) and inside command editor it wasn't properly described this functionality.

Thus in this PR, I refines the case splitting command description to make users without using Emacs-Mode to know it's possible to case splitting by delimitting variables with whitespaces.