### PR TITLE
Agda as an embedded language

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -42,9 +42,7 @@
     ["{{", "}}"],
     ["⦃", "⦄"]
   ],
-  // "wordPattern" is temporarily disabled because it will hinder the activation of other autocompletion-based input methods like `latex-input` 
-  // see https://github.com/banacorn/agda-mode-vscode/issues/184
-  // "wordPattern": "[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
+  "wordPattern": "[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
   "onEnterRules": [
     {
       // Indent if a line ends with any of `=` `:` `⦃`

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -42,7 +42,7 @@
     ["{{", "}}"],
     ["⦃", "⦄"]
   ],
-  "wordPattern": "[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
+  "wordPattern": "(?!\\\\)[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
   "onEnterRules": [
     {
       // Indent if a line ends with any of `=` `:` `⦃`

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -42,6 +42,10 @@
     ["{{", "}}"],
     ["⦃", "⦄"]
   ],
+  // "wordPattern" won't match words that start with a backslash because it will
+  // hinder the activation of other autocompletion-based input methods like
+  // `latex-input`.
+  // see https://github.com/banacorn/agda-mode-vscode/issues/184
   "wordPattern": "(?!\\\\)[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
   "onEnterRules": [
     {

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -29,6 +29,11 @@
       "open": "⦃",
       "close": "⦄",
       "notIn": ["comment", "string"]
+    },
+    {
+      "open": "⦇",
+      "close": "⦈",
+      "notIn": ["comment", "string"]
     }
   ],
   "surroundingPairs": [
@@ -40,13 +45,15 @@
     ["{!", "!}"],
     ["{-#", "#-}"],
     ["{{", "}}"],
-    ["⦃", "⦄"]
+    ["⦃", "⦄"],
+    ["(|", "|)"],
+    ["⦇", "⦈"]
   ],
   "wordPattern": "[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
   "onEnterRules": [
     {
-      // Indent if a line ends with any of `=` `:` `⦃`
-      "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"][=:⦃]\\s*$",
+      // Indent if a line ends with any of `=` `:` `⦃` `⦇`
+      "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"][=:⦃⦇]\\s*$",
       "action": {
         "indent": "indent"
       }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -29,11 +29,6 @@
       "open": "⦃",
       "close": "⦄",
       "notIn": ["comment", "string"]
-    },
-    {
-      "open": "⦇",
-      "close": "⦈",
-      "notIn": ["comment", "string"]
     }
   ],
   "surroundingPairs": [
@@ -45,15 +40,13 @@
     ["{!", "!}"],
     ["{-#", "#-}"],
     ["{{", "}}"],
-    ["⦃", "⦄"],
-    ["(|", "|)"],
-    ["⦇", "⦈"]
+    ["⦃", "⦄"]
   ],
   "wordPattern": "[^\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"]+",
   "onEnterRules": [
     {
-      // Indent if a line ends with any of `=` `:` `⦃` `⦇`
-      "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"][=:⦃⦇]\\s*$",
+      // Indent if a line ends with any of `=` `:` `⦃`
+      "beforeText": "[\\s\\n\\.\\;\\{\\}\\(\\)\\@\\\"][=:⦃]\\s*$",
       "action": {
         "indent": "indent"
       }

--- a/lib/js/src/Editor.bs.js
+++ b/lib/js/src/Editor.bs.js
@@ -280,7 +280,7 @@ var documentSelector = [
       }),
   VSCode.StringOr.make({
         TAG: "String",
-        _0: "lagda-typ",
+        _0: "lagda-typst",
         [Symbol.for("name")]: "String"
       }),
   VSCode.StringOr.make({

--- a/lib/js/src/Editor.bs.js
+++ b/lib/js/src/Editor.bs.js
@@ -44,18 +44,18 @@ function highlightBackgroundPrim(editor, backgroundColor, ranges) {
 
 function highlightBackground(editor, style, ranges) {
   return highlightBackgroundPrim(editor, VSCode.StringOr.make({
-    TAG: "Others",
-    _0: new Vscode.ThemeColor(style),
-    [Symbol.for("name")]: "Others"
-  }), ranges);
+                  TAG: "Others",
+                  _0: new Vscode.ThemeColor(style),
+                  [Symbol.for("name")]: "Others"
+                }), ranges);
 }
 
 function highlightBackgroundWithColor(editor, color, ranges) {
   return highlightBackgroundPrim(editor, VSCode.StringOr.make({
-    TAG: "String",
-    _0: color,
-    [Symbol.for("name")]: "String"
-  }), ranges);
+                  TAG: "String",
+                  _0: color,
+                  [Symbol.for("name")]: "String"
+                }), ranges);
 }
 
 function decorateTextPrim(editor, color, ranges) {
@@ -70,18 +70,18 @@ function decorateTextPrim(editor, color, ranges) {
 
 function decorateText(editor, style, ranges) {
   return decorateTextPrim(editor, VSCode.StringOr.make({
-    TAG: "Others",
-    _0: new Vscode.ThemeColor(style),
-    [Symbol.for("name")]: "Others"
-  }), ranges);
+                  TAG: "Others",
+                  _0: new Vscode.ThemeColor(style),
+                  [Symbol.for("name")]: "Others"
+                }), ranges);
 }
 
 function decorateTextWithColor(editor, color, ranges) {
   return decorateTextPrim(editor, VSCode.StringOr.make({
-    TAG: "String",
-    _0: color,
-    [Symbol.for("name")]: "String"
-  }), ranges);
+                  TAG: "String",
+                  _0: color,
+                  [Symbol.for("name")]: "String"
+                }), ranges);
 }
 
 function overlayTextPrim(editor, color, text, range) {
@@ -99,18 +99,18 @@ function overlayTextPrim(editor, color, text, range) {
 
 function overlayText(editor, style, text, range) {
   return overlayTextPrim(editor, VSCode.StringOr.make({
-    TAG: "Others",
-    _0: new Vscode.ThemeColor(style),
-    [Symbol.for("name")]: "Others"
-  }), text, range);
+                  TAG: "Others",
+                  _0: new Vscode.ThemeColor(style),
+                  [Symbol.for("name")]: "Others"
+                }), text, range);
 }
 
 function overlayTextWithColor(editor, color, text, range) {
   return overlayTextPrim(editor, VSCode.StringOr.make({
-    TAG: "String",
-    _0: color,
-    [Symbol.for("name")]: "String"
-  }), text, range);
+                  TAG: "String",
+                  _0: color,
+                  [Symbol.for("name")]: "String"
+                }), text, range);
 }
 
 function underlineText(editor, range) {
@@ -149,8 +149,8 @@ function set(editor, point) {
 
 function setMany(editor, points) {
   var selections = points.map(function (point) {
-    return new Vscode.Selection(point, point);
-  });
+        return new Vscode.Selection(point, point);
+      });
   editor.selections = selections;
 }
 
