### PR TITLE
Add Forester language support

### DIFF
--- a/lib/js/src/Parser/SourceFile.bs.js
+++ b/lib/js/src/Parser/SourceFile.bs.js
@@ -158,6 +158,8 @@ var Regex = {
   rstEnd: rstEnd,
   orgBegin: orgBegin,
   orgEnd: orgEnd,
+  foresterBegin: foresterBegin,
+  foresterEnd: foresterEnd,
   comment: comment,
   goalBracket: goalBracket,
   goalQuestionMarkRaw: goalQuestionMarkRaw,

--- a/lib/js/src/Parser/SourceFile.bs.js
+++ b/lib/js/src/Parser/SourceFile.bs.js
@@ -17,6 +17,8 @@ function parse(filepath) {
     return "LiterateTeX";
   } else if (/\.lagda\.org$/i.test(Parser$AgdaModeVscode.filepath(filepath))) {
     return "LiterateOrg";
+  } else if (/\.lagda\.tree$/i.test(Parser$AgdaModeVscode.filepath(filepath))) {
+    return "LiterateForester";
   } else {
     return "Agda";
   }
@@ -134,6 +136,10 @@ var orgBegin = /\#\+begin\_src agda2/i;
 
 var orgEnd = /\#\+end\_src/i;
 
+var foresterBegin = /\\agda\{/;
+
+var foresterEnd = /^\s*\}\s*$/;
+
 var comment = /((?<=^|[\s\"\_\;\.\(\)\{\}\@])--[^\r\n]*(?:\r|\n|$))|(\{-(?:[^-]|[\r\n]|(?:-+(?:[^-\}]|[\r\n])))*-+\})/;
 
 var goalBracket = /(\{\!(?:(?!\!\})(?:.|\s))*\!\})/;
@@ -232,6 +238,10 @@ function markOrg(extra) {
   return markWithRules(orgBegin, orgEnd, extra);
 }
 
+function markForester(extra) {
+  return markWithRules(foresterBegin, foresterEnd, extra);
+}
+
 var Literate = {
   toTokens: toTokens,
   markWithRules: markWithRules,
@@ -239,7 +249,8 @@ var Literate = {
   markTypst: markTypst,
   markTex: markTex,
   markRST: markRST,
-  markOrg: markOrg
+  markOrg: markOrg,
+  markForester: markForester
 };
 
 function toString(param) {
@@ -272,7 +283,9 @@ function parse$1(indices, filepath, raw) {
     case "LiterateOrg" :
         preprocessed = markWithRules(orgBegin, orgEnd, raw);
         break;
-    
+    case "LiterateForester" :
+        preprocessed = markWithRules(foresterBegin, foresterEnd, raw);
+        break;
   }
   var original = lex(goalQuestionMark, "GoalQMRaw", "GoalQM", lex(goalQuestionMarkRaw, "AgdaRaw", "GoalQMRaw", lex(goalBracket, "AgdaRaw", "GoalBracket", lex(comment, "AgdaRaw", "Comment", preprocessed))));
   var questionMark2GoalBracket = function (token) {

--- a/lib/js/src/Parser/SourceFile.bs.js
+++ b/lib/js/src/Parser/SourceFile.bs.js
@@ -138,7 +138,7 @@ var orgEnd = /\#\+end\_src/i;
 
 var foresterBegin = /\\agda\{/;
 
-var foresterEnd = /^\s*\}\s*$/;
+var foresterEnd = /^\s*\}/;
 
 var comment = /((?<=^|[\s\"\_\;\.\(\)\{\}\@])--[^\r\n]*(?:\r|\n|$))|(\{-(?:[^-]|[\r\n]|(?:-+(?:[^-\}]|[\r\n])))*-+\})/;
 

--- a/lib/js/test/tests/Parser/Test__Parser__SourceFile.bs.js
+++ b/lib/js/test/tests/Parser/Test__Parser__SourceFile.bs.js
@@ -15,6 +15,7 @@ describe("when parsing file paths", (function () {
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.typ"), "LiterateTypst", undefined);
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.rst"), "LiterateRST", undefined);
                 Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.org"), "LiterateOrg", undefined);
+                Curry._3(Assert.equal, SourceFile$AgdaModeVscode.FileType.parse("a.lagda.tree"), "LiterateForester", undefined);
               }));
       }));
 

--- a/package.json
+++ b/package.json
@@ -125,6 +125,20 @@
 				}
 			},
 			{
+				"id": "lagda-org",
+				"extensions": [
+					".lagda.org"
+				],
+				"aliases": [
+					"Literate Agda (Org)"
+				],
+				"configuration": "./language-configuration.json",
+				"icon": {
+					"dark": "./asset/dark.png",
+					"light": "./asset/light.png"
+				}
+			},
+			{
 				"id": "lagda-forester",
 				"extensions": [
 					".lagda.tree"
@@ -177,6 +191,14 @@
 				"language": "lagda-tex",
 				"scopeName": "source.tex",
 				"path": "./syntaxes/tex.tmLanguage.json",
+				"injectTo": [
+					"source.agda"
+				]
+			},
+			{
+				"language": "lagda-org",
+				"scopeName": "source.org",
+				"path": "./syntaxes/org.tmLanguage.json",
 				"injectTo": [
 					"source.agda"
 				]

--- a/package.json
+++ b/package.json
@@ -524,412 +524,412 @@
 				"command": "agda-mode.load",
 				"key": "ctrl+c ctrl+l",
 				"mac": "ctrl+c ctrl+l",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "\\",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.quit",
 				"key": "ctrl+c ctrl+x ctrl+q",
 				"mac": "ctrl+c ctrl+x ctrl+q",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.restart",
 				"key": "ctrl+c ctrl+x ctrl+r",
 				"mac": "ctrl+c ctrl+x ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compile",
 				"key": "ctrl+c ctrl+x ctrl+c",
 				"mac": "ctrl+c ctrl+x ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-implicit-arguments",
 				"key": "ctrl+c ctrl+x ctrl+h",
 				"mac": "ctrl+c ctrl+x ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-irrelevant-arguments",
 				"key": "ctrl+c ctrl+x ctrl+i",
 				"mac": "ctrl+c ctrl+x ctrl+i",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-constraints",
 				"key": "ctrl+c ctrl+=",
 				"mac": "ctrl+c ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Simplified]",
 				"key": "ctrl+c ctrl+s",
 				"mac": "ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+?",
 				"mac": "ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+shift+/",
 				"mac": "ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.next-goal",
 				"key": "ctrl+c ctrl+f",
 				"mac": "ctrl+c ctrl+f",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.previous-goal",
 				"key": "ctrl+c ctrl+b",
 				"mac": "ctrl+c ctrl+b",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Simplified]",
 				"key": "ctrl+c ctrl+z",
 				"mac": "ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.give",
 				"key": "ctrl+c ctrl+space",
 				"mac": "ctrl+c ctrl+space",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.refine",
 				"key": "ctrl+c ctrl+r",
 				"mac": "ctrl+c ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Simplified]",
 				"key": "ctrl+c ctrl+m",
 				"mac": "ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.auto[AsIs]",
 				"key": "ctrl+c ctrl+a",
 				"mac": "ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Simplified]",
 				"key": "ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[HeadNormal]",
 				"key": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.case",
 				"key": "ctrl+c ctrl+c",
 				"mac": "ctrl+c ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Simplified]",
 				"key": "ctrl+c ctrl+h",
 				"mac": "ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type[Simplified]",
 				"key": "ctrl+c ctrl+t",
 				"mac": "ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.context[Simplified]",
 				"key": "ctrl+c ctrl+e",
 				"mac": "ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.infer-type[Simplified]",
 				"key": "ctrl+c ctrl+d",
 				"mac": "ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Simplified]",
 				"key": "ctrl+c ctrl+,",
 				"mac": "ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Simplified]",
 				"key": "ctrl+c ctrl+.",
 				"mac": "ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Simplified]",
 				"key": "ctrl+c ctrl+;",
 				"mac": "ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.module-contents[Simplified]",
 				"key": "ctrl+c ctrl+o",
 				"mac": "ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[DefaultCompute]",
 				"key": "ctrl+c ctrl+n",
 				"mac": "ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[IgnoreAbstract]",
 				"key": "ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[UseShowInstance]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.why-in-scope",
 				"key": "ctrl+c ctrl+w",
 				"mac": "ctrl+c ctrl+w",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.switch-agda-version",
 				"key": "ctrl+x ctrl+s",
 				"mac": "ctrl+x ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.escape",
 				"key": "escape",
 				"mac": "escape",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModePrompting || agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModePrompting || agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseUp]",
 				"key": "up",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseRight]",
 				"key": "right",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseDown]",
 				"key": "down",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseLeft]",
 				"key": "left",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenCurlyBraces]",
 				"key": "shift+[",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenParenthesis]",
 				"key": "shift+9",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.lookup-symbol",
 				"key": "ctrl+x ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -123,6 +123,20 @@
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
 				}
