### PR TITLE
Improve the logic related to buffer's font size adjustment

### DIFF
--- a/lib/js/src/Config.bs.js
+++ b/lib/js/src/Config.bs.js
@@ -221,13 +221,15 @@ var InputMethod = {
 
 function getFontSize() {
   var config = Vscode.workspace.getConfiguration("agdaMode", undefined);
+  var n = Vscode.workspace.getConfiguration("editor", undefined).get("fontSize");
+  var editorFontSize = n !== undefined ? Caml_option.valFromOption(n) : 14;
   var m = config.get("buffer.fontSize");
   var size;
   if (m !== undefined) {
-    size = Caml_option.valFromOption(m);
+    var m$1 = Caml_option.valFromOption(m);
+    size = m$1 === null ? editorFontSize : m$1;
   } else {
-    var n = Vscode.workspace.getConfiguration("editor", undefined).get("fontSize");
-    size = n !== undefined ? Caml_option.valFromOption(n) : 14;
+    size = editorFontSize;
   }
   config.update("buffer.fontSize", size, 1, undefined);
   return size.toString();

--- a/lib/js/src/Main.bs.js
+++ b/lib/js/src/Main.bs.js
@@ -31,8 +31,8 @@ function isAgda(fileName) {
 function onOpenEditor(callback) {
   Core__Option.forEach(Vscode.window.activeTextEditor, callback);
   return Vscode.window.onDidChangeActiveTextEditor(function (next) {
-    Core__Option.forEach(next, callback);
-  });
+              Core__Option.forEach(next, callback);
+            });
 }
 
 function onCloseDocument(callback) {
@@ -41,18 +41,18 @@ function onCloseDocument(callback) {
 
 function onTriggerCommand(callback) {
   return Command$AgdaModeVscode.names.map(function (param) {
-    var command = param[0];
-    return Vscode.commands.registerCommand("agda-mode." + param[1], (function () {
-      return Core__Option.map(Vscode.window.activeTextEditor, (function (editor) {
-        var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
-        if (isAgda(fileName)) {
-          return callback(command, editor);
-        } else {
-          return Promise.resolve(undefined);
-        }
-      }));
-    }));
-  });
+              var command = param[0];
+              return Vscode.commands.registerCommand("agda-mode." + param[1], (function () {
+                            return Core__Option.map(Vscode.window.activeTextEditor, (function (editor) {
+                                          var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
+                                          if (isAgda(fileName)) {
+                                            return callback(command, editor);
+                                          } else {
+                                            return Promise.resolve(undefined);
+                                          }
+                                        }));
+                          }));
+            });
 }
 
 var Inputs = {
@@ -64,13 +64,13 @@ var Inputs = {
 function initialize(channels, extensionPath, globalStoragePath, editor, fileName) {
   var panel = Singleton$AgdaModeVscode.Panel.make(extensionPath);
   WebviewPanel$AgdaModeVscode.onceDestroyed(panel).finally(function () {
-    Registry$AgdaModeVscode.removeAndDestroyAll();
-  });
+        Registry$AgdaModeVscode.removeAndDestroyAll();
+      });
   var state = State$AgdaModeVscode.make(channels, globalStoragePath, extensionPath, editor);
   State__View$AgdaModeVscode.Panel.setFontSize(state, Config$AgdaModeVscode.$$Buffer.getFontSize());
   Chan$AgdaModeVscode.once(state.onRemoveFromRegistry).finally(function () {
-    Registry$AgdaModeVscode.remove(fileName);
-  });
+        Registry$AgdaModeVscode.remove(fileName);
+      });
   var subscribe = function (disposable) {
     state.subscriptions.push(disposable);
   };
@@ -83,44 +83,44 @@ function initialize(channels, extensionPath, globalStoragePath, editor, fileName
     }
   };
   subscribe(WebviewPanel$AgdaModeVscode.onEvent(State__View$AgdaModeVscode.Panel.get(state), (function ($$event) {
-    var editor$p = getCurrentEditor();
-    if (editor$p === undefined) {
-      return;
-    }
-    var fileName$p = Parser$AgdaModeVscode.filepath(Caml_option.valFromOption(editor$p).document.fileName);
-    if (fileName$p === fileName) {
-      State__Command$AgdaModeVscode.dispatchCommand(state, {
-        TAG: "EventFromView",
-        _0: $$event,
-        [Symbol.for("name")]: "EventFromView"
-      });
-      return;
-    }
-
-  })));
+              var editor$p = getCurrentEditor();
+              if (editor$p === undefined) {
+                return ;
+              }
+              var fileName$p = Parser$AgdaModeVscode.filepath(Caml_option.valFromOption(editor$p).document.fileName);
+              if (fileName$p === fileName) {
+                State__Command$AgdaModeVscode.dispatchCommand(state, {
+                      TAG: "EventFromView",
+                      _0: $$event,
+                      [Symbol.for("name")]: "EventFromView"
+                    });
+                return ;
+              }
+              
+            })));
   subscribe(Vscode.window.onDidChangeTextEditorSelection(function ($$event) {
-    var $$document = editor.document;
-    var intervals = $$event.selections.map(function (selection) {
-      return [
-        $$document.offsetAt(selection.start),
-        $$document.offsetAt(selection.end)
-      ];
-    });
-    State__InputMethod$AgdaModeVscode.select(state, intervals);
-  }));
+            var $$document = editor.document;
+            var intervals = $$event.selections.map(function (selection) {
+                  return [
+                          $$document.offsetAt(selection.start),
+                          $$document.offsetAt(selection.end)
+                        ];
+                });
+            State__InputMethod$AgdaModeVscode.select(state, intervals);
+          }));
   subscribe(Vscode.workspace.onDidChangeTextDocument(function ($$event) {
-    var changes = IM$AgdaModeVscode.Input.fromTextDocumentChangeEvent(editor, $$event);
-    State__InputMethod$AgdaModeVscode.keyUpdateEditorIM(state, changes);
-  }));
+            var changes = IM$AgdaModeVscode.Input.fromTextDocumentChangeEvent(editor, $$event);
+            State__InputMethod$AgdaModeVscode.keyUpdateEditorIM(state, changes);
+          }));
   subscribe(Editor$AgdaModeVscode.Provider.registerDefinitionProvider(function (fileName, position) {
-    var currentFileName = Parser$AgdaModeVscode.filepath(state.document.fileName);
-    var normalizedFileName = Parser$AgdaModeVscode.filepath(fileName);
-    var offset = state.document.offsetAt(position);
-    if (normalizedFileName === currentFileName) {
-      return Tokens$AgdaModeVscode.lookupSrcLoc(state.tokens, offset);
-    }
-
-  }));
+            var currentFileName = Parser$AgdaModeVscode.filepath(state.document.fileName);
+            var normalizedFileName = Parser$AgdaModeVscode.filepath(fileName);
+            var offset = state.document.offsetAt(position);
+            if (normalizedFileName === currentFileName) {
+              return Tokens$AgdaModeVscode.lookupSrcLoc(state.tokens, offset);
+            }
+            
+          }));
   return state;
 }
 
