### PR TITLE
[ fix ] Don't add padding to goal brackets

### DIFF
--- a/lib/js/src/Parser/SourceFile.bs.js
+++ b/lib/js/src/Parser/SourceFile.bs.js
@@ -246,9 +246,6 @@ var Diff = {
 };
 
 function parse$1(indices, filepath, raw) {
-  var i = {
-    contents: 0
-  };
   var fileType = parse(filepath);
   var preprocessed;
   switch (fileType) {
@@ -277,44 +274,7 @@ function parse$1(indices, filepath, raw) {
             kind: "GoalBracket"
           };
   };
-  var adjustGoalBracket = function (token) {
-    var idx = indices[i.contents];
-    var goalIndex = idx !== undefined ? String(idx) : "*";
-    var requiredSpaces = goalIndex.length;
-    var content = Core__Option.getOr(Core__Option.flatMap(Caml_option.nullable_to_opt(goalBracketContent.exec(token.content)), (function (result) {
-                return Core__Option.flatMap(result[1], (function (x) {
-                              return x;
-                            }));
-              })), "");
-    var actualSpaces = Core__Option.getOr(Core__Option.flatMap(Caml_option.nullable_to_opt(content.match(/\s*$/)), (function (matches) {
-                var match = matches[0];
-                if (match === undefined) {
-                  return ;
-                }
-                var s = Caml_option.valFromOption(match);
-                if (s !== undefined) {
-                  return s.length;
-                }
-                
-              })), 0);
-    var newContent;
-    if (actualSpaces < requiredSpaces) {
-      var padding = " ".repeat(requiredSpaces - actualSpaces | 0);
-      newContent = token.content.replace(/\{!.*!\}/, "{!" + content + padding + "!}");
-    } else {
-      newContent = token.content;
-    }
-    i.contents = i.contents + 1 | 0;
-    return {
-            content: newContent,
-            range: [
-              1,
-              2
-            ],
-            kind: "GoalBracket"
-          };
-  };
-  var modified = mapOnly("GoalBracket", adjustGoalBracket, mapOnly("GoalQM", questionMark2GoalBracket, original));
+  var modified = mapOnly("GoalQM", questionMark2GoalBracket, original);
   var originalHoles = original.filter(isHole);
   var modifiedHoles = modified.filter(isHole);
   return Core__Array.filterMap(originalHoles.map(function (token, idx) {

--- a/src/Parser/SourceFile.res
+++ b/src/Parser/SourceFile.res
@@ -217,8 +217,6 @@ module Diff = {
 
 let parse = (indices: array<int>, filepath: string, raw: string): array<Diff.t> => {
   open Token
-  // counter for indices
-  let i = ref(0)
   // processed literate Agda
   let fileType = FileType.parse(filepath)
   let preprocessed = switch fileType {
@@ -252,67 +250,8 @@ let parse = (indices: array<int>, filepath: string, raw: string): array<Diff.t> 
     range: token.range,
     kind: GoalBracket,
   }
-  let adjustGoalBracket = (token: Token.t) => {
-    /* {!!} => {!   !} */
 
-    /* in case that the goal index wasn't given, make it '*' */
-    /* this happens when splitting case, agda2-goals-action is one index short */
-    let goalIndex = switch indices[i.contents] {
-    | Some(idx) => string_of_int(idx)
-    | None => "*"
-    }
-
-    /* {! zero 42!}
-         <------>    hole content
-               <>    index
-              <->    space for index
- */
-
-    /* calculate how much space the index would take */
-    let requiredSpaces = String.length(goalIndex)
-
-    /* calculate how much space we have */
-    let content: string =
-      // Js.Re.exec_(Regex.goalBracketContent, token.content)
-      // ->Option.flatMap(result =>{
-      //   Js.Re.captures(result)[1]->Option.map(Nullable.toOption)->Option.flatMap(x => x)
-      // })
-      // ->Option.getOr("")
-      Regex.goalBracketContent
-      ->RegExp.exec(token.content)
-      ->Option.flatMap(result => result[1]->Option.flatMap(x => x))
-      ->Option.getOr("")
-
-    let actualSpaces =
-      content
-      ->String.match(%re("/\s*$/"))
-      ->Option.flatMap(matches =>
-        switch matches[0] {
-        | None => None
-        | Some(None) => None
-        | Some(Some(s)) => Some(String.length(s))
-        }
-      )
-      ->Option.getOr(0)
-
-    /* make room for the index, if there's not enough space */
-    let newContent = if actualSpaces < requiredSpaces {
-      let padding = " "->String.repeat(requiredSpaces - actualSpaces)
-      token.content->String.replaceRegExp(%re("/\{!.*!\}/"), "{!" ++ content ++ padding ++ "!}")
-    } else {
-      token.content
-    }
-
-    /* update the index */
-    i := i.contents + 1
-    {content: newContent, kind: GoalBracket, range: (1, 2)}
-  }
-
-  let modified = Lexer.mapOnly(
-    GoalBracket,
-    adjustGoalBracket,
-    Lexer.mapOnly(GoalQM, questionMark2GoalBracket, original),
-  )
+  let modified = Lexer.mapOnly(GoalQM, questionMark2GoalBracket, original)
   let originalHoles = original->Array.filter(isHole)
   let modifiedHoles = modified->Array.filter(isHole)
 


### PR DESCRIPTION
Fixes https://github.com/banacorn/agda-mode-vscode/issues/207, fixes https://github.com/banacorn/agda-mode-vscode/issues/205.

As explained in the first linked issue, the `adjustGoalBracket` function used to have no effect because it computed the padding by repeating the empty string, i.e. never added any padding. This was "fixed" in https://github.com/banacorn/agda-mode-vscode/commit/3611495ff8881cdbc14513766a8668be6859bcf8#diff-3802c29909ec1c1d484b9eae9d0c163d290880b5a2b66a197eb2b3b4295f6300L287, which introduced the above two issues. This PR removes `adjustGoalBracket` entirely.

I am not sure why this function was there in the first place.