@@ -160,8 +160,8 @@ function get(editor) {
 
 function getMany(editor) {
   return editor.selections.map(function (prim) {
-    return prim.active;
-  });
+              return prim.active;
+            });
 }
 
 var Cursor = {
@@ -178,8 +178,8 @@ function set$1(editor, range) {
 
 function setMany$1(editor, ranges) {
   var selections = ranges.map(function (range) {
-    return new Vscode.Selection(range.start, range.end);
-  });
+        return new Vscode.Selection(range.start, range.end);
+      });
   editor.selections = selections;
 }
 
@@ -190,8 +190,8 @@ function get$1(editor) {
 
 function getMany$1(editor) {
   return editor.selections.map(function (selection) {
-    return new Vscode.Range(selection.start, selection.end);
-  });
+              return new Vscode.Range(selection.start, selection.end);
+            });
 }
 
 var $$Selection = {
@@ -218,8 +218,8 @@ function replace($$document, range, text) {
 function batchReplace($$document, replacements) {
   var workspaceEdit = new Vscode.WorkspaceEdit();
   replacements.forEach(function (param) {
-    workspaceEdit.replace($$document.uri, param[0], param[1], undefined);
-  });
+        workspaceEdit.replace($$document.uri, param[0], param[1], undefined);
+      });
   return Vscode.workspace.applyEdit(workspaceEdit);
 }
 
@@ -232,8 +232,8 @@ function insert($$document, point, text) {
 function batchInsert($$document, points, text) {
   var workspaceEdit = new Vscode.WorkspaceEdit();
   var textEdits = points.map(function (point) {
-    return Vscode.TextEdit.insert(point, text);
-  });
+        return Vscode.TextEdit.insert(point, text);
+      });
   workspaceEdit.set($$document.uri, textEdits);
   return Vscode.workspace.applyEdit(workspaceEdit);
 }
@@ -264,61 +264,61 @@ function reveal(editor, range) {
 
 var documentSelector = [
   VSCode.StringOr.make({
-    TAG: "String",
-    _0: "agda",
-    [Symbol.for("name")]: "String"
-  }),
+        TAG: "String",
+        _0: "agda",
+        [Symbol.for("name")]: "String"
+      }),
   VSCode.StringOr.make({
-    TAG: "String",
-    _0: "lagda-markdown",
-    [Symbol.for("name")]: "String"
-  }),
+        TAG: "String",
+        _0: "lagda-markdown",
+        [Symbol.for("name")]: "String"
+      }),
   VSCode.StringOr.make({
-    TAG: "String",
-    _0: "lagda-rst",
-    [Symbol.for("name")]: "String"
-  }),
+        TAG: "String",
+        _0: "lagda-rst",
+        [Symbol.for("name")]: "String"
+      }),
   VSCode.StringOr.make({
-    TAG: "String",
-    _0: "lagda-typst",
-    [Symbol.for("name")]: "String"
-  }),
+        TAG: "String",
+        _0: "lagda-typst",
+        [Symbol.for("name")]: "String"
+      }),
   VSCode.StringOr.make({
-    TAG: "String",
-    _0: "lagda-tex",
-    [Symbol.for("name")]: "String"
-  })
+        TAG: "String",
+        _0: "lagda-tex",
+        [Symbol.for("name")]: "String"
+      })
 ];
 
 function registerDefinitionProvider(definitionProvider) {
   return Vscode.languages.registerDefinitionProvider(documentSelector, {
-    provideDefinition: (function (textDocument, point, param) {
-      return VSCode.ProviderResult.map(definitionProvider(textDocument.fileName, point), (function (pairs) {
-        return VSCode.LocationLinkOrLocation.locationLinks(pairs.map(function (param) {
-          var targetPos = param[2];
-          return {
-            originSelectionRange: Caml_option.some(param[0]),
-            targetRange: new Vscode.Range(targetPos, targetPos),
-            targetSelectionRange: undefined,
-            targetUri: Vscode.Uri.file(param[1])
-          };
-        }));
-      }));
-    })
-  });
+              provideDefinition: (function (textDocument, point, param) {
+                  return VSCode.ProviderResult.map(definitionProvider(textDocument.fileName, point), (function (pairs) {
+                                return VSCode.LocationLinkOrLocation.locationLinks(pairs.map(function (param) {
+                                                var targetPos = param[2];
+                                                return {
+                                                        originSelectionRange: Caml_option.some(param[0]),
+                                                        targetRange: new Vscode.Range(targetPos, targetPos),
+                                                        targetSelectionRange: undefined,
+                                                        targetUri: Vscode.Uri.file(param[1])
+                                                      };
+                                              }));
+                              }));
+                })
+            });
 }
 
 function registerHoverProvider(hoverProvider) {
   return Vscode.languages.registerHoverProvider(documentSelector, {
-    provideHover: (function (textDocument, point, param) {
-      return VSCode.ProviderResult.map(hoverProvider(textDocument.fileName, point), (function (param) {
-        var markdownStrings = param[0].map(function (string) {
-          return new Vscode.MarkdownString(string, true);
-        });
-        return new Vscode.Hover(markdownStrings, param[1]);
-      }));
-    })
-  });
+              provideHover: (function (textDocument, point, param) {
+                  return VSCode.ProviderResult.map(hoverProvider(textDocument.fileName, point), (function (param) {
+                                var markdownStrings = param[0].map(function (string) {
+                                      return new Vscode.MarkdownString(string, true);
+                                    });
+                                return new Vscode.Hover(markdownStrings, param[1]);
+                              }));
+                })
+            });
 }
 
 var SemanticsTokens = {};