@@ -132,22 +132,22 @@ function registerDocumentSemanticTokensProvider() {
     var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
     if (useSemanticHighlighting) {
       return Caml_option.some(Registry$AgdaModeVscode.requestSemanticTokens(fileName).then(function (tokens) {
-        var semanticTokensLegend = new Vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
-        var builder = new Vscode.SemanticTokensBuilder(semanticTokensLegend);
-        tokens.forEach(function (param) {
-          builder.push(Highlighting__SemanticToken$AgdaModeVscode.Module.SingleLineRange.toVsCodeRange(param.range), Highlighting__SemanticToken$AgdaModeVscode.TokenType.toString(param.type_), Core__Option.map(param.modifiers, (function (xs) {
-            return xs.map(Highlighting__SemanticToken$AgdaModeVscode.TokenModifier.toString);
-          })));
-        });
-        return builder.build();
-      }));
+                      var semanticTokensLegend = new Vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
+                      var builder = new Vscode.SemanticTokensBuilder(semanticTokensLegend);
+                      tokens.forEach(function (param) {
+                            builder.push(Highlighting__SemanticToken$AgdaModeVscode.Module.SingleLineRange.toVsCodeRange(param.range), Highlighting__SemanticToken$AgdaModeVscode.TokenType.toString(param.type_), Core__Option.map(param.modifiers, (function (xs) {
+                                        return xs.map(Highlighting__SemanticToken$AgdaModeVscode.TokenModifier.toString);
+                                      })));
+                          });
+                      return builder.build();
+                    }));
     }
-
+    
   };
   return Editor$AgdaModeVscode.Provider.registerDocumentSemanticTokensProvider(provideDocumentSemanticTokens, [
-    tokenTypes,
-    tokenModifiers
-  ]);
+              tokenTypes,
+              tokenModifiers
+            ]);
 }
 
 function finalize(isRestart) {
@@ -156,10 +156,10 @@ function finalize(isRestart) {
     if (!isRestart) {
       return Singleton$AgdaModeVscode.DebugBuffer.destroy();
     } else {
-      return;
+      return ;
     }
   }
-
+  
 }
 
 function activateWithoutContext(subscriptions, extensionPath, globalStoragePath) {
@@ -180,99 +180,102 @@ function activateWithoutContext(subscriptions, extensionPath, globalStoragePath)
     log: channels_log
   };
   subscribe(onOpenEditor(function (editor) {
-    var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
-    if (isAgda(fileName)) {
-      return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
-        state.editor = editor;
-        state.document = editor.document;
-        State__Command$AgdaModeVscode.dispatchCommand(state, "Refresh");
-      }));
-    }
-
-  }));
+            var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
+            if (isAgda(fileName)) {
+              return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
+                            state.editor = editor;
+                            state.document = editor.document;
+                            State__Command$AgdaModeVscode.dispatchCommand(state, "Refresh");
+                          }));
+            }
+            
+          }));
   subscribe(Vscode.workspace.onDidChangeTextDocument(function ($$event) {
-    var $$document = $$event.document;
-    var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
-    if (isAgda(fileName)) {
-      return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
-        Highlighting$AgdaModeVscode.updateSemanticHighlighting(state.highlighting, $$event);
-      }));
-    }
-
-  }));
+            var $$document = $$event.document;
+            var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
+            if (isAgda(fileName)) {
+              return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
+                            Highlighting$AgdaModeVscode.updateSemanticHighlighting(state.highlighting, $$event);
+                          }));
+            }
+            
+          }));
   subscribe(Vscode.workspace.onDidChangeConfiguration(function ($$event) {
-    var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined)
-    if (!fontSizeChanged) {
-      return;
-    }
-    var fontSize = Config$AgdaModeVscode.$$Buffer.getFontSize();
-    WebviewPanel$AgdaModeVscode.sendEvent(Singleton$AgdaModeVscode.Panel.make(extensionPath), {
-      TAG: "ConfigurationChange",
-      _0: fontSize,
-      [Symbol.for("name")]: "ConfigurationChange"
-    });
-  }));
+            if (Singleton$AgdaModeVscode.Panel.get() === undefined) {
+              return ;
+            }
+            var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined);
+            if (!fontSizeChanged) {
+              return ;
+            }
+            var fontSize = Config$AgdaModeVscode.$$Buffer.getFontSize();
+            WebviewPanel$AgdaModeVscode.sendEvent(Singleton$AgdaModeVscode.Panel.make(extensionPath), {
+                  TAG: "ConfigurationChange",
+                  _0: fontSize,
+                  [Symbol.for("name")]: "ConfigurationChange"
+                });
+          }));
   subscribe(Vscode.workspace.onDidCloseTextDocument(function ($$document) {
-    var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
-    if (isAgda(fileName)) {
-      Registry$AgdaModeVscode.removeAndDestroy(fileName);
-      finalize(false);
-      return;
-    }
-
-  }));
+            var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
+            if (isAgda(fileName)) {
+              Registry$AgdaModeVscode.removeAndDestroy(fileName);
+              finalize(false);
+              return ;
+            }
+            
+          }));
   subscribeMany(onTriggerCommand(async function (command, editor) {
-    var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
-    if (typeof command !== "object") {
-      switch (command) {
-        case "Quit":
-          await Registry$AgdaModeVscode.removeAndDestroy(fileName);
-          finalize(false);
-          break;
-        case "Restart":
-          await Registry$AgdaModeVscode.removeAndDestroy(fileName);
-          finalize(true);
-          break;
-        default:
-
-      }
-    }
-    var exit = 0;
-    if (typeof command !== "object") {
-      switch (command) {
-        case "Load":
-        case "Restart":
-          exit = 1;
-          break;
-        default:
-
-      }
-    } else if (command.TAG === "InputMethod") {
-      var tmp = command._0;
-      if (typeof tmp !== "object" && tmp === "Activate") {
-        exit = 1;
-      }
-
-    }
-    if (exit === 1) {
-      var match = Registry$AgdaModeVscode.get(fileName);
-      if (match === undefined) {
-        var state = initialize(channels, extensionPath, globalStoragePath, editor, fileName);
-        Registry$AgdaModeVscode.add(fileName, state);
-      }
-
-    }
-    var state$1 = Registry$AgdaModeVscode.get(fileName);
-    if (state$1 !== undefined) {
-      await State__Command$AgdaModeVscode.dispatchCommand(state$1, command);
-      return {
-        TAG: "Ok",
-        _0: state$1,
-        [Symbol.for("name")]: "Ok"
-      };
-    }
-
-  }));
+            var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
+            if (typeof command !== "object") {
+              switch (command) {
+                case "Quit" :
+                    await Registry$AgdaModeVscode.removeAndDestroy(fileName);
+                    finalize(false);
+                    break;
+                case "Restart" :
+                    await Registry$AgdaModeVscode.removeAndDestroy(fileName);
+                    finalize(true);
+                    break;
+                default:
+                  
+              }
+            }
+            var exit = 0;
+            if (typeof command !== "object") {
+              switch (command) {
+                case "Load" :
+                case "Restart" :
+                    exit = 1;
+                    break;
+                default:
+                  
+              }
+            } else if (command.TAG === "InputMethod") {
+              var tmp = command._0;
+              if (typeof tmp !== "object" && tmp === "Activate") {
+                exit = 1;
+              }
+              
+            }
+            if (exit === 1) {
+              var match = Registry$AgdaModeVscode.get(fileName);
+              if (match === undefined) {
+                var state = initialize(channels, extensionPath, globalStoragePath, editor, fileName);
+                Registry$AgdaModeVscode.add(fileName, state);
+              }
+              
+            }
+            var state$1 = Registry$AgdaModeVscode.get(fileName);
+            if (state$1 !== undefined) {
+              await State__Command$AgdaModeVscode.dispatchCommand(state$1, command);
+              return {
+                      TAG: "Ok",
+                      _0: state$1,
+                      [Symbol.for("name")]: "Ok"
+                    };
+            }
+            
+          }));
   subscribe(registerDocumentSemanticTokensProvider());
   return channels;
 }
