### PR TITLE
Upgrade @datastructures-js/binary-search-tree to v5.3.2

### DIFF
--- a/lib/js/src/Tokens.bs.js
+++ b/lib/js/src/Tokens.bs.js
@@ -17,7 +17,6 @@ var Parser$AgdaModeVscode = require("./Parser/Parser.bs.js");
 var AVLTree$AgdaModeVscode = require("./Util/AVLTree.bs.js");
 var Node__Fs$AgdaModeVscode = require("./Node/Node__Fs.bs.js");
 var Json_Decode$JsonCombinators = require("@glennsl/rescript-json-combinators/lib/js/src/Json_Decode.bs.js");
-var BinarySearchTree = require("@datastructures-js/binary-search-tree");
 var Highlighting__AgdaAspect$AgdaModeVscode = require("./Highlighting/Highlighting__AgdaAspect.bs.js");
 var Highlighting__Decoration$AgdaModeVscode = require("./Highlighting/Highlighting__Decoration.bs.js");
 var Highlighting__SemanticToken$AgdaModeVscode = require("./Highlighting/Highlighting__SemanticToken.bs.js");
@@ -248,7 +247,7 @@ function toString$1(self) {
 function make() {
   return {
           tempFiles: [],
-          tokens: new BinarySearchTree.BinarySearchTree()
+          tokens: AVLTree$AgdaModeVscode.make()
         };
 }
 
@@ -261,7 +260,7 @@ function insert(self, editor, tokens) {
         var existing = AVLTree$AgdaModeVscode.find(self.tokens, startOffset);
         if (existing !== undefined) {
           var old = existing[0];
-          self.tokens.remove(startOffset);
+          AVLTree$AgdaModeVscode.remove(self.tokens, startOffset);
           var newAspects = Caml_obj.equal(old.aspects, info.aspects) ? old.aspects : old.aspects.concat(info.aspects);
           var new_start = old.start;
           var new_end_ = old.end_;
@@ -276,16 +275,15 @@ function insert(self, editor, tokens) {
             note: new_note,
             source: new_source
           };
-          self.tokens.insert(startOffset, [
-                $$new,
-                existing[1]
-              ]);
-          return ;
+          return AVLTree$AgdaModeVscode.insert(self.tokens, startOffset, [
+                      $$new,
+                      existing[1]
+                    ]);
         }
         var start = $$document.positionAt(startOffset);
         var end_ = $$document.positionAt(Agda$AgdaModeVscode.OffsetConverter.convert(offsetConverter, info.end_));
         var range = new Vscode.Range(start, end_);
-        self.tokens.insert(startOffset, [
+        AVLTree$AgdaModeVscode.insert(self.tokens, startOffset, [
               info,
               range
             ]);
@@ -323,7 +321,7 @@ function clear(self) {
                 
               }));
       });
-  self.tokens = new BinarySearchTree.BinarySearchTree();
+  self.tokens = AVLTree$AgdaModeVscode.make();
 }
 
 function toArray(self) {

--- a/lib/js/src/Util/AVLTree.bs.js
+++ b/lib/js/src/Util/AVLTree.bs.js
@@ -3,61 +3,77 @@
 
 var Caml_option = require("rescript/lib/js/caml_option.js");
 var Core__Option = require("@rescript/core/lib/js/src/Core__Option.bs.js");
+var BinarySearchTree = require("@datastructures-js/binary-search-tree");
 
-var $$Node = {};
+function getValue(self) {
+  return self.getValue()[1];
+}
+
+var $$Node = {
+  getValue: getValue
+};
+
+function make() {
+  return new BinarySearchTree.BinarySearchTree((function (param, param$1) {
+                return param[0] - param$1[0] | 0;
+              }), {
+              key: "0"
+            });
+}
+
+function insert(self, key, value) {
+  self.insert([
+        key,
+        value
+      ]);
+}
 
 function find(self, key) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.find(key)), (function (prim) {
-                return prim.getValue();
-              }));
+  return Core__Option.map(Caml_option.nullable_to_opt(self.findKey(key)), getValue);
 }
 
 function max(self) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.max()), (function (prim) {
-                return prim.getValue();
-              }));
+  return Core__Option.map(Caml_option.nullable_to_opt(self.max()), getValue);
 }
 
 function min(self) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.min()), (function (prim) {
-                return prim.getValue();
-              }));
+  return Core__Option.map(Caml_option.nullable_to_opt(self.min()), getValue);
 }
 
 function upperBound(self, key) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.upperBound(key)), (function (prim) {
-                return prim.getValue();
-              }));
+  return Core__Option.map(Caml_option.nullable_to_opt(self.upperBoundKey(key)), getValue);
 }
 
 function lowerBound(self, key) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.lowerBound(key)), (function (prim) {
-                return prim.getValue();
-              }));
+  return Core__Option.map(Caml_option.nullable_to_opt(self.lowerBoundKey(key)), getValue);
 }
 
 function floor(self, key) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.floor(key)), (function (prim) {
-                return prim.getValue();
-              }));
+  return Core__Option.map(Caml_option.nullable_to_opt(self.floorKey(key)), getValue);
 }
 
 function ceil(self, key) {
-  return Core__Option.map(Caml_option.nullable_to_opt(self.ceil(key)), (function (prim) {
-                return prim.getValue();
+  return Core__Option.map(Caml_option.nullable_to_opt(self.ceilKey(key)), getValue);
+}
+
+function remove(self, key) {
+  return Core__Option.mapOr(Caml_option.nullable_to_opt(self.findKey(key)), false, (function (node) {
+                return self.removeNode(node);
               }));
 }
 
 function toArray(self) {
   var accum = [];
   self.traverseInOrder(function (node) {
-        var value = node.getValue();
+        var value = getValue(node);
         accum.push(value);
       });
   return accum;
 }
 
 exports.$$Node = $$Node;
+exports.make = make;
+exports.insert = insert;
 exports.find = find;
 exports.max = max;
 exports.min = min;
@@ -65,5 +81,6 @@ exports.upperBound = upperBound;
 exports.lowerBound = lowerBound;
 exports.floor = floor;
 exports.ceil = ceil;
+exports.remove = remove;
 exports.toArray = toArray;
-/* No side effect */
+/* @datastructures-js/binary-search-tree Not a pure module */

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "agda-mode",
 			"version": "0.5.7",
 			"dependencies": {
-				"@datastructures-js/binary-search-tree": "^4.3.0",
+				"@datastructures-js/binary-search-tree": "^5.3.2",
 				"@glennsl/rescript-json-combinators": "^1.4.0",
 				"@rescript/core": "^1.3.0",
 				"@rescript/react": "^0.13.0",
@@ -43,9 +43,9 @@
 			}
 		},
 		"node_modules/@datastructures-js/binary-search-tree": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@datastructures-js/binary-search-tree/-/binary-search-tree-4.3.2.tgz",
-			"integrity": "sha512-fZV3GoZAPxfgGTky7Q+5oiMUtLhQoHxSlJt3DmUPbl+1pMpuopOSG/MymdcruWOBQU90kSzo0lN+3gmSaEYCTw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/@datastructures-js/binary-search-tree/-/binary-search-tree-5.3.2.tgz",
+			"integrity": "sha512-8Y6SqH9wncY5HQMWbazjADyI5Sjop7VFVTPAcYoWWE8pHIVmAuS2CWCQ5wgwNEPUAnJMUz5idRTXmjtl5gwDCQ==",
 			"license": "MIT"
 		},
 		"node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -22,22 +22,23 @@
 		"vfx-dry-run": "npm list --production --parseable --depth=99999 --loglevel=error"
 	},
 	"devDependencies": {
-		"rescript-mocha": "github:DZakh-forks/rescript-mocha#uncurried",
+		"@vscode/test-electron": "^2.3.8",
 		"copy-webpack-plugin": "^6.0.3",
 		"glob": "^7.1.6",
 		"less": "^4.1.1",
 		"less-loader": "^7.0.2",
 		"less-watch-compiler": "^1.14.6",
 		"mocha": "^10.4.0",
-		"@vscode/test-electron": "^2.3.8",
+		"rescript-mocha": "github:DZakh-forks/rescript-mocha#uncurried",
 		"webpack": "^5.76.0",
 		"webpack-cli": "^4.2.0"
 	},
 	"dependencies": {
-		"@datastructures-js/binary-search-tree": "^4.3.0",
+		"@datastructures-js/binary-search-tree": "^5.3.2",
 		"@glennsl/rescript-json-combinators": "^1.4.0",
-		"@rescript/react": "^0.13.0",
 		"@rescript/core": "^1.3.0",
+		"@rescript/react": "^0.13.0",
+		"@vscode/codicons": "^0.0.36",
 		"compare-versions": "^3.5.1",
 		"eventemitter3": ">=4.0.0",
 		"getos": "^3.2.1",
@@ -49,7 +50,6 @@
 		"rescript-webapi": ">=0.2.0",
 		"untildify": "^4.0.0",
 		"unzipper": "^0.10.11",
-		"@vscode/codicons": "^0.0.36",
 		"vscode-languageclient": "^8.0.0"
 	},
 	"contributes": {

--- a/src/Util/AVLTree.res
+++ b/src/Util/AVLTree.res
@@ -1,16 +1,35 @@
+// The code has been updated to preserve the API while adapting to the
+// interface change of @datastructures-js/binary-search-tree from v4 to v5.
+// Namely, the library no longer store keys aside from value. Instead, the
+// constructor accepts a custom comparator and the field name of keys.
+
 module Node = {
   type t<'a>
-  @send external getValue: t<'a> => 'a = "getValue"
+  @send external getKeyValue: t<'a> => (int, 'a) = "getValue"
+  let getValue = (self: t<'a>): 'a => self->getKeyValue->(((_, v)) => v)
 }
 
 type t<'a>
+
+type compareFunction<'a> = ((int, 'a), (int, 'a)) => int
+
+type options = {
+  key?: string
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Constructor
 ////////////////////////////////////////////////////////////////////////////////
 
 @module("@datastructures-js/binary-search-tree") @new
-external make: unit => t<'a> = "BinarySearchTree"
+external makeInner: (
+  ~compare: compareFunction<'a>=?,
+  ~options: options=?,
+  unit
+) => t<'a> = "BinarySearchTree"
+
+let make = (): t<'a> =>
+  makeInner(~compare=((ka, _), (kb, _)) => ka - kb, ~options={ key: "0" }, ())
 
 ////////////////////////////////////////////////////////////////////////////////
 // Methods
@@ -18,13 +37,15 @@ external make: unit => t<'a> = "BinarySearchTree"
 
 @send external count: t<'a> => int = "count"
 
-@send external insert: (t<'a>, int, 'a) => unit = "insert"
+@send external insert: (t<'a>, (int, 'a)) => unit = "insert"
+let insert = (self: t<'a>, key: int, value: 'a) =>
+  self->insert((key, value))
 
 @send external has: (t<'a>, int) => bool = "has"
 
-@send external find: (t<'a>, int) => Nullable.t<Node.t<'a>> = "find"
+@send external findKey: (t<'a>, int) => Nullable.t<Node.t<'a>> = "findKey"
 let find = (self: t<'a>, key: int): option<'a> =>
-  self->find(key)->Nullable.toOption->Option.map(Node.getValue)
+  self->findKey(key)->Nullable.toOption->Option.map(Node.getValue)
 
 @send external max: t<'a> => Nullable.t<Node.t<'a>> = "max"
 let max = (self: t<'a>): option<'a> => self->max->Nullable.toOption->Option.map(Node.getValue)
@@ -32,23 +53,25 @@ let max = (self: t<'a>): option<'a> => self->max->Nullable.toOption->Option.map(
 @send external min: t<'a> => Nullable.t<Node.t<'a>> = "min"
 let min = (self: t<'a>): option<'a> => self->min->Nullable.toOption->Option.map(Node.getValue)
 
-@send external upperBound: (t<'a>, int) => Nullable.t<Node.t<'a>> = "upperBound"
+@send external upperBoundKey: (t<'a>, int) => Nullable.t<Node.t<'a>> = "upperBoundKey"
 let upperBound = (self: t<'a>, key: int): option<'a> =>
-  self->upperBound(key)->Nullable.toOption->Option.map(Node.getValue)
+  self->upperBoundKey(key)->Nullable.toOption->Option.map(Node.getValue)
 
-@send external lowerBound: (t<'a>, int) => Nullable.t<Node.t<'a>> = "lowerBound"
+@send external lowerBoundKey: (t<'a>, int) => Nullable.t<Node.t<'a>> = "lowerBoundKey"
 let lowerBound = (self: t<'a>, key: int): option<'a> =>
-  self->lowerBound(key)->Nullable.toOption->Option.map(Node.getValue)
+  self->lowerBoundKey(key)->Nullable.toOption->Option.map(Node.getValue)
 
-@send external floor: (t<'a>, int) => Nullable.t<Node.t<'a>> = "floor"
+@send external floorKey: (t<'a>, int) => Nullable.t<Node.t<'a>> = "floorKey"
 let floor = (self: t<'a>, key: int): option<'a> =>
-  self->floor(key)->Nullable.toOption->Option.map(Node.getValue)
+  self->floorKey(key)->Nullable.toOption->Option.map(Node.getValue)
 
-@send external ceil: (t<'a>, int) => Nullable.t<Node.t<'a>> = "ceil"
+@send external ceilKey: (t<'a>, int) => Nullable.t<Node.t<'a>> = "ceilKey"
 let ceil = (self: t<'a>, key: int): option<'a> =>
-  self->ceil(key)->Nullable.toOption->Option.map(Node.getValue)
+  self->ceilKey(key)->Nullable.toOption->Option.map(Node.getValue)
 
-@send external remove: (t<'a>, int) => bool = "remove"
+@send external removeNode: (t<'a>, Node.t<'a>) => bool = "removeNode"
+let remove = (self: t<'a>, key: int): bool =>
+  self->findKey(key)->Nullable.toOption->Option.mapOr(false, node => self->removeNode(node))
 
 @send external clear: t<'a> => unit = "clear"
 


### PR DESCRIPTION
This PR upgrades the dependency providing a BST implementation to v5.3.2, adjusts the interface on our side to fit its breaking change.

This is first step to adopt [this patch](https://github.com/datastructures-js/binary-search-tree/pull/60). I reviewed the code, and thought that adopting an iterative approach is the most prominent way to prevent stack size blowing up on large files.