@@ -333,9 +333,9 @@ var SemanticTokensBuilder = {};
 
 function make(provideDocumentSemanticTokens, provideDocumentSemanticTokensEdits, param) {
   return {
-    provideDocumentSemanticTokens: provideDocumentSemanticTokens,
-    provideDocumentSemanticTokensEdits: provideDocumentSemanticTokensEdits
-  };
+          provideDocumentSemanticTokens: provideDocumentSemanticTokens,
+          provideDocumentSemanticTokensEdits: provideDocumentSemanticTokensEdits
+        };
 }
 
 var DocumentSemanticTokensProvider = {

--- a/lib/js/src/Editor.bs.js
+++ b/lib/js/src/Editor.bs.js
@@ -44,18 +44,18 @@ function highlightBackgroundPrim(editor, backgroundColor, ranges) {
 
 function highlightBackground(editor, style, ranges) {
   return highlightBackgroundPrim(editor, VSCode.StringOr.make({
-                  TAG: "Others",
-                  _0: new Vscode.ThemeColor(style),
-                  [Symbol.for("name")]: "Others"
-                }), ranges);
+    TAG: "Others",
+    _0: new Vscode.ThemeColor(style),
+    [Symbol.for("name")]: "Others"
+  }), ranges);
 }
 
 function highlightBackgroundWithColor(editor, color, ranges) {
   return highlightBackgroundPrim(editor, VSCode.StringOr.make({
-                  TAG: "String",
-                  _0: color,
-                  [Symbol.for("name")]: "String"
-                }), ranges);
+    TAG: "String",
+    _0: color,
+    [Symbol.for("name")]: "String"
+  }), ranges);
 }
 
 function decorateTextPrim(editor, color, ranges) {
@@ -70,18 +70,18 @@ function decorateTextPrim(editor, color, ranges) {
 
 function decorateText(editor, style, ranges) {
   return decorateTextPrim(editor, VSCode.StringOr.make({
-                  TAG: "Others",
-                  _0: new Vscode.ThemeColor(style),
-                  [Symbol.for("name")]: "Others"
-                }), ranges);
+    TAG: "Others",
+    _0: new Vscode.ThemeColor(style),
+    [Symbol.for("name")]: "Others"
+  }), ranges);
 }
 
 function decorateTextWithColor(editor, color, ranges) {
   return decorateTextPrim(editor, VSCode.StringOr.make({
-                  TAG: "String",
-                  _0: color,
-                  [Symbol.for("name")]: "String"
-                }), ranges);
+    TAG: "String",
+    _0: color,
+    [Symbol.for("name")]: "String"
+  }), ranges);
 }
 
 function overlayTextPrim(editor, color, text, range) {
@@ -99,18 +99,18 @@ function overlayTextPrim(editor, color, text, range) {
 
 function overlayText(editor, style, text, range) {
   return overlayTextPrim(editor, VSCode.StringOr.make({
-                  TAG: "Others",
-                  _0: new Vscode.ThemeColor(style),
-                  [Symbol.for("name")]: "Others"
-                }), text, range);
+    TAG: "Others",
+    _0: new Vscode.ThemeColor(style),
+    [Symbol.for("name")]: "Others"
+  }), text, range);
 }
 
 function overlayTextWithColor(editor, color, text, range) {
   return overlayTextPrim(editor, VSCode.StringOr.make({
-                  TAG: "String",
-                  _0: color,
-                  [Symbol.for("name")]: "String"
-                }), text, range);
+    TAG: "String",
+    _0: color,
+    [Symbol.for("name")]: "String"
+  }), text, range);
 }
 
 function underlineText(editor, range) {
@@ -149,8 +149,8 @@ function set(editor, point) {
 
 function setMany(editor, points) {
   var selections = points.map(function (point) {
-        return new Vscode.Selection(point, point);
-      });
+    return new Vscode.Selection(point, point);
+  });
   editor.selections = selections;
 }
 
@@ -160,8 +160,8 @@ function get(editor) {
 
 function getMany(editor) {
   return editor.selections.map(function (prim) {
-              return prim.active;
-            });
+    return prim.active;
+  });
 }
 
 var Cursor = {
@@ -178,8 +178,8 @@ function set$1(editor, range) {
 
 function setMany$1(editor, ranges) {
   var selections = ranges.map(function (range) {
-        return new Vscode.Selection(range.start, range.end);
-      });
+    return new Vscode.Selection(range.start, range.end);
+  });
   editor.selections = selections;
 }
 
@@ -190,8 +190,8 @@ function get$1(editor) {
 
 function getMany$1(editor) {
   return editor.selections.map(function (selection) {
-              return new Vscode.Range(selection.start, selection.end);
-            });
+    return new Vscode.Range(selection.start, selection.end);
+  });
 }
 
 var $$Selection = {
@@ -218,8 +218,8 @@ function replace($$document, range, text) {
 function batchReplace($$document, replacements) {
   var workspaceEdit = new Vscode.WorkspaceEdit();
   replacements.forEach(function (param) {
-        workspaceEdit.replace($$document.uri, param[0], param[1], undefined);
-      });
+    workspaceEdit.replace($$document.uri, param[0], param[1], undefined);
+  });
   return Vscode.workspace.applyEdit(workspaceEdit);
 }
 
@@ -232,8 +232,8 @@ function insert($$document, point, text) {
 function batchInsert($$document, points, text) {
   var workspaceEdit = new Vscode.WorkspaceEdit();
   var textEdits = points.map(function (point) {
-        return Vscode.TextEdit.insert(point, text);
-      });
+    return Vscode.TextEdit.insert(point, text);
+  });
   workspaceEdit.set($$document.uri, textEdits);
   return Vscode.workspace.applyEdit(workspaceEdit);
 }