@@ -285,7 +288,7 @@ function activate(context) {
 }
 
 function deactivate() {
-
+  
 }
 
 exports.isAgda = isAgda;

--- a/lib/js/src/Main.bs.js
+++ b/lib/js/src/Main.bs.js
@@ -3,7 +3,6 @@
 
 var Vscode = require("vscode");
 var Caml_option = require("rescript/lib/js/caml_option.js");
-var Core__Array = require("@rescript/core/lib/js/src/Core__Array.bs.js");
 var Core__Option = require("@rescript/core/lib/js/src/Core__Option.bs.js");
 var Caml_splice_call = require("rescript/lib/js/caml_splice_call.js");
 var IM$AgdaModeVscode = require("./InputMethod/IM.bs.js");
@@ -32,8 +31,8 @@ function isAgda(fileName) {
 function onOpenEditor(callback) {
   Core__Option.forEach(Vscode.window.activeTextEditor, callback);
   return Vscode.window.onDidChangeActiveTextEditor(function (next) {
-              Core__Option.forEach(next, callback);
-            });
+    Core__Option.forEach(next, callback);
+  });
 }
 
 function onCloseDocument(callback) {
@@ -42,18 +41,18 @@ function onCloseDocument(callback) {
 
 function onTriggerCommand(callback) {
   return Command$AgdaModeVscode.names.map(function (param) {
-              var command = param[0];
-              return Vscode.commands.registerCommand("agda-mode." + param[1], (function () {
-                            return Core__Option.map(Vscode.window.activeTextEditor, (function (editor) {
-                                          var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
-                                          if (isAgda(fileName)) {
-                                            return callback(command, editor);
-                                          } else {
-                                            return Promise.resolve(undefined);
-                                          }
-                                        }));
-                          }));
-            });
+    var command = param[0];
+    return Vscode.commands.registerCommand("agda-mode." + param[1], (function () {
+      return Core__Option.map(Vscode.window.activeTextEditor, (function (editor) {
+        var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
+        if (isAgda(fileName)) {
+          return callback(command, editor);
+        } else {
+          return Promise.resolve(undefined);
+        }
+      }));
+    }));
+  });
 }
 
 var Inputs = {
@@ -65,13 +64,13 @@ var Inputs = {
 function initialize(channels, extensionPath, globalStoragePath, editor, fileName) {
   var panel = Singleton$AgdaModeVscode.Panel.make(extensionPath);
   WebviewPanel$AgdaModeVscode.onceDestroyed(panel).finally(function () {
-        Registry$AgdaModeVscode.removeAndDestroyAll();
-      });
+    Registry$AgdaModeVscode.removeAndDestroyAll();
+  });
   var state = State$AgdaModeVscode.make(channels, globalStoragePath, extensionPath, editor);
   State__View$AgdaModeVscode.Panel.setFontSize(state, Config$AgdaModeVscode.$$Buffer.getFontSize());
   Chan$AgdaModeVscode.once(state.onRemoveFromRegistry).finally(function () {
-        Registry$AgdaModeVscode.remove(fileName);
-      });
+    Registry$AgdaModeVscode.remove(fileName);
+  });
   var subscribe = function (disposable) {
     state.subscriptions.push(disposable);
   };
