### PR TITLE
[ fix ] update Interval format for upcoming 2.8.0

### DIFF
--- a/lib/js/src/Goal.bs.js
+++ b/lib/js/src/Goal.bs.js
@@ -91,7 +91,9 @@ function buildHaskellRange(self, $$document, version, filepath) {
   var endRow = String(endPoint.line + 1 | 0);
   var endColumn = String(endPoint.character - 1 | 0);
   var endPart = endIndex$p + " " + endRow + " " + endColumn;
-  if (Util$AgdaModeVscode.Version.gte(version, "2.5.1")) {
+  if (Util$AgdaModeVscode.Version.gte(version, "2.8.0")) {
+    return "(intervalsToRange (Just (mkAbsolute \"" + filepath + "\")) [Interval () (Pn () " + startPart + ") (Pn () " + endPart + ")])";
+  } else if (Util$AgdaModeVscode.Version.gte(version, "2.5.1")) {
     return "(intervalsToRange (Just (mkAbsolute \"" + filepath + "\")) [Interval (Pn () " + startPart + ") (Pn () " + endPart + ")])";
   } else {
     return "(Range [Interval (Pn (Just (mkAbsolute \"" + filepath + "\")) " + startPart + ") (Pn (Just (mkAbsolute \"" + filepath + "\")) " + endPart + ")])";

--- a/src/Goal.res
+++ b/src/Goal.res
@@ -127,8 +127,10 @@ module Module: Module = {
     let endColumn = string_of_int(VSCode.Position.character(endPoint) - 1)
     let endPart = `${endIndex'} ${endRow} ${endColumn}`
 
-    if Util.Version.gte(version, "2.5.1") {
-      `(intervalsToRange (Just (mkAbsolute "${filepath}")) [Interval (Pn () ${startPart}) (Pn () ${endPart})])` // after 2.5.1
+    if Util.Version.gte(version, "2.8.0") {
+      `(intervalsToRange (Just (mkAbsolute "${filepath}")) [Interval () (Pn () ${startPart}) (Pn () ${endPart})])` // after 2.8.0
+    } else if Util.Version.gte(version, "2.5.1") {
+      `(intervalsToRange (Just (mkAbsolute "${filepath}")) [Interval (Pn () ${startPart}) (Pn () ${endPart})])` // after 2.5.1, before (not including) 2.8.0
     } else {
       `(Range [Interval (Pn (Just (mkAbsolute "${filepath}")) ${startPart}) (Pn (Just (mkAbsolute "${filepath}")) ${endPart})])` // before (not including) 2.5.1
     }


### PR DESCRIPTION
The `Interval` constructor will start taking an extra unit argument in 2.8.0, see https://github.com/agda/agda/pull/7610

For searchability, with Agda 2.8.0 (current `master`) and the current version of the extension, trying to give or refine a goal results in errors like

```
Something went wrong when parsing S-expressions. Error code PreprocessError "cannot read: IOTCM "/file.agda" NonInteractive Direct( Cmd_give WithoutForce 0 (intervalsToRange (Just (mkAbsolute "/file.agda")) [Interval (Pn () 216 9 22) (Pn () 218 9 26)]) "x" )"
```