### PR TITLE
Basic `lagda.typ` support

### DIFF
--- a/lib/js/src/Editor.bs.js
+++ b/lib/js/src/Editor.bs.js
@@ -280,6 +280,11 @@ var documentSelector = [
       }),
   VSCode.StringOr.make({
         TAG: "String",
+        _0: "lagda-typ",
+        [Symbol.for("name")]: "String"
+      }),
+  VSCode.StringOr.make({
+        TAG: "String",
         _0: "lagda-tex",
         [Symbol.for("name")]: "String"
       })

--- a/lib/js/src/Parser/SourceFile.bs.js
+++ b/lib/js/src/Parser/SourceFile.bs.js
@@ -11,6 +11,8 @@ function parse(filepath) {
     return "LiterateRST";
   } else if (/\.lagda\.md$/i.test(Parser$AgdaModeVscode.filepath(filepath))) {
     return "LiterateMarkdown";
+  } else if (/\.lagda\.typ$/i.test(Parser$AgdaModeVscode.filepath(filepath))) {
+    return "LiterateTypst";
   } else if (/\.lagda\.tex$|\.lagda$/i.test(Parser$AgdaModeVscode.filepath(filepath))) {
     return "LiterateTeX";
   } else if (/\.lagda\.org$/i.test(Parser$AgdaModeVscode.filepath(filepath))) {
@@ -214,6 +216,10 @@ function markMarkdown(extra) {
   return markWithRules(markdown, markdown, extra);
 }
 
+function markTypst(extra) {
+  return markWithRules(markdown, markdown, extra);
+}
+
 function markTex(extra) {
   return markWithRules(texBegin, texEnd, extra);
 }
@@ -230,6 +236,7 @@ var Literate = {
   toTokens: toTokens,
   markWithRules: markWithRules,
   markMarkdown: markMarkdown,
+  markTypst: markTypst,
   markTex: markTex,
   markRST: markRST,
   markOrg: markOrg
@@ -262,6 +269,7 @@ function parse$1(indices, filepath, raw) {
         preprocessed = markWithRules(rstBegin, rstEnd, raw);
         break;
     case "LiterateMarkdown" :
+    case "LiterateTypst" :
         preprocessed = markWithRules(markdown, markdown, raw);
         break;
     case "LiterateOrg" :

--- a/lib/js/test/tests/Parser/Test__Parser__SourceFile.bs.js
+++ b/lib/js/test/tests/Parser/Test__Parser__SourceFile.bs.js
@@ -12,6 +12,7 @@ describe("when parsing file paths", (function () {
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda"), "LiterateTeX", undefined);
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.tex"), "LiterateTeX", undefined);
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.md"), "LiterateMarkdown", undefined);
+                Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.typ"), "LiterateTypst", undefined);
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.rst"), "LiterateRST", undefined);
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.org"), "LiterateOrg", undefined);
               }));

--- a/package.json
+++ b/package.json
@@ -82,6 +82,20 @@
 				}
 			},
 			{
+				"id": "lagda-typ",
+				"extensions": [
+					".lagda.typ"
+				],
+				"aliases": [
+					"Literate Agda (Typst)"
+				],
+				"configuration": "./language-configuration.json",
+				"icon": {
+					"dark": "./asset/dark.png",
+					"light": "./asset/light.png"
+				}
+			},
+			{
 				"id": "lagda-tex",
 				"extensions": [
 					".lagda.tex",
@@ -125,6 +139,14 @@
 				"language": "lagda-md",
 				"scopeName": "source.markdown",
 				"path": "./syntaxes/markdown.tmLanguage.json",
+				"injectTo": [
+					"source.agda"
+				]
+			},
+			{
+				"language": "lagda-typ",
+				"scopeName": "source.typst",
+				"path": "./syntaxes/typst.tmLanguage.json",
 				"injectTo": [
 					"source.agda"
 				]
@@ -458,412 +480,412 @@
 				"command": "agda-mode.load",
 				"key": "ctrl+c ctrl+l",
 				"mac": "ctrl+c ctrl+l",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "\\",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.quit",
 				"key": "ctrl+c ctrl+x ctrl+q",
 				"mac": "ctrl+c ctrl+x ctrl+q",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.restart",
 				"key": "ctrl+c ctrl+x ctrl+r",
 				"mac": "ctrl+c ctrl+x ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compile",
 				"key": "ctrl+c ctrl+x ctrl+c",
 				"mac": "ctrl+c ctrl+x ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-implicit-arguments",
 				"key": "ctrl+c ctrl+x ctrl+h",
 				"mac": "ctrl+c ctrl+x ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-irrelevant-arguments",
 				"key": "ctrl+c ctrl+x ctrl+i",
 				"mac": "ctrl+c ctrl+x ctrl+i",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-constraints",
 				"key": "ctrl+c ctrl+=",
 				"mac": "ctrl+c ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Simplified]",
 				"key": "ctrl+c ctrl+s",
 				"mac": "ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+?",
 				"mac": "ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+shift+/",
 				"mac": "ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.next-goal",
 				"key": "ctrl+c ctrl+f",
 				"mac": "ctrl+c ctrl+f",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.previous-goal",
 				"key": "ctrl+c ctrl+b",
 				"mac": "ctrl+c ctrl+b",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Simplified]",
 				"key": "ctrl+c ctrl+z",
 				"mac": "ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.give",
 				"key": "ctrl+c ctrl+space",
 				"mac": "ctrl+c ctrl+space",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.refine",
 				"key": "ctrl+c ctrl+r",
 				"mac": "ctrl+c ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Simplified]",
 				"key": "ctrl+c ctrl+m",
 				"mac": "ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.auto[AsIs]",
 				"key": "ctrl+c ctrl+a",
 				"mac": "ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Simplified]",
 				"key": "ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[HeadNormal]",
 				"key": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.case",
 				"key": "ctrl+c ctrl+c",
 				"mac": "ctrl+c ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Simplified]",
 				"key": "ctrl+c ctrl+h",
 				"mac": "ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.goal-type[Simplified]",
 				"key": "ctrl+c ctrl+t",
 				"mac": "ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.context[Simplified]",
 				"key": "ctrl+c ctrl+e",
 				"mac": "ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.infer-type[Simplified]",
 				"key": "ctrl+c ctrl+d",
 				"mac": "ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Simplified]",
 				"key": "ctrl+c ctrl+,",
 				"mac": "ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Simplified]",
 				"key": "ctrl+c ctrl+.",
 				"mac": "ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Simplified]",
 				"key": "ctrl+c ctrl+;",
 				"mac": "ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.module-contents[Simplified]",
 				"key": "ctrl+c ctrl+o",
 				"mac": "ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[DefaultCompute]",
 				"key": "ctrl+c ctrl+n",
 				"mac": "ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[IgnoreAbstract]",
 				"key": "ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[UseShowInstance]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
 			},
 			{
 				"command": "agda-mode.why-in-scope",
 				"key": "ctrl+c ctrl+w",
 				"mac": "ctrl+c ctrl+w",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.switch-agda-version",
 				"key": "ctrl+x ctrl+s",
 				"mac": "ctrl+x ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.escape",
 				"key": "escape",
 				"mac": "escape",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModePrompting || agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModePrompting || agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseUp]",
 				"key": "up",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseRight]",
 				"key": "right",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseDown]",
 				"key": "down",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseLeft]",
 				"key": "left",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenCurlyBraces]",
 				"key": "shift+[",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenParenthesis]",
 				"key": "shift+9",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.lookup-symbol",
 				"key": "ctrl+x ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
 			}
 		],
 		"configuration": {

--- a/src/Editor.res
+++ b/src/Editor.res
@@ -199,6 +199,7 @@ module Provider = {
     VSCode.StringOr.make(String("agda")),
     VSCode.StringOr.make(String("lagda-md")),
     VSCode.StringOr.make(String("lagda-rst")),
+    VSCode.StringOr.make(String("lagda-typ")),
     VSCode.StringOr.make(String("lagda-tex")),
   ]
   let registerDefinitionProvider = definitionProvider => {

--- a/src/Parser/SourceFile.res
+++ b/src/Parser/SourceFile.res
@@ -8,12 +8,15 @@ module FileType = {
     | LiterateTeX
     | LiterateRST
     | LiterateMarkdown
+    | LiterateTypst
     | LiterateOrg
   let parse = filepath =>
     if RegExp.test(%re("/\.lagda\.rst$/i"), Parser.filepath(filepath)) {
       LiterateRST
     } else if RegExp.test(%re("/\.lagda\.md$/i"), Parser.filepath(filepath)) {
       LiterateMarkdown
+    } else if RegExp.test(%re("/\.lagda\.typ$/i"), Parser.filepath(filepath)) {
+      LiterateTypst
     } else if RegExp.test(%re("/\.lagda\.tex$|\.lagda$/i"), Parser.filepath(filepath)) {
       LiterateTeX
     } else if RegExp.test(%re("/\.lagda\.org$/i"), Parser.filepath(filepath)) {
@@ -189,6 +192,7 @@ module Literate = {
   }
 
   let markMarkdown = markWithRules(Regex.markdown, Regex.markdown, ...)
+  let markTypst = markWithRules(Regex.markdown, Regex.markdown, ...)
   let markTex = markWithRules(Regex.texBegin, Regex.texEnd, ...)
   let markRST = markWithRules(Regex.rstBegin, Regex.rstEnd, ...)
   let markOrg = markWithRules(Regex.orgBegin, Regex.orgEnd, ...)
@@ -224,6 +228,7 @@ let parse = (indices: array<int>, filepath: string, raw: string): array<Diff.t> 
   let preprocessed = switch fileType {
   | LiterateTeX => Literate.markTex(raw)
   | LiterateMarkdown => Literate.markMarkdown(raw)
+  | LiterateTypst => Literate.markTypst(raw)
   | LiterateRST => Literate.markRST(raw)
   | LiterateOrg => Literate.markOrg(raw)
   | Agda => Lexer.make(raw)

--- a/syntaxes/typst.tmLanguage.json
+++ b/syntaxes/typst.tmLanguage.json
@@ -1,0 +1,6 @@
+{
+    "scopeName": "source.typst",
+    "patterns": [
+        { "include": "source.typst" }
+    ]
+}

--- a/test/tests/Parser/Test__Parser__SourceFile.res
+++ b/test/tests/Parser/Test__Parser__SourceFile.res
@@ -7,6 +7,7 @@ describe("when parsing file paths", () =>
     Assert.equal(parse("a.lagda"), LiterateTeX)
     Assert.equal(parse("a.lagda.tex"), LiterateTeX)
     Assert.equal(parse("a.lagda.md"), LiterateMarkdown)
+    Assert.equal(parse("a.lagda.typ"), LiterateTypst)
     Assert.equal(parse("a.lagda.rst"), LiterateRST)
     Assert.equal(parse("a.lagda.org"), LiterateOrg)
   })


### PR DESCRIPTION
Unsure if this is the best way to do it, but I basically extended Markdown support a bit to Typst, considering the syntax is similar. I tested it locally and it worked.

Also, I'm unsure if I should've committed the generated files in `lib/js`.

Let me know if there are changes I should make!