### PR TITLE
Fix year in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #158: C-c C-s and C-c C-a inserts \n instead of newlines by [@jiangsy](https://github.com/jiangsy)
 - #198: Address several warnings during build by [@jiangsy](https://github.com/jiangsy)
 
-## v0.5.0 - 2023-11-13
+## v0.5.0 - 2024-11-13
 
 ### Fixed
 - #196: Improve the logic related to buffer's font size adjustment by [@jiangsy](https://github.com/jiangsy)


### PR DESCRIPTION
The year for the `0.5.0` version is wrong in the changelog.