+			},
+			{
+				"id": "lagda-forester",
+				"extensions": [
+					".lagda.tree"
+				],
+				"aliases": [
+					"Literate Agda (forester)"
+				],
+				"configuration": "./language-configuration.json",
+				"icon": {
+					"dark": "./asset/dark.png",
+					"light": "./asset/light.png"
+				}
 			}
 		],
 		"grammars": [
@@ -163,6 +177,14 @@
 				"language": "lagda-tex",
 				"scopeName": "source.tex",
 				"path": "./syntaxes/tex.tmLanguage.json",
+				"injectTo": [
+					"source.agda"
+				]
+			},
+			{
+				"language": "lagda-forester",
+				"scopeName": "source.forester",
+				"path": "./syntaxes/forester.tmLanguage.json",
 				"injectTo": [
 					"source.agda"
 				]

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 			},
 			{
 				"language": "lagda-rst",
-				"scopeName": "source.restructuredtext",
+				"scopeName": "source.rst",
 				"path": "./syntaxes/restructuredtext.tmLanguage.json",
 				"injectTo": [
 					"source.agda"

--- a/src/Parser/SourceFile.res
+++ b/src/Parser/SourceFile.res
@@ -10,6 +10,7 @@ module FileType = {
     | LiterateMarkdown
     | LiterateTypst
     | LiterateOrg
+    | LiterateForester
   let parse = filepath =>
     if RegExp.test(%re("/\.lagda\.rst$/i"), Parser.filepath(filepath)) {
       LiterateRST
@@ -21,6 +22,8 @@ module FileType = {
       LiterateTeX
     } else if RegExp.test(%re("/\.lagda\.org$/i"), Parser.filepath(filepath)) {
       LiterateOrg
+    } else if RegExp.test(%re("/\.lagda\.tree$/i"), Parser.filepath(filepath)) {
+      LiterateForester
     } else {
       Agda
     }
@@ -196,6 +199,7 @@ module Literate = {
   let markTex = markWithRules(Regex.texBegin, Regex.texEnd, ...)
   let markRST = markWithRules(Regex.rstBegin, Regex.rstEnd, ...)
   let markOrg = markWithRules(Regex.orgBegin, Regex.orgEnd, ...)
+  let markForester = markWithRules(Regex.foresterBegin, Regex.foresterEnd, ...)
 }
 
 module Diff = {
@@ -229,6 +233,7 @@ let parse = (indices: array<int>, filepath: string, raw: string): array<Diff.t> 
   | LiterateTypst => Literate.markTypst(raw)
   | LiterateRST => Literate.markRST(raw)
   | LiterateOrg => Literate.markOrg(raw)
+  | LiterateForester => Literate.markForester(raw)
   | Agda => Lexer.make(raw)
   }
   /* just lexing, doesn't mess around with raw text, preserves positions */

--- a/src/Parser/SourceFile.res
+++ b/src/Parser/SourceFile.res
@@ -116,6 +116,8 @@ module Regex = {
   let rstEnd = %re("/^[^\s]/")
   let orgBegin = %re("/\#\+begin\_src agda2/i")
   let orgEnd = %re("/\#\+end\_src/i")
+  let foresterBegin = %re("/\\agda\{/")
+  let foresterEnd = %re("/^\s*\}/")
 
   let comment = %re(
     "/((?<=^|[\s\"\_\;\.\(\)\{\}\@])--[^\r\n]*(?:\r|\n|$))|(\{-(?:[^-]|[\r\n]|(?:-+(?:[^-\}]|[\r\n])))*-+\})/"

--- a/syntaxes/forester.tmLanguage.json
+++ b/syntaxes/forester.tmLanguage.json
@@ -1,0 +1,6 @@
+{
+    "scopeName": "source.forester",
+    "patterns": [
+        { "include": "source.forester" }
+    ]
+}

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -1,0 +1,6 @@
+{
+    "scopeName": "source.org",
+    "patterns": [
+        { "include": "source.org" }
+    ]
+}

--- a/syntaxes/restructuredtext.tmLanguage.json
+++ b/syntaxes/restructuredtext.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-    "scopeName": "source.restructuredtext",
+    "scopeName": "source.rst",
     "patterns": [
         { "include": "source.rst" }
     ]

--- a/test/tests/Parser/Test__Parser__SourceFile.res
+++ b/test/tests/Parser/Test__Parser__SourceFile.res
@@ -10,6 +10,7 @@ describe("when parsing file paths", () =>
     Assert.equal(parse("a.lagda.typ"), LiterateTypst)
     Assert.equal(parse("a.lagda.rst"), LiterateRST)
     Assert.equal(parse("a.lagda.org"), LiterateOrg)
+    Assert.equal(parse("a.lagda.tree"), LiterateForester)
   })
 )
 


### PR DESCRIPTION
Also adds missing bindings for literate org files, and renames the scope of reStructuredText to the standard one.