### PR TITLE
Address several warnings during build

### DIFF
--- a/lib/js/src/View/Root.bs.js
+++ b/lib/js/src/View/Root.bs.js
@@ -3,9 +3,9 @@
 
 var React = require("react");
 var VSCode = require("rescript-vscode/lib/js/src/VSCode.bs.js");
-var ReactDom = require("react-dom");
 var Belt_Option = require("rescript/lib/js/belt_Option.js");
 var Caml_option = require("rescript/lib/js/caml_option.js");
+var Client = require("react-dom/client");
 var Chan$AgdaModeVscode = require("../Util/Chan.bs.js");
 var View$AgdaModeVscode = require("./View.bs.js");
 var Json$JsonCombinators = require("@glennsl/rescript-json-combinators/lib/js/src/Json.bs.js");
@@ -51,13 +51,13 @@ Chan$AgdaModeVscode.on(onEventFromView, (function ($$event) {
                 }));
       }));
 
-Belt_Option.forEach(Caml_option.nullable_to_opt(document.getElementById("root")), (function (element) {
-        ReactDom.render(React.createElement(Panel$AgdaModeVscode.make, {
+Belt_Option.forEach(Caml_option.nullable_to_opt(document.getElementById("root")), (function (rootElement) {
+        Client.createRoot(rootElement).render(React.createElement(Panel$AgdaModeVscode.make, {
                   onRequest: onRequest,
                   onEventToView: onEventToView,
                   onResponse: onResponse,
                   onEventFromView: onEventFromView
-                }), element);
+                }));
       }));
 
 exports.vscode = vscode;

--- a/src/Connection/LSP/Connection__LSP.res
+++ b/src/Connection/LSP/Connection__LSP.res
@@ -302,9 +302,9 @@ module Module: Module = {
     | Ok(Result(None)) => await waitForResponseEnd
     }
     // stop listening for requests from server once `ResponseEnd` arrived
-    stopListeningForNotifications->VSCode.Disposable.dispose
+    stopListeningForNotifications->VSCode.Disposable.dispose->ignore
     // start handling Last Responses, after all NonLast Responses have been handled
-    await scheduler->Scheduler.runLast(handler)
+    let _ = await scheduler->Scheduler.runLast(handler)
     result
   }
 }

--- a/src/Editor.res
+++ b/src/Editor.res
@@ -1,8 +1,6 @@
 open VSCode
 module VSRange = Range
 
-open Common
-
 module Position = {
   let toString = position =>
     string_of_int(VSCode.Position.line(position)) ++
@@ -197,12 +195,12 @@ let reveal = (editor, range) =>
   editor->TextEditor.revealRange(range, Some(TextEditorRevealType.InCenterIfOutsideViewport))
 
 module Provider = {
-  let documentSelector =
-    [VSCode.StringOr.string("agda")
-    ,VSCode.StringOr.string("lagda-md")
-    ,VSCode.StringOr.string("lagda-rst")
-    ,VSCode.StringOr.string("lagda-tex")
-    ]
+  let documentSelector = [
+    VSCode.StringOr.string("agda"),
+    VSCode.StringOr.string("lagda-md"),
+    VSCode.StringOr.string("lagda-rst"),
+    VSCode.StringOr.string("lagda-tex"),
+  ]
   let registerDefinitionProvider = definitionProvider => {
     open DefinitionProvider
     Languages.registerDefinitionProvider(
@@ -240,8 +238,7 @@ module Provider = {
               strings,
               range,
             )) => {
-              let markdownStrings =
-                strings->Array.map(string => MarkdownString.make(string, true))
+              let markdownStrings = strings->Array.map(string => MarkdownString.make(string, true))
               Hover.makeWithRange(markdownStrings, range)
             }),
         }
@@ -353,8 +350,8 @@ module Provider = {
         ~provideDocumentSemanticTokensEdits: option<provideDocumentSemanticTokensEdits>=?,
         (),
       ) => {
-        provideDocumentSemanticTokens: provideDocumentSemanticTokens,
-        provideDocumentSemanticTokensEdits: provideDocumentSemanticTokensEdits,
+        provideDocumentSemanticTokens,
+        provideDocumentSemanticTokensEdits,
       }
     }
 

--- a/src/View/Root.res
+++ b/src/View/Root.res
@@ -31,6 +31,8 @@ let _ = onEventFromView->Chan.on(event => {
 })
 
 // mount the view at the "root" element
-Webapi.Dom.Document.getElementById(Webapi.Dom.document, "root")->Option.forEach(element =>
-  ReactDOM.render(<Panel onRequest onEventToView onResponse onEventFromView />, element)
-)
+Webapi.Dom.Document.getElementById(Webapi.Dom.document, "root")->Option.forEach(rootElement => {
+  ReactDOM.Client.createRoot(rootElement)->ReactDOM.Client.Root.render(
+    <Panel onRequest onEventToView onResponse onEventFromView />,
+  )
+})


### PR DESCRIPTION
-  `3:deprecated: ReactDOM.render ReactDOM.render is no longer supported in React 18. Use ReactDOM.Client.createRoot instead.` (https://github.com/banacorn/agda-mode-vscode/blob/ea033d842f5af531e5a48403167a4dac88ced590/src/View/Root.res#L34)
- `33:unused open AgdaModeVscode.Common`
(https://github.com/banacorn/agda-mode-vscode/blob/ea033d842f5af531e5a48403167a4dac88ced590/src/Editor.res#L4)
- `21:this statement never returns (or has an unsound type.)`
(https://github.com/banacorn/agda-mode-vscode/blob/ea033d842f5af531e5a48403167a4dac88ced590/src/Connection/LSP/Connection__LSP.res#L305)

there are several warnings `44:this open statement shadows the module identifier` left. This could be solved by changing `open *` to `open! *` but not sure if this is desirable. So I leave them unchanged  