@@ -84,44 +83,44 @@ function initialize(channels, extensionPath, globalStoragePath, editor, fileName
     }
   };
   subscribe(WebviewPanel$AgdaModeVscode.onEvent(State__View$AgdaModeVscode.Panel.get(state), (function ($$event) {
-              var editor$p = getCurrentEditor();
-              if (editor$p === undefined) {
-                return ;
-              }
-              var fileName$p = Parser$AgdaModeVscode.filepath(Caml_option.valFromOption(editor$p).document.fileName);
-              if (fileName$p === fileName) {
-                State__Command$AgdaModeVscode.dispatchCommand(state, {
-                      TAG: "EventFromView",
-                      _0: $$event,
-                      [Symbol.for("name")]: "EventFromView"
-                    });
-                return ;
-              }
-              
-            })));
+    var editor$p = getCurrentEditor();
+    if (editor$p === undefined) {
+      return;
+    }
+    var fileName$p = Parser$AgdaModeVscode.filepath(Caml_option.valFromOption(editor$p).document.fileName);
+    if (fileName$p === fileName) {
+      State__Command$AgdaModeVscode.dispatchCommand(state, {
+        TAG: "EventFromView",
+        _0: $$event,
+        [Symbol.for("name")]: "EventFromView"
+      });
+      return;
+    }
+
+  })));
   subscribe(Vscode.window.onDidChangeTextEditorSelection(function ($$event) {
-            var $$document = editor.document;
-            var intervals = $$event.selections.map(function (selection) {
-                  return [
-                          $$document.offsetAt(selection.start),
-                          $$document.offsetAt(selection.end)
-                        ];
-                });
-            State__InputMethod$AgdaModeVscode.select(state, intervals);
-          }));
+    var $$document = editor.document;
+    var intervals = $$event.selections.map(function (selection) {
+      return [
+        $$document.offsetAt(selection.start),
+        $$document.offsetAt(selection.end)
+      ];
+    });
+    State__InputMethod$AgdaModeVscode.select(state, intervals);
+  }));
   subscribe(Vscode.workspace.onDidChangeTextDocument(function ($$event) {
-            var changes = IM$AgdaModeVscode.Input.fromTextDocumentChangeEvent(editor, $$event);
-            State__InputMethod$AgdaModeVscode.keyUpdateEditorIM(state, changes);
-          }));
+    var changes = IM$AgdaModeVscode.Input.fromTextDocumentChangeEvent(editor, $$event);
+    State__InputMethod$AgdaModeVscode.keyUpdateEditorIM(state, changes);
+  }));
   subscribe(Editor$AgdaModeVscode.Provider.registerDefinitionProvider(function (fileName, position) {
-            var currentFileName = Parser$AgdaModeVscode.filepath(state.document.fileName);
-            var normalizedFileName = Parser$AgdaModeVscode.filepath(fileName);
-            var offset = state.document.offsetAt(position);
-            if (normalizedFileName === currentFileName) {
-              return Tokens$AgdaModeVscode.lookupSrcLoc(state.tokens, offset);
-            }
-            
-          }));
+    var currentFileName = Parser$AgdaModeVscode.filepath(state.document.fileName);
+    var normalizedFileName = Parser$AgdaModeVscode.filepath(fileName);
+    var offset = state.document.offsetAt(position);
+    if (normalizedFileName === currentFileName) {
+      return Tokens$AgdaModeVscode.lookupSrcLoc(state.tokens, offset);
+    }
+
+  }));
   return state;
 }
 
@@ -133,22 +132,22 @@ function registerDocumentSemanticTokensProvider() {
     var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
     if (useSemanticHighlighting) {
       return Caml_option.some(Registry$AgdaModeVscode.requestSemanticTokens(fileName).then(function (tokens) {
-                      var semanticTokensLegend = new Vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
-                      var builder = new Vscode.SemanticTokensBuilder(semanticTokensLegend);
-                      tokens.forEach(function (param) {
-                            builder.push(Highlighting__SemanticToken$AgdaModeVscode.Module.SingleLineRange.toVsCodeRange(param.range), Highlighting__SemanticToken$AgdaModeVscode.TokenType.toString(param.type_), Core__Option.map(param.modifiers, (function (xs) {
-                                        return xs.map(Highlighting__SemanticToken$AgdaModeVscode.TokenModifier.toString);
-                                      })));
-                          });
-                      return builder.build();
-                    }));
+        var semanticTokensLegend = new Vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
+        var builder = new Vscode.SemanticTokensBuilder(semanticTokensLegend);
+        tokens.forEach(function (param) {
+          builder.push(Highlighting__SemanticToken$AgdaModeVscode.Module.SingleLineRange.toVsCodeRange(param.range), Highlighting__SemanticToken$AgdaModeVscode.TokenType.toString(param.type_), Core__Option.map(param.modifiers, (function (xs) {
+            return xs.map(Highlighting__SemanticToken$AgdaModeVscode.TokenModifier.toString);
+          })));
+        });
+        return builder.build();
+      }));
     }