@@ -264,61 +264,61 @@ function reveal(editor, range) {
 
 var documentSelector = [
   VSCode.StringOr.make({
-        TAG: "String",
-        _0: "agda",
-        [Symbol.for("name")]: "String"
-      }),
+    TAG: "String",
+    _0: "agda",
+    [Symbol.for("name")]: "String"
+  }),
   VSCode.StringOr.make({
-        TAG: "String",
-        _0: "lagda-md",
-        [Symbol.for("name")]: "String"
-      }),
+    TAG: "String",
+    _0: "lagda-markdown",
+    [Symbol.for("name")]: "String"
+  }),
   VSCode.StringOr.make({
-        TAG: "String",
-        _0: "lagda-rst",
-        [Symbol.for("name")]: "String"
-      }),
+    TAG: "String",
+    _0: "lagda-rst",
+    [Symbol.for("name")]: "String"
+  }),
   VSCode.StringOr.make({
-        TAG: "String",
-        _0: "lagda-typst",
-        [Symbol.for("name")]: "String"
-      }),
+    TAG: "String",
+    _0: "lagda-typst",
+    [Symbol.for("name")]: "String"
+  }),
   VSCode.StringOr.make({
-        TAG: "String",
-        _0: "lagda-tex",
-        [Symbol.for("name")]: "String"
-      })
+    TAG: "String",
+    _0: "lagda-tex",
+    [Symbol.for("name")]: "String"
+  })
 ];
 
 function registerDefinitionProvider(definitionProvider) {
   return Vscode.languages.registerDefinitionProvider(documentSelector, {
-              provideDefinition: (function (textDocument, point, param) {
-                  return VSCode.ProviderResult.map(definitionProvider(textDocument.fileName, point), (function (pairs) {
-                                return VSCode.LocationLinkOrLocation.locationLinks(pairs.map(function (param) {
-                                                var targetPos = param[2];
-                                                return {
-                                                        originSelectionRange: Caml_option.some(param[0]),
-                                                        targetRange: new Vscode.Range(targetPos, targetPos),
-                                                        targetSelectionRange: undefined,
-                                                        targetUri: Vscode.Uri.file(param[1])
-                                                      };
-                                              }));
-                              }));
-                })
-            });
+    provideDefinition: (function (textDocument, point, param) {
+      return VSCode.ProviderResult.map(definitionProvider(textDocument.fileName, point), (function (pairs) {
+        return VSCode.LocationLinkOrLocation.locationLinks(pairs.map(function (param) {
+          var targetPos = param[2];
+          return {
+            originSelectionRange: Caml_option.some(param[0]),
+            targetRange: new Vscode.Range(targetPos, targetPos),
+            targetSelectionRange: undefined,
+            targetUri: Vscode.Uri.file(param[1])
+          };
+        }));
+      }));
+    })
+  });
 }
 
 function registerHoverProvider(hoverProvider) {
   return Vscode.languages.registerHoverProvider(documentSelector, {
-              provideHover: (function (textDocument, point, param) {
-                  return VSCode.ProviderResult.map(hoverProvider(textDocument.fileName, point), (function (param) {
-                                var markdownStrings = param[0].map(function (string) {
-                                      return new Vscode.MarkdownString(string, true);
-                                    });
-                                return new Vscode.Hover(markdownStrings, param[1]);
-                              }));
-                })
-            });
+    provideHover: (function (textDocument, point, param) {
+      return VSCode.ProviderResult.map(hoverProvider(textDocument.fileName, point), (function (param) {
+        var markdownStrings = param[0].map(function (string) {
+          return new Vscode.MarkdownString(string, true);
+        });
+        return new Vscode.Hover(markdownStrings, param[1]);
+      }));
+    })
+  });
 }
 
 var SemanticsTokens = {};
@@ -333,9 +333,9 @@ var SemanticTokensBuilder = {};
 
 function make(provideDocumentSemanticTokens, provideDocumentSemanticTokensEdits, param) {
   return {
-          provideDocumentSemanticTokens: provideDocumentSemanticTokens,
-          provideDocumentSemanticTokensEdits: provideDocumentSemanticTokensEdits
-        };
+    provideDocumentSemanticTokens: provideDocumentSemanticTokens,
+    provideDocumentSemanticTokensEdits: provideDocumentSemanticTokensEdits
+  };
 }
 
 var DocumentSemanticTokensProvider = {

--- a/package.json
+++ b/package.json
@@ -587,412 +587,412 @@
 				"command": "agda-mode.load",
 				"key": "ctrl+c ctrl+l",
 				"mac": "ctrl+c ctrl+l",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "\\",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && (editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
+				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && editorTextFocus && variableLanguage"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && (editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
+				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.quit",
 				"key": "ctrl+c ctrl+x ctrl+q",
 				"mac": "ctrl+c ctrl+x ctrl+q",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.restart",
 				"key": "ctrl+c ctrl+x ctrl+r",
 				"mac": "ctrl+c ctrl+x ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compile",
 				"key": "ctrl+c ctrl+x ctrl+c",
 				"mac": "ctrl+c ctrl+x ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-implicit-arguments",
 				"key": "ctrl+c ctrl+x ctrl+h",
 				"mac": "ctrl+c ctrl+x ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-irrelevant-arguments",
 				"key": "ctrl+c ctrl+x ctrl+i",
 				"mac": "ctrl+c ctrl+x ctrl+i",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-constraints",
 				"key": "ctrl+c ctrl+=",
 				"mac": "ctrl+c ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Simplified]",
 				"key": "ctrl+c ctrl+s",
 				"mac": "ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+?",
 				"mac": "ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+shift+/",
 				"mac": "ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.next-goal",
 				"key": "ctrl+c ctrl+f",
 				"mac": "ctrl+c ctrl+f",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.previous-goal",
 				"key": "ctrl+c ctrl+b",
 				"mac": "ctrl+c ctrl+b",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Simplified]",
 				"key": "ctrl+c ctrl+z",
 				"mac": "ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.give",
 				"key": "ctrl+c ctrl+space",
 				"mac": "ctrl+c ctrl+space",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.refine",
 				"key": "ctrl+c ctrl+r",
 				"mac": "ctrl+c ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Simplified]",
 				"key": "ctrl+c ctrl+m",
 				"mac": "ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.auto[AsIs]",
 				"key": "ctrl+c ctrl+a",
 				"mac": "ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Simplified]",
 				"key": "ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[HeadNormal]",
 				"key": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.case",
 				"key": "ctrl+c ctrl+c",
 				"mac": "ctrl+c ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Simplified]",
 				"key": "ctrl+c ctrl+h",
 				"mac": "ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.goal-type[Simplified]",
 				"key": "ctrl+c ctrl+t",
 				"mac": "ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.context[Simplified]",
 				"key": "ctrl+c ctrl+e",
 				"mac": "ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.infer-type[Simplified]",
 				"key": "ctrl+c ctrl+d",
 				"mac": "ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Simplified]",
 				"key": "ctrl+c ctrl+,",
 				"mac": "ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Simplified]",
 				"key": "ctrl+c ctrl+.",
 				"mac": "ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Simplified]",
 				"key": "ctrl+c ctrl+;",
 				"mac": "ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.module-contents[Simplified]",
 				"key": "ctrl+c ctrl+o",
 				"mac": "ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[DefaultCompute]",
 				"key": "ctrl+c ctrl+n",
 				"mac": "ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[IgnoreAbstract]",
 				"key": "ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[UseShowInstance]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
 			},
 			{
 				"command": "agda-mode.why-in-scope",
 				"key": "ctrl+c ctrl+w",
 				"mac": "ctrl+c ctrl+w",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.switch-agda-version",
 				"key": "ctrl+x ctrl+s",
 				"mac": "ctrl+x ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.escape",
 				"key": "escape",
 				"mac": "escape",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModePrompting || agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModePrompting || agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseUp]",
 				"key": "up",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseRight]",
 				"key": "right",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseDown]",
 				"key": "down",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseLeft]",
 				"key": "left",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenCurlyBraces]",
 				"key": "shift+[",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenParenthesis]",
 				"key": "shift+9",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.lookup-symbol",
 				"key": "ctrl+x ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,15 @@
 				}
 			},
 			{
+				"id": "markdown",
+				"extensions": [
+					".md"
+				],
+				"aliases": [
+					"Markdown"
+				]
+			},
+			{
 				"id": "lagda-typ",
 				"extensions": [
 					".lagda.typ"
@@ -93,6 +102,15 @@
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
 				}
+			},
+			{
+				"id": "typst",
+				"extensions": [
+					".typ"
+				],
+				"aliases": [
+					"Typst"
+				]
 			},
 			{
 				"id": "lagda-tex",
@@ -135,6 +153,15 @@
 				}
 			},
 			{
+				"id": "org",
+				"extensions": [
+					".org"
+				],
+				"aliases": [
+					"Org"
+				]
+			},
+			{
 				"id": "lagda-forester",
 				"extensions": [
 					".lagda.tree"
@@ -146,6 +173,15 @@
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
 				}
+			},
+			{
+				"id": "forester",
+				"extensions": [
+					".tree"
+				],
+				"aliases": [
+					"forester"
+				]
 			}
 		],
 		"grammars": [
@@ -167,7 +203,23 @@
 				}
 			},
 			{
+				"language": "markdown",
+				"scopeName": "source.markdown",
+				"path": "./syntaxes/markdown.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
+			},
+			{
 				"language": "lagda-typ",
+				"scopeName": "source.typst",
+				"path": "./syntaxes/typst.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
+			},
+			{
+				"language": "typst",
 				"scopeName": "source.typst",
 				"path": "./syntaxes/typst.tmLanguage.json",
 				"embeddedLanguages": {
@@ -199,7 +251,23 @@
 				}
 			},
 			{
+				"language": "org",
+				"scopeName": "source.org",
+				"path": "./syntaxes/org.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
+			},
+			{
 				"language": "lagda-forester",
+				"scopeName": "source.forester",
+				"path": "./syntaxes/forester.tmLanguage.json",
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
+			},
+			{
+				"language": "forester",
 				"scopeName": "source.forester",
 				"path": "./syntaxes/forester.tmLanguage.json",
 				"embeddedLanguages": {

--- a/package.json
+++ b/package.json
@@ -609,7 +609,7 @@
 				"command": "agda-mode.restart",
 				"key": "ctrl+c ctrl+x ctrl+r",
 				"mac": "ctrl+c ctrl+x ctrl+r",
-				"when": "editorLangId =~ /.*\bl?agda\b.*/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compile",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
 				]
 			},
 			{
-				"id": "lagda-typ",
+				"id": "lagda-typst",
 				"extensions": [
 					".lagda.typ"
 				],
@@ -211,7 +211,7 @@
 				}
 			},
 			{
-				"language": "lagda-typ",
+				"language": "lagda-typst",
 				"scopeName": "source.typst",
 				"path": "./syntaxes/typst.tmLanguage.json",
 				"embeddedLanguages": {
@@ -587,412 +587,412 @@
 				"command": "agda-mode.load",
 				"key": "ctrl+c ctrl+l",
 				"mac": "ctrl+c ctrl+l",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "\\",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && (editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
+				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && (editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && (editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
+				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && (editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.quit",
 				"key": "ctrl+c ctrl+x ctrl+q",
 				"mac": "ctrl+c ctrl+x ctrl+q",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.restart",
 				"key": "ctrl+c ctrl+x ctrl+r",
 				"mac": "ctrl+c ctrl+x ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compile",
 				"key": "ctrl+c ctrl+x ctrl+c",
 				"mac": "ctrl+c ctrl+x ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-implicit-arguments",
 				"key": "ctrl+c ctrl+x ctrl+h",
 				"mac": "ctrl+c ctrl+x ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-irrelevant-arguments",
 				"key": "ctrl+c ctrl+x ctrl+i",
 				"mac": "ctrl+c ctrl+x ctrl+i",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-constraints",
 				"key": "ctrl+c ctrl+=",
 				"mac": "ctrl+c ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Simplified]",
 				"key": "ctrl+c ctrl+s",
 				"mac": "ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+?",
 				"mac": "ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+shift+/",
 				"mac": "ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+?",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.next-goal",
 				"key": "ctrl+c ctrl+f",
 				"mac": "ctrl+c ctrl+f",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.previous-goal",
 				"key": "ctrl+c ctrl+b",
 				"mac": "ctrl+c ctrl+b",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Simplified]",
 				"key": "ctrl+c ctrl+z",
 				"mac": "ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+z",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.give",
 				"key": "ctrl+c ctrl+space",
 				"mac": "ctrl+c ctrl+space",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.refine",
 				"key": "ctrl+c ctrl+r",
 				"mac": "ctrl+c ctrl+r",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Simplified]",
 				"key": "ctrl+c ctrl+m",
 				"mac": "ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+m",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.auto[AsIs]",
 				"key": "ctrl+c ctrl+a",
 				"mac": "ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Simplified]",
 				"key": "ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[HeadNormal]",
 				"key": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.case",
 				"key": "ctrl+c ctrl+c",
 				"mac": "ctrl+c ctrl+c",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Simplified]",
 				"key": "ctrl+c ctrl+h",
 				"mac": "ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+h",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type[Simplified]",
 				"key": "ctrl+c ctrl+t",
 				"mac": "ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+t",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.context[Simplified]",
 				"key": "ctrl+c ctrl+e",
 				"mac": "ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+e",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.infer-type[Simplified]",
 				"key": "ctrl+c ctrl+d",
 				"mac": "ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Simplified]",
 				"key": "ctrl+c ctrl+,",
 				"mac": "ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+,",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Simplified]",
 				"key": "ctrl+c ctrl+.",
 				"mac": "ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+.",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Simplified]",
 				"key": "ctrl+c ctrl+;",
 				"mac": "ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+;",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.module-contents[Simplified]",
 				"key": "ctrl+c ctrl+o",
 				"mac": "ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+o",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[DefaultCompute]",
 				"key": "ctrl+c ctrl+n",
 				"mac": "ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[IgnoreAbstract]",
 				"key": "ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[UseShowInstance]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+n",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester)"
 			},
 			{
 				"command": "agda-mode.why-in-scope",
 				"key": "ctrl+c ctrl+w",
 				"mac": "ctrl+c ctrl+w",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.switch-agda-version",
 				"key": "ctrl+x ctrl+s",
 				"mac": "ctrl+x ctrl+s",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.escape",
 				"key": "escape",
 				"mac": "escape",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModePrompting || agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModePrompting || agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseUp]",
 				"key": "up",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseRight]",
 				"key": "right",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseDown]",
 				"key": "down",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseLeft]",
 				"key": "left",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenCurlyBraces]",
 				"key": "shift+[",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenParenthesis]",
 				"key": "shift+9",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.lookup-symbol",
 				"key": "ctrl+x ctrl+=",
-				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typ || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
+				"when": "(editorLangId == agda || editorLangId == lagda-md || editorLangId == lagda-typst || editorLangId == lagda-rst || editorLangId == lagda-tex || editorLangId == lagda-org || editorLangId == lagda-forester) && !terminalFocus"
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
 				"aliases": [
 					"Literate Agda (markdown)"
 				],
-				"configuration": "./language-configuration.json",
 				"icon": {
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
@@ -90,7 +89,6 @@
 				"aliases": [
 					"Literate Agda (Typst)"
 				],
-				"configuration": "./language-configuration.json",
 				"icon": {
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
@@ -105,7 +103,6 @@
 				"aliases": [
 					"Literate Agda (TeX)"
 				],
-				"configuration": "./language-configuration.json",
 				"icon": {
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
@@ -119,7 +116,6 @@
 				"aliases": [
 					"Literate Agda (reStructuredText)"
 				],
-				"configuration": "./language-configuration.json",
 				"icon": {
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
@@ -133,7 +129,6 @@
 				"aliases": [
 					"Literate Agda (Org)"
 				],
-				"configuration": "./language-configuration.json",
 				"icon": {
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
@@ -147,7 +142,6 @@
 				"aliases": [
 					"Literate Agda (forester)"
 				],
-				"configuration": "./language-configuration.json",
 				"icon": {
 					"dark": "./asset/dark.png",
 					"light": "./asset/light.png"
@@ -168,49 +162,49 @@
 				"language": "lagda-md",
 				"scopeName": "source.markdown",
 				"path": "./syntaxes/markdown.tmLanguage.json",
-				"injectTo": [
-					"source.agda"
-				]
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
 			},
 			{
 				"language": "lagda-typ",
 				"scopeName": "source.typst",
 				"path": "./syntaxes/typst.tmLanguage.json",
-				"injectTo": [
-					"source.agda"
-				]
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
 			},
 			{
 				"language": "lagda-rst",
 				"scopeName": "source.rst",
 				"path": "./syntaxes/restructuredtext.tmLanguage.json",
-				"injectTo": [
-					"source.agda"
-				]
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
 			},
 			{
 				"language": "lagda-tex",
 				"scopeName": "source.tex",
 				"path": "./syntaxes/tex.tmLanguage.json",
-				"injectTo": [
-					"source.agda"
-				]
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
 			},
 			{
 				"language": "lagda-org",
 				"scopeName": "source.org",
 				"path": "./syntaxes/org.tmLanguage.json",
-				"injectTo": [
-					"source.agda"
-				]
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
 			},
 			{
 				"language": "lagda-forester",
 				"scopeName": "source.forester",
 				"path": "./syntaxes/forester.tmLanguage.json",
-				"injectTo": [
-					"source.agda"
-				]
+				"embeddedLanguages": {
+					"meta.embedded.block.agda": "agda"
+				}
 			}
 		],
 		"commands": [

--- a/package.json
+++ b/package.json
@@ -587,412 +587,412 @@
 				"command": "agda-mode.load",
 				"key": "ctrl+c ctrl+l",
 				"mac": "ctrl+c ctrl+l",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "\\",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && editorTextFocus && variableLanguage"
+				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && editorTextFocus && variableLanguage"
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && editorTextFocus"
+				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.quit",
 				"key": "ctrl+c ctrl+x ctrl+q",
 				"mac": "ctrl+c ctrl+x ctrl+q",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.restart",
 				"key": "ctrl+c ctrl+x ctrl+r",
 				"mac": "ctrl+c ctrl+x ctrl+r",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*\bl?agda\b.*/i && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compile",
 				"key": "ctrl+c ctrl+x ctrl+c",
 				"mac": "ctrl+c ctrl+x ctrl+c",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-implicit-arguments",
 				"key": "ctrl+c ctrl+x ctrl+h",
 				"mac": "ctrl+c ctrl+x ctrl+h",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.toggle-display-of-irrelevant-arguments",
 				"key": "ctrl+c ctrl+x ctrl+i",
 				"mac": "ctrl+c ctrl+x ctrl+i",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-constraints",
 				"key": "ctrl+c ctrl+=",
 				"mac": "ctrl+c ctrl+=",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Simplified]",
 				"key": "ctrl+c ctrl+s",
 				"mac": "ctrl+c ctrl+s",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+c ctrl+s",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.solve-constraints[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+s",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+s",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+?",
 				"mac": "ctrl+c ctrl+?",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Simplified]",
 				"key": "ctrl+c ctrl+shift+/",
 				"mac": "ctrl+c ctrl+shift+/",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+c ctrl+?",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+c ctrl+shift+/",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+?",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+?",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.show-goals[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+shift+/",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.next-goal",
 				"key": "ctrl+c ctrl+f",
 				"mac": "ctrl+c ctrl+f",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.previous-goal",
 				"key": "ctrl+c ctrl+b",
 				"mac": "ctrl+c ctrl+b",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Simplified]",
 				"key": "ctrl+c ctrl+z",
 				"mac": "ctrl+c ctrl+z",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+c ctrl+z",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.search-about[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+z",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+z",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.give",
 				"key": "ctrl+c ctrl+space",
 				"mac": "ctrl+c ctrl+space",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.refine",
 				"key": "ctrl+c ctrl+r",
 				"mac": "ctrl+c ctrl+r",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Simplified]",
 				"key": "ctrl+c ctrl+m",
 				"mac": "ctrl+c ctrl+m",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+c ctrl+m",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.elaborate-and-give[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+m",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+m",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.auto[AsIs]",
 				"key": "ctrl+c ctrl+a",
 				"mac": "ctrl+c ctrl+a",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Simplified]",
 				"key": "ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+c ctrl+a",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.auto[HeadNormal]",
 				"key": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
 				"mac": "ctrl+u ctrl+u ctrl+u ctrl+c ctrl+a",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.case",
 				"key": "ctrl+c ctrl+c",
 				"mac": "ctrl+c ctrl+c",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Simplified]",
 				"key": "ctrl+c ctrl+h",
 				"mac": "ctrl+c ctrl+h",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+c ctrl+h",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.helper-function-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+h",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+h",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.goal-type[Simplified]",
 				"key": "ctrl+c ctrl+t",
 				"mac": "ctrl+c ctrl+t",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+c ctrl+t",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+t",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+t",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.context[Simplified]",
 				"key": "ctrl+c ctrl+e",
 				"mac": "ctrl+c ctrl+e",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+c ctrl+e",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+e",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+e",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.infer-type[Simplified]",
 				"key": "ctrl+c ctrl+d",
 				"mac": "ctrl+c ctrl+d",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.infer-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+d",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+d",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Simplified]",
 				"key": "ctrl+c ctrl+,",
 				"mac": "ctrl+c ctrl+,",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+c ctrl+,",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-and-context[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+,",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+,",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Simplified]",
 				"key": "ctrl+c ctrl+.",
 				"mac": "ctrl+c ctrl+.",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+c ctrl+.",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-inferred-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+.",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+.",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Simplified]",
 				"key": "ctrl+c ctrl+;",
 				"mac": "ctrl+c ctrl+;",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+c ctrl+;",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.goal-type-context-and-checked-type[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+;",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+;",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.module-contents[Simplified]",
 				"key": "ctrl+c ctrl+o",
 				"mac": "ctrl+c ctrl+o",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Instantiated]",
 				"key": "ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+c ctrl+o",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.module-contents[Normalised]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+o",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+o",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[DefaultCompute]",
 				"key": "ctrl+c ctrl+n",
 				"mac": "ctrl+c ctrl+n",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[IgnoreAbstract]",
 				"key": "ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+c ctrl+n",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			},
 			{
 				"command": "agda-mode.compute-normal-form[UseShowInstance]",
 				"key": "ctrl+u ctrl+u ctrl+c ctrl+n",
 				"mac": "ctrl+u ctrl+u ctrl+c ctrl+n",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/"
 			},
 			{
 				"command": "agda-mode.why-in-scope",
 				"key": "ctrl+c ctrl+w",
 				"mac": "ctrl+c ctrl+w",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.switch-agda-version",
 				"key": "ctrl+x ctrl+s",
 				"mac": "ctrl+x ctrl+s",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !editorHasSelection && editorTextFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !editorHasSelection && editorTextFocus"
 			},
 			{
 				"command": "agda-mode.escape",
 				"key": "escape",
 				"mac": "escape",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModePrompting || agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModePrompting || agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseUp]",
 				"key": "up",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseRight]",
 				"key": "right",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseDown]",
 				"key": "down",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[BrowseLeft]",
 				"key": "left",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenCurlyBraces]",
 				"key": "shift+[",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.input-symbol[InsertOpenParenthesis]",
 				"key": "shift+9",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && agdaModeTyping"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && agdaModeTyping"
 			},
 			{
 				"command": "agda-mode.lookup-symbol",
 				"key": "ctrl+x ctrl+=",
-				"when": "editorLangId =~ /^(l?agda(-(md|typst|tex|rst|org|forester))?)$/i && !terminalFocus"
+				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 				}
 			},
 			{
-				"id": "lagda-md",
+				"id": "lagda-markdown",
 				"extensions": [
 					".lagda.md"
 				],
@@ -195,7 +195,7 @@
 				}
 			},
 			{
-				"language": "lagda-md",
+				"language": "lagda-markdown",
 				"scopeName": "source.markdown",
 				"path": "./syntaxes/markdown.tmLanguage.json",
 				"embeddedLanguages": {

--- a/src/Editor.res
+++ b/src/Editor.res
@@ -197,7 +197,7 @@ let reveal = (editor, range) =>
 module Provider = {
   let documentSelector = [
     VSCode.StringOr.make(String("agda")),
-    VSCode.StringOr.make(String("lagda-md")),
+    VSCode.StringOr.make(String("lagda-markdown")),
     VSCode.StringOr.make(String("lagda-rst")),
     VSCode.StringOr.make(String("lagda-typst")),
     VSCode.StringOr.make(String("lagda-tex")),

--- a/src/Editor.res
+++ b/src/Editor.res
@@ -199,7 +199,7 @@ module Provider = {
     VSCode.StringOr.make(String("agda")),
     VSCode.StringOr.make(String("lagda-md")),
     VSCode.StringOr.make(String("lagda-rst")),
-    VSCode.StringOr.make(String("lagda-typ")),
+    VSCode.StringOr.make(String("lagda-typst")),
     VSCode.StringOr.make(String("lagda-tex")),
   ]
   let registerDefinitionProvider = definitionProvider => {

--- a/syntaxes/forester.tmLanguage.json
+++ b/syntaxes/forester.tmLanguage.json
@@ -1,6 +1,31 @@
 {
-    "scopeName": "source.forester",
-    "patterns": [
-        { "include": "source.forester" }
-    ]
+  "scopeName": "source.forester",
+  "patterns": [
+    {
+      "include": "#agda-block"
+    },
+    {
+      "include": "source.forester"
+    }
+  ],
+  "repository": {
+    "agda-block": {
+      "begin": "\\\\(agda)\\{",
+      "end": "^\\s*\\}",
+      "name": "markup.raw.block.forester",
+      "contentName": "meta.embedded.block.agda",
+      "beginCaptures": {
+        "0": { "name": "keyword.control.agda.begin.forester" }
+        "1": { "name": "fenced_code.block.language.forester" }
+      },
+      "endCaptures": {
+        "0": { "name": "keyword.control.agda.end.forester" }
+      },
+      "patterns": [
+        {
+          "include": "source.agda"
+        }
+      ]
+    }
+  }
 }

--- a/syntaxes/markdown.tmLanguage.json
+++ b/syntaxes/markdown.tmLanguage.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "agda-block": {
-      "begin": "(^|\\G)(\\s*)(```)(\\s*)(agda)?(\\s*$)",
+      "begin": "(^|\\G)(\\s*)(```)(\\s*)(agda)(\\s*$)",
       "end": "(^|\\G)(\\2)(```)(\\s*$)",
       "name": "markup.fenced_code.block.markdown",
       "contentName": "meta.embedded.block.agda",

--- a/syntaxes/markdown.tmLanguage.json
+++ b/syntaxes/markdown.tmLanguage.json
@@ -1,6 +1,32 @@
 {
-    "scopeName": "source.markdown",
-    "patterns": [
-        { "include": "text.html.markdown" }
-    ]
+  "scopeName": "source.markdown",
+  "patterns": [
+    {
+      "include": "#agda-block"
+    },
+    {
+      "include": "text.html.markdown"
+    }
+  ],
+  "repository": {
+    "agda-block": {
+      "begin": "(^|\\G)(\\s*)(```)(\\s*)(agda)?(\\s*$)",
+      "end": "(^|\\G)(\\2)(```)(\\s*$)",
+      "name": "markup.fenced_code.block.markdown",
+      "contentName": "meta.embedded.block.agda",
+      "beginCaptures": {
+        "3": { "name": "punctuation.definition.markdown" },
+        "5": { "name": "fenced_code.block.language.markdown" },
+        "6": { "name": "fenced_code.block.language.attributes.markdown" }
+      },
+      "endCaptures": {
+        "3": { "name": "punctuation.definition.markdown" }
+      },
+      "patterns": [
+        {
+          "include": "source.agda"
+        }
+      ]
+    }
+  }
 }

--- a/syntaxes/org.tmLanguage.json
+++ b/syntaxes/org.tmLanguage.json
@@ -1,6 +1,31 @@
 {
-    "scopeName": "source.org",
-    "patterns": [
-        { "include": "source.org" }
-    ]
+  "scopeName": "source.org",
+  "patterns": [
+    {
+      "include": "#agda-block"
+    },
+    {
+      "include": "source.org"
+    }
+  ],
+  "repository": {
+    "agda-block": {
+      "begin": "(?i)\\#\\+begin\\_src\\s+(agda2)",
+      "end": "(?i)\\#\\+end\\_src",
+      "name": "markup.raw.block.org",
+      "contentName": "meta.embedded.block.agda",
+      "beginCaptures": {
+        "0": { "name": "keyword.control.agda.begin.org" }
+        "1": { "name": "fenced_code.block.language.org" }
+      },
+      "endCaptures": {
+        "0": { "name": "keyword.control.agda.end.org" }
+      },
+      "patterns": [
+        {
+          "include": "source.agda"
+        }
+      ]
+    }
+  }
 }

--- a/syntaxes/restructuredtext.tmLanguage.json
+++ b/syntaxes/restructuredtext.tmLanguage.json
@@ -1,6 +1,30 @@
 {
-    "scopeName": "source.rst",
-    "patterns": [
-        { "include": "source.rst" }
-    ]
+  "scopeName": "source.rst",
+  "patterns": [
+    {
+      "include": "#agda-block"
+    },
+    {
+      "include": "source.rst"
+    }
+  ],
+  "repository": {
+    "agda-block": {
+      "begin": "\\:\\:",
+      "end": "^(?=\\S)",
+      "name": "markup.raw.block.restructuredtext",
+      "contentName": "meta.embedded.block.agda",
+      "beginCaptures": {
+        "0": { "name": "keyword.control.agda.begin.restructuredtext" }
+      },
+      "endCaptures": {
+        "0": { "name": "keyword.control.agda.end.restructuredtext" }
+      },
+      "patterns": [
+        {
+          "include": "source.agda"
+        }
+      ]
+    }
+  }
 }

--- a/syntaxes/tex.tmLanguage.json
+++ b/syntaxes/tex.tmLanguage.json
@@ -1,6 +1,30 @@
 {
-    "scopeName": "source.tex",
-    "patterns": [
-        { "include": "text.tex" }
-    ]
+  "scopeName": "source.tex",
+  "patterns": [
+    {
+      "include": "#agda-block"
+    },
+    {
+      "include": "text.tex"
+    }
+  ],
+  "repository": {
+    "agda-block": {
+      "begin": "\\\\begin\\{code\\}.*",
+      "end": "\\\\end\\{code\\}.*",
+      "name": "markup.raw.block.latex",
+      "contentName": "meta.embedded.block.agda",
+      "beginCaptures": {
+        "0": { "name": "keyword.control.agda.begin.latex" }
+      },
+      "endCaptures": {
+        "0": { "name": "keyword.control.agda.end.latex" }
+      },
+      "patterns": [
+        {
+          "include": "source.agda"
+        }
+      ]
+    }
+  }
 }

--- a/syntaxes/typst.tmLanguage.json
+++ b/syntaxes/typst.tmLanguage.json
@@ -1,6 +1,32 @@
 {
-    "scopeName": "source.typst",
-    "patterns": [
-        { "include": "source.typst" }
-    ]
+  "scopeName": "source.typst",
+  "patterns": [
+    {
+      "include": "#agda-block"
+    },
+    {
+      "include": "text.html.typst"
+    }
+  ],
+  "repository": {
+    "agda-block": {
+      "begin": "(^|\\G)(\\s*)(```)(\\s*)(agda)?(\\s*$)",
+      "end": "(^|\\G)(\\2)(```)(\\s*$)",
+      "name": "markup.fenced_code.block.typst",
+      "contentName": "meta.embedded.block.agda",
+      "beginCaptures": {
+        "3": { "name": "punctuation.definition.typst" },
+        "5": { "name": "fenced_code.block.language.typst" },
+        "6": { "name": "fenced_code.block.language.attributes.typst" }
+      },
+      "endCaptures": {
+        "3": { "name": "punctuation.definition.typst" }
+      },
+      "patterns": [
+        {
+          "include": "source.agda"
+        }
+      ]
+    }
+  }
 }

--- a/syntaxes/typst.tmLanguage.json
+++ b/syntaxes/typst.tmLanguage.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "agda-block": {
-      "begin": "(^|\\G)(\\s*)(```)(\\s*)(agda)?(\\s*$)",
+      "begin": "(^|\\G)(\\s*)(```)(\\s*)(agda)(\\s*$)",
       "end": "(^|\\G)(\\2)(```)(\\s*$)",
       "name": "markup.fenced_code.block.typst",
       "contentName": "meta.embedded.block.agda",


### PR DESCRIPTION
Use Agda as an embedded language instead of only using injection grammar. This makes the language configuration only apply within agda blocks, and allows other language configurations to apply elsewhere.

Resolves #223, resolves #108

~Breaks #184 (partially).~