-    
+
   };
   return Editor$AgdaModeVscode.Provider.registerDocumentSemanticTokensProvider(provideDocumentSemanticTokens, [
-              tokenTypes,
-              tokenModifiers
-            ]);
+    tokenTypes,
+    tokenModifiers
+  ]);
 }
 
 function finalize(isRestart) {
@@ -157,10 +156,10 @@ function finalize(isRestart) {
     if (!isRestart) {
       return Singleton$AgdaModeVscode.DebugBuffer.destroy();
     } else {
-      return ;
+      return;
     }
   }
-  
+
 }
 
 function activateWithoutContext(subscriptions, extensionPath, globalStoragePath) {
@@ -181,109 +180,99 @@ function activateWithoutContext(subscriptions, extensionPath, globalStoragePath)
     log: channels_log
   };
   subscribe(onOpenEditor(function (editor) {
-            var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
-            if (isAgda(fileName)) {
-              return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
-                            state.editor = editor;
-                            state.document = editor.document;
-                            State__Command$AgdaModeVscode.dispatchCommand(state, "Refresh");
-                          }));
-            }
-            
-          }));
+    var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
+    if (isAgda(fileName)) {
+      return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
+        state.editor = editor;
+        state.document = editor.document;
+        State__Command$AgdaModeVscode.dispatchCommand(state, "Refresh");
+      }));
+    }
+
+  }));
   subscribe(Vscode.workspace.onDidChangeTextDocument(function ($$event) {
-            var $$document = $$event.document;
-            var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
-            if (isAgda(fileName)) {
-              return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
-                            Highlighting$AgdaModeVscode.updateSemanticHighlighting(state.highlighting, $$event);
-                          }));
-            }
-            
-          }));
+    var $$document = $$event.document;
+    var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
+    if (isAgda(fileName)) {
+      return Core__Option.forEach(Registry$AgdaModeVscode.get(fileName), (function (state) {
+        Highlighting$AgdaModeVscode.updateSemanticHighlighting(state.highlighting, $$event);
+      }));
+    }
+
+  }));
   subscribe(Vscode.workspace.onDidChangeConfiguration(function ($$event) {
-            var getFileName = function (editor) {
-              return Parser$AgdaModeVscode.filepath(editor.document.fileName);
-            };
-            var state = Core__Array.reduce(Vscode.window.visibleTextEditors, undefined, (function (state, editor) {
-                    if (state !== undefined) {
-                      return state;
-                    } else {
-                      return Registry$AgdaModeVscode.get(getFileName(editor));
-                    }
-                  }));
-            var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined);
-            if (!fontSizeChanged) {
-              return ;
-            }
-            var size = Config$AgdaModeVscode.$$Buffer.getFontSize();
-            if (state !== undefined) {
-              State__View$AgdaModeVscode.Panel.setFontSize(state, size);
-              return ;
-            }
-            
-          }));
+    var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined)
+    if (!fontSizeChanged) {
+      return;
+    }
+    var fontSize = Config$AgdaModeVscode.$$Buffer.getFontSize();
+    WebviewPanel$AgdaModeVscode.sendEvent(Singleton$AgdaModeVscode.Panel.make(extensionPath), {
+      TAG: "ConfigurationChange",
+      _0: fontSize,
+      [Symbol.for("name")]: "ConfigurationChange"
+    });
+  }));
   subscribe(Vscode.workspace.onDidCloseTextDocument(function ($$document) {
-            var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
-            if (isAgda(fileName)) {
-              Registry$AgdaModeVscode.removeAndDestroy(fileName);
-              finalize(false);
-              return ;
-            }
-            
-          }));
+    var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);
+    if (isAgda(fileName)) {
+      Registry$AgdaModeVscode.removeAndDestroy(fileName);
+      finalize(false);
+      return;
+    }
+
+  }));
   subscribeMany(onTriggerCommand(async function (command, editor) {
-            var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
-            if (typeof command !== "object") {
-              switch (command) {
-                case "Quit" :
-                    await Registry$AgdaModeVscode.removeAndDestroy(fileName);
-                    finalize(false);
-                    break;
-                case "Restart" :
-                    await Registry$AgdaModeVscode.removeAndDestroy(fileName);
-                    finalize(true);
-                    break;
-                default:
-                  
-              }
-            }
-            var exit = 0;
-            if (typeof command !== "object") {
-              switch (command) {
-                case "Load" :
-                case "Restart" :
-                    exit = 1;
-                    break;
-                default:
-                  
-              }
-            } else if (command.TAG === "InputMethod") {
-              var tmp = command._0;
-              if (typeof tmp !== "object" && tmp === "Activate") {
-                exit = 1;
-              }
-              
-            }
-            if (exit === 1) {
-              var match = Registry$AgdaModeVscode.get(fileName);
-              if (match === undefined) {
-                var state = initialize(channels, extensionPath, globalStoragePath, editor, fileName);
-                Registry$AgdaModeVscode.add(fileName, state);
-              }
-              
-            }
-            var state$1 = Registry$AgdaModeVscode.get(fileName);
-            if (state$1 !== undefined) {
-              await State__Command$AgdaModeVscode.dispatchCommand(state$1, command);
-              return {
-                      TAG: "Ok",
-                      _0: state$1,
-                      [Symbol.for("name")]: "Ok"
-                    };
-            }
-            
-          }));
+    var fileName = Parser$AgdaModeVscode.filepath(editor.document.fileName);
+    if (typeof command !== "object") {
+      switch (command) {
+        case "Quit":
+          await Registry$AgdaModeVscode.removeAndDestroy(fileName);
+          finalize(false);
+          break;
+        case "Restart":
+          await Registry$AgdaModeVscode.removeAndDestroy(fileName);
+          finalize(true);
+          break;
+        default:
+
+      }
+    }
+    var exit = 0;
+    if (typeof command !== "object") {
+      switch (command) {
+        case "Load":
+        case "Restart":
+          exit = 1;
+          break;
+        default:
+
+      }
+    } else if (command.TAG === "InputMethod") {
+      var tmp = command._0;
+      if (typeof tmp !== "object" && tmp === "Activate") {
+        exit = 1;
+      }
+
+    }
+    if (exit === 1) {
+      var match = Registry$AgdaModeVscode.get(fileName);
+      if (match === undefined) {
+        var state = initialize(channels, extensionPath, globalStoragePath, editor, fileName);
+        Registry$AgdaModeVscode.add(fileName, state);
+      }
+
+    }
+    var state$1 = Registry$AgdaModeVscode.get(fileName);
+    if (state$1 !== undefined) {
+      await State__Command$AgdaModeVscode.dispatchCommand(state$1, command);
+      return {
+        TAG: "Ok",
+        _0: state$1,
+        [Symbol.for("name")]: "Ok"
+      };
+    }
+
+  }));
   subscribe(registerDocumentSemanticTokensProvider());
   return channels;
 }
@@ -296,7 +285,7 @@ function activate(context) {
 }
 
 function deactivate() {
-  
+
 }
 
 exports.isAgda = isAgda;

--- a/lib/js/src/Main.bs.js
+++ b/lib/js/src/Main.bs.js
@@ -204,7 +204,7 @@ function activateWithoutContext(subscriptions, extensionPath, globalStoragePath)
             if (Singleton$AgdaModeVscode.Panel.get() === undefined) {
               return ;
             }
-            var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined);
+            var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined) || $$event.affectsConfiguration("editor.fontSize", undefined);
             if (!fontSizeChanged) {
               return ;
             }

--- a/lib/js/src/Main.bs.js
+++ b/lib/js/src/Main.bs.js
@@ -201,7 +201,8 @@ function activateWithoutContext(subscriptions, extensionPath, globalStoragePath)
             
           }));
   subscribe(Vscode.workspace.onDidChangeConfiguration(function ($$event) {
-            if (Singleton$AgdaModeVscode.Panel.get() === undefined) {
+            var panel = Singleton$AgdaModeVscode.Panel.get();
+            if (panel === undefined) {
               return ;
             }
             var fontSizeChanged = $$event.affectsConfiguration("agdaMode.buffer.fontSize", undefined) || $$event.affectsConfiguration("editor.fontSize", undefined);
@@ -209,11 +210,13 @@ function activateWithoutContext(subscriptions, extensionPath, globalStoragePath)
               return ;
             }
             var fontSize = Config$AgdaModeVscode.$$Buffer.getFontSize();
-            WebviewPanel$AgdaModeVscode.sendEvent(Singleton$AgdaModeVscode.Panel.make(extensionPath), {
-                  TAG: "ConfigurationChange",
-                  _0: fontSize,
-                  [Symbol.for("name")]: "ConfigurationChange"
-                });
+            Core__Option.forEach(panel, (function (panel) {
+                    WebviewPanel$AgdaModeVscode.sendEvent(panel, {
+                          TAG: "ConfigurationChange",
+                          _0: fontSize,
+                          [Symbol.for("name")]: "ConfigurationChange"
+                        });
+                  }));
           }));
   subscribe(Vscode.workspace.onDidCloseTextDocument(function ($$document) {
             var fileName = Parser$AgdaModeVscode.filepath($$document.fileName);

--- a/lib/js/src/View/Singleton.bs.js
+++ b/lib/js/src/View/Singleton.bs.js
@@ -22,6 +22,10 @@ function make(extensionPath) {
   return panel$1;
 }
 
+function get() {
+  return handle.contents;
+}
+
 function destroy() {
   Belt_Option.forEach(handle.contents, WebviewPanel$AgdaModeVscode.destroy);
   handle.contents = undefined;
@@ -29,14 +33,15 @@ function destroy() {
 
 var Panel = {
   make: make,
-  destroy: destroy
+  destroy: destroy,
+  get: get
 };
 
 var handle$1 = {
   contents: undefined
 };
 
-function get() {
+function get$1() {
   return handle$1.contents;
 }
 
@@ -59,7 +64,7 @@ function destroy$1() {
 }
 
 var DebugBuffer = {
-  get: get,
+  get: get$1,
   make: make$1,
   destroy: destroy$1
 };

--- a/package.json
+++ b/package.json
@@ -918,9 +918,12 @@
 					"description": "Key for activating Unicode input method"
 				},
 				"agdaMode.buffer.fontSize": {
-					"type": "number",
+					"type": [
+						"number",
+						"null"
+					],
 					"default": 14,
-					"description": "The font size of Agda buffer"
+					"markdownDescription": "The font size of Agda buffer. If not set, `#editor.fontSize#` is used."
 				}
 			}
 		}

--- a/src/Config.res
+++ b/src/Config.res
@@ -208,15 +208,21 @@ module InputMethod = {
 module Buffer = {
   let getFontSize = () => {
     let config = Workspace.getConfiguration(Some("agdaMode"), None)
+    let editorFontSize = switch Workspace.getConfiguration(
+      Some("editor"),
+      None,
+    )->WorkspaceConfiguration.get("fontSize") {
+    | Some(n) => n
+    | _ => 14
+    }
     let size = switch config->WorkspaceConfiguration.get("buffer.fontSize") {
-    | Some(m) => m
-    | None =>
-      switch Workspace.getConfiguration(Some("editor"), None)->WorkspaceConfiguration.get(
-        "fontSize",
-      ) {
-      | Some(n) => n
-      | _ => 14
+    | Some(m) =>
+      if m == null {
+        editorFontSize
+      } else {
+        m
       }
+    | None => editorFontSize
     }
 
     config->WorkspaceConfiguration.updateGlobalSettings("buffer.fontSize", size, None)->ignore

--- a/src/Main.res
+++ b/src/Main.res
@@ -253,17 +253,17 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
   })->subscribe
 
   VSCode.Workspace.onDidChangeConfiguration((event: VSCode.ConfigurationChangeEvent.t) => {
-    let getFileName = editor =>
-      editor->VSCode.TextEditor.document->VSCode.TextDocument.fileName->Parser.filepath
+    // let getFileName = editor =>
+    //   editor->VSCode.TextEditor.document->VSCode.TextDocument.fileName->Parser.filepath
     // Maybe we should check active editor
     // or define some methods to send events without state since changing style is irrelevant to states of eidtors
     // (Currently, sending an event to the webview has to get the view from a state and send the event with the view)
-    let state = Array.reduce(VSCode.Window.visibleTextEditors, None, (state, editor) => {
-      switch state {
-      | None => editor->getFileName->Registry.get
-      | _ => state
-      }
-    })
+    // let state = Array.reduce(VSCode.Window.visibleTextEditors, None, (state, editor) => {
+    //   switch state {
+    //   | None => editor->getFileName->Registry.get
+    //   | _ => state
+    //   }
+    // })
     let fontSizeChanged =
       event->VSCode.ConfigurationChangeEvent.affectsConfiguration(
         "agdaMode.buffer.fontSize",
@@ -271,11 +271,10 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
       )
 
     if fontSizeChanged {
-      let size = Config.Buffer.getFontSize()
-      switch state {
-      | Some(state) => state->State__View.Panel.setFontSize(size)->ignore
-      | None => ()
-      }
+      let fontSize = Config.Buffer.getFontSize()
+      Singleton.Panel.make(extensionPath)
+      ->WebviewPanel.sendEvent(ConfigurationChange(fontSize))
+      ->ignore
     }
   })->subscribe
 

--- a/src/Main.res
+++ b/src/Main.res
@@ -233,7 +233,6 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
         // we need to replace it with this new one
         state.editor = editor
         state.document = editor->VSCode.TextEditor.document
-        //
         State__Command.dispatchCommand(state, Refresh)->ignore
       })
     }
@@ -253,28 +252,20 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
   })->subscribe
 
   VSCode.Workspace.onDidChangeConfiguration((event: VSCode.ConfigurationChangeEvent.t) => {
-    // let getFileName = editor =>
-    //   editor->VSCode.TextEditor.document->VSCode.TextDocument.fileName->Parser.filepath
-    // Maybe we should check active editor
-    // or define some methods to send events without state since changing style is irrelevant to states of eidtors
-    // (Currently, sending an event to the webview has to get the view from a state and send the event with the view)
-    // let state = Array.reduce(VSCode.Window.visibleTextEditors, None, (state, editor) => {
-    //   switch state {
-    //   | None => editor->getFileName->Registry.get
-    //   | _ => state
-    //   }
-    // })
-    let fontSizeChanged =
-      event->VSCode.ConfigurationChangeEvent.affectsConfiguration(
-        "agdaMode.buffer.fontSize",
-        #Others(None),
-      )
+    if Singleton.Panel.get() != None {
+      let fontSizeChanged =
+        event->VSCode.ConfigurationChangeEvent.affectsConfiguration(
+          "agdaMode.buffer.fontSize",
+          #Others(None),
+        )
 
-    if fontSizeChanged {
-      let fontSize = Config.Buffer.getFontSize()
-      Singleton.Panel.make(extensionPath)
-      ->WebviewPanel.sendEvent(ConfigurationChange(fontSize))
-      ->ignore
+      if fontSizeChanged {
+        let fontSize = Config.Buffer.getFontSize()
+        // maybe put Singleton instances in to the Registry?
+        Singleton.Panel.make(extensionPath)
+        ->WebviewPanel.sendEvent(ConfigurationChange(fontSize))
+        ->ignore
+      }
     }
   })->subscribe
 

--- a/src/Main.res
+++ b/src/Main.res
@@ -252,7 +252,8 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
   })->subscribe
 
   VSCode.Workspace.onDidChangeConfiguration((event: VSCode.ConfigurationChangeEvent.t) => {
-    if Singleton.Panel.get() != None {
+    let panel = Singleton.Panel.get()
+    if panel != None {
       let fontSizeChanged =
         event->VSCode.ConfigurationChangeEvent.affectsConfiguration(
           "agdaMode.buffer.fontSize",
@@ -266,9 +267,9 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
       if fontSizeChanged {
         let fontSize = Config.Buffer.getFontSize()
         // maybe put Singleton instances in to the Registry?
-        Singleton.Panel.make(extensionPath)
-        ->WebviewPanel.sendEvent(ConfigurationChange(fontSize))
-        ->ignore
+        panel->Option.forEach(panel =>
+          panel->WebviewPanel.sendEvent(ConfigurationChange(fontSize))->ignore
+        )
       }
     }
   })->subscribe

--- a/src/Main.res
+++ b/src/Main.res
@@ -257,7 +257,11 @@ let activateWithoutContext = (subscriptions, extensionPath, globalStoragePath) =
         event->VSCode.ConfigurationChangeEvent.affectsConfiguration(
           "agdaMode.buffer.fontSize",
           #Others(None),
-        )
+        ) ||
+          event->VSCode.ConfigurationChangeEvent.affectsConfiguration(
+            "editor.fontSize",
+            #Others(None),
+          )
 
       if fontSizeChanged {
         let fontSize = Config.Buffer.getFontSize()

--- a/src/View/Singleton.res
+++ b/src/View/Singleton.res
@@ -4,6 +4,7 @@ module Panel: {
   // methods
   let make: string => WebviewPanel.t
   let destroy: unit => unit
+  let get: unit => option<WebviewPanel.t>
 } = {
   let handle: ref<option<WebviewPanel.t>> = ref(None)
   let make = extensionPath =>
@@ -12,12 +13,16 @@ module Panel: {
       let panel = WebviewPanel.make("Agda", extensionPath)
       handle := Some(panel)
       // free the handle when the view has been forcibly destructed
-      WebviewPanel.onceDestroyed(panel)->Promise.finally(() => {
+      WebviewPanel.onceDestroyed(panel)
+      ->Promise.finally(() => {
         handle := None
-      })->Promise.done
+      })
+      ->Promise.done
       panel
     | Some(panel) => panel
     }
+
+  let get = () => handle.contents
 
   let destroy = () => {
     handle.contents->Option.forEach(WebviewPanel.destroy)
@@ -38,9 +43,11 @@ module DebugBuffer: {
       let panel = WebviewPanel.make("Agda Debug Buffer", extensionPath)
       handle := Some(panel)
       // free the handle when the view has been forcibly destructed
-      WebviewPanel.onceDestroyed(panel)->Promise.finally(() => {
+      WebviewPanel.onceDestroyed(panel)
+      ->Promise.finally(() => {
         handle := None
-      })->Promise.done
+      })
+      ->Promise.done
       panel
     | Some(panel) => panel
     }

--- a/style/style.less
+++ b/style/style.less
@@ -22,8 +22,8 @@
 // we need this container to overcome the width problem of fixed elements
 .agda-mode-header-container {
     position: fixed;
-    width   : 100%; // this 100% percentage is relative to the viewport rather than its parent
-    left    : 0; // stick it to the viewport
+    width: 100%; // this 100% percentage is relative to the viewport rather than its parent
+    left: 0; // stick it to the viewport
 }
 
 .agda-mode-keyboard {
@@ -42,7 +42,7 @@
     }
 
     // dimension
-    width     : calc(100% - 2.5rem); // why 2.5 ???
+    width : calc(100% - 2.5rem); // why 2.5 ???
     min-height: @header-height;
 
     &.deactivated {
@@ -53,32 +53,32 @@
     background: @header-background;
 
     .agda-mode-keyboard-sequence-and-candidates {
-        display    : flex;
+        display: flex;
         // dimensions
-        padding    : @padding 0;
-        min-height : 1.5rem;
+        padding: @padding 0;
+        min-height: 1.5rem;
         line-height: 1.5rem;
 
         .agda-mode-keyboard-sequence {
-            padding    : 0rem @padding;
-            flex-grow  : 100;
-            background : @body-background;
+            padding: 0rem @padding;
+            flex-grow: 100;
+            background: @body-background;
             font-weight: bold;
         }
 
         .agda-mode-keyboard-candidates {
             margin-left: @padding;
 
-            width      : calc(@button-height * 10 + @button-margin * 20);
-            flex-grow  : 0;
+            width: calc(@button-height * 10 + @button-margin * 20);
+            flex-grow: 0;
             font-weight: bold;
         }
     }
 
     .agda-mode-keyboard-suggestions {
-        max-width     : 100%;
-        display       : flex;
-        flex-wrap     : wrap;
+        max-width: 100%;
+        display: flex;
+        flex-wrap: wrap;
         padding-bottom: @padding;
     }
 
@@ -89,21 +89,21 @@
 
 
         background: @input-background;
-        color     : @foreground;
+        color: @foreground;
 
-        top          : 0;
-        width        : @button-height;
-        height       : @button-height;
-        line-height  : @button-height;
-        margin       : @button-margin;
-        padding      : 0;
-        border       : 0;
+        top: 0;
+        width: @button-height;
+        height: @button-height;
+        line-height: @button-height;
+        margin: @button-margin;
+        padding: 0;
+        border: 0;
         border-radius: @button-margin;
-        text-align   : center;
+        text-align: center;
 
         &:hover {
             background: @selection;
-            cursor    : pointer;
+            cursor: pointer;
         }
 
         &.selected {
@@ -116,7 +116,7 @@
 
     height: @header-height;
 
-    margin : 0 @root-padding;
+    margin: 0 @root-padding;
     padding: calc(@padding/2) 0;
 
     // create a shadow at the bottom of the <Header>
@@ -125,7 +125,7 @@
     background: @header-background;
 
     line-height: @header-height;
-    font-size  : 100%;
+    font-size: var(--agdaMode-buffer-font-size);
     font-weight: bold;
 
     &.success {
@@ -141,10 +141,10 @@
     }
 
     .agda-mode-header-status {
-        color       : @foreground-subtle;
-        font-size   : 50%;
+        color: @foreground-subtle;
+        font-size: 50%;
         font-variant: small-caps;
-        float       : right
+        float: right
     }
 }
 
@@ -157,7 +157,7 @@
     white-space: pre;
 
     font-family: var(--vscode-editor-font-family);
-    font-size  : var(--agdaMode-buffer-font-size);
+    font-size: var(--agdaMode-buffer-font-size);
     line-height: @line-height;
 
     .codicon {
@@ -166,7 +166,7 @@
 
     li {
         // dimensions
-        margin : @padding 0;
+        margin: @padding 0;
         padding: calc(@padding/2) @padding;
 
         &:first-of-type {
@@ -186,12 +186,12 @@
     li.unlabeled-item,
     li.labeled-item {
         // background & border
-        background : @body-background;
+        background: @body-background;
         border-left: @left-border-width solid @body-background;
     }
 
     li.header-item {
-        margin : 0;
+        margin: 0;
         padding: 0;
 
         h3 {
@@ -201,8 +201,8 @@
 
     li .item-content {
         white-space: pre-wrap;
-        order      : 1;
-        flex-grow  : 1;
+        order: 1;
+        flex-grow: 1;
     }
 
     // the button that shows "raw Emacs string" when clicked
@@ -210,19 +210,19 @@
     li .item-raw-button {
         visibility: hidden;
 
-        order    : 1;
+        order: 1;
         flex-grow: 0;
 
         padding-left: 1ch;
 
         font-variant: small-caps;
-        text-align  : right;
+        text-align: right;
 
         color: @foreground-subtle;
 
         &:hover {
             cursor: pointer;
-            color : @foreground-highlight
+            color: @foreground-highlight
         }
 
         &.active {
@@ -230,24 +230,24 @@
             visibility: visible;
 
             cursor: pointer;
-            color : @warning
+            color: @warning
         }
     }
 
     // the button that shows allow users to jump to some location
     li .item-location-button {
-        order    : 2;
+        order: 2;
         flex-grow: 0;
 
         padding-left: 1ch;
 
         font-variant: small-caps;
-        text-align  : right;
+        text-align: right;
 
 
         &:hover {
             cursor: pointer;
-            color : @foreground-highlight
+            color: @foreground-highlight
         }
     }
 
@@ -257,8 +257,8 @@
         margin-left: calc(@padding/2);
 
         font-variant: small-caps;
-        font-weight : bolder;
-        text-align  : right;
+        font-weight: bolder;
+        text-align: right;
     }
 
     li.special .item-label {
@@ -287,26 +287,26 @@
 
     ul {
         list-style: none;
-        padding   : 0px;
-        margin    : 0px;
+        padding: 0px;
+        margin: 0px;
     }
 }
 
 // the total height of .agda-mode-prompt should be the same as @header-height
 .agda-mode-prompt {
     white-space: pre;
-    margin     : 0 @root-padding;
+    margin: 0 @root-padding;
 
     input {
         // Issue #31 - make the input box larger
-        width    : calc(100% - @padding * 2);
+        width: calc(100% - @padding * 2);
         font-size: 100%;
-        padding  : @padding;
-        height   : 1rem;
+        padding: @padding;
+        height: 1rem;
 
         background-color: @input-background;
-        border          : none;
-        color           : @input;
+        border: none;
+        color: @input;
     }
 
     input::-webkit-input-placeholder {
@@ -320,7 +320,7 @@
     color: @link;
 
     .codicon-link::after {
-        content    : " ";
+        content: " ";
         white-space: pre;
     }
 
@@ -331,8 +331,8 @@
 }
 
 .component-link:hover {
-    color          : @link-hover;
-    cursor         : pointer;
+    color: @link-hover;
+    cursor: pointer;
     text-decoration: underline;
 
     &.component-hole,
@@ -347,8 +347,8 @@
 // the parent container of a Horizontal grouping
 .component-horz {
     // so that we can set paddings
-    display     : inline-flex;
-    flex-wrap   : wrap;
+    display: inline-flex;
+    flex-wrap: wrap;
     // use padding-left to indent every child
     padding-left: calc(@indent - 1ch);
 }


### PR DESCRIPTION
- allow `agdaMode.Buffer.fontSize` to be `null`, and inherit `editor.fontSize` in such a case
- directly getting the panel instance, instead of iterating over the `state` in `Registry`
- the header in the panel also uses the set font size