### PR TITLE
Fix character offset when jumping to error

### DIFF
--- a/lib/js/src/Agda.bs.js
+++ b/lib/js/src/Agda.bs.js
@@ -223,11 +223,11 @@ var Output = {
 };
 
 function make(indicesUTF16) {
-  var indicesUTF8 = indicesUTF16.map(function (x, i) {
+  var indicesCodepoint = indicesUTF16.map(function (x, i) {
         return x - i | 0;
       });
-  var intervals = indicesUTF8.map(function (rightEndpoint, i) {
-        var x = indicesUTF8[i - 1 | 0];
+  var intervals = indicesCodepoint.map(function (rightEndpoint, i) {
+        var x = indicesCodepoint[i - 1 | 0];
         var leftEndpoint = x !== undefined ? x + 1 | 0 : 0;
         return [
                 leftEndpoint,

--- a/lib/js/src/Editor.bs.js
+++ b/lib/js/src/Editor.bs.js
@@ -372,7 +372,7 @@ var Provider = {
   registerDocumentSemanticTokensProvider: registerDocumentSemanticTokensProvider
 };
 
-function toUTF8Offset($$document, offset) {
+function toCodepointOffset($$document, offset) {
   var range = new Vscode.Range(new Vscode.Position(0, 0), $$document.positionAt(offset));
   var text = $$document.getText(Caml_option.some(range));
   return Agda$AgdaModeVscode.OffsetConverter.characterWidth(text);
@@ -390,5 +390,5 @@ exports.$$Text = $$Text;
 exports.focus = focus;
 exports.reveal = reveal;
 exports.Provider = Provider;
-exports.toUTF8Offset = toUTF8Offset;
+exports.toCodepointOffset = toCodepointOffset;
 /* documentSelector Not a pure module */

--- a/lib/js/src/State/State__Response.bs.js
+++ b/lib/js/src/State/State__Response.bs.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var Vscode = require("vscode");
+var Agda$AgdaModeVscode = require("../Agda.bs.js");
 var Chan$AgdaModeVscode = require("../Util/Chan.bs.js");
 var Item$AgdaModeVscode = require("../View/Component/Item.bs.js");
 var Util$AgdaModeVscode = require("../Util/Util.bs.js");
@@ -248,7 +249,10 @@ async function handle$1(state, dispatchCommand, response) {
             if (path !== response._0) {
               return ;
             }
-            var point = state.document.positionAt(response._1 - 1 | 0);
+            var text = Editor$AgdaModeVscode.$$Text.getAll(state.document);
+            var converter = Agda$AgdaModeVscode.OffsetConverter.make(text);
+            var offset_ = Agda$AgdaModeVscode.OffsetConverter.convert(converter, response._1 - 1 | 0);
+            var point = state.document.positionAt(offset_);
             return Editor$AgdaModeVscode.Cursor.set(state.editor, point);
         case "InteractionPoints" :
             return await State__Goal$AgdaModeVscode.instantiate(state, response._0);

--- a/lib/js/test/tests/TextEditor/Test__AgdaOffset.bs.js
+++ b/lib/js/test/tests/TextEditor/Test__AgdaOffset.bs.js
@@ -175,11 +175,11 @@ describe("Conversion between Agda Offsets and Editor Offsets", (function () {
                         Curry._3(Assert.deepEqual, Agda$AgdaModeVscode.Indices.expose(a)[1], 0, undefined);
                       }));
               }));
-        describe("Editor.toUTF8Offset", (function () {
+        describe("Editor.toCodepointOffset", (function () {
                 it("should do it right", (async function () {
                         var textEditor = await openEditorWithContent("𝐀a𝐁bb𝐂c\\na");
                         var f = function (n) {
-                          return Editor$AgdaModeVscode.toUTF8Offset(textEditor.document, n);
+                          return Editor$AgdaModeVscode.toCodepointOffset(textEditor.document, n);
                         };
                         Curry._3(Assert.equal, f(0), 0, undefined);
                         Curry._3(Assert.equal, f(1), 1, undefined);
@@ -193,10 +193,10 @@ describe("Conversion between Agda Offsets and Editor Offsets", (function () {
                         Curry._3(Assert.equal, f(11), 8, undefined);
                         return Curry._3(Assert.equal, f(12), 9, undefined);
                       }));
-                it("should be a left inverse of Editor.fromUTF8Offset", (async function () {
+                it("should be a left inverse of Editor.fromCodepointOffset", (async function () {
                         var textEditor = await openEditorWithContent("𝐀a𝐁bb𝐂c\\na");
                         var f = function (n) {
-                          return Editor$AgdaModeVscode.toUTF8Offset(textEditor.document, n);
+                          return Editor$AgdaModeVscode.toCodepointOffset(textEditor.document, n);
                         };
                         var g = function (n) {
                           return Agda$AgdaModeVscode.Indices.convert(Agda$AgdaModeVscode.Indices.make(Agda$AgdaModeVscode.OffsetConverter.computeUTF16SurrogatePairIndices("𝐀a𝐁bb𝐂c\\na")), n);
@@ -212,13 +212,13 @@ describe("Conversion between Agda Offsets and Editor Offsets", (function () {
                         Curry._3(Assert.equal, f(g(8)), 8, undefined);
                         return Curry._3(Assert.equal, f(g(9)), 9, undefined);
                       }));
-                it("should be a right inverse of Editor.fromUTF8Offset ()", (async function () {
+                it("should be a right inverse of Editor.fromCodepointOffset ()", (async function () {
                         var textEditor = await openEditorWithContent("𝐀a𝐁bb𝐂c\\na");
                         var f = function (n) {
                           return Agda$AgdaModeVscode.Indices.convert(Agda$AgdaModeVscode.Indices.make(Agda$AgdaModeVscode.OffsetConverter.computeUTF16SurrogatePairIndices("𝐀a𝐁bb𝐂c\\na")), n);
                         };
                         var g = function (n) {
-                          return Editor$AgdaModeVscode.toUTF8Offset(textEditor.document, n);
+                          return Editor$AgdaModeVscode.toCodepointOffset(textEditor.document, n);
                         };
                         Curry._3(Assert.equal, f(g(0)), 0, undefined);
                         Curry._3(Assert.equal, f(g(2)), 2, undefined);

--- a/src/Editor.res
+++ b/src/Editor.res
@@ -422,7 +422,7 @@ module Provider = {
   }
 }
 
-let toUTF8Offset = (document, offset) => {
+let toCodepointOffset = (document, offset) => {
   let range = VSRange.make(VSCode.Position.make(0, 0), document->TextDocument.positionAt(offset)) // start // end
   let text = document->TextDocument.getText(Some(range))
   Agda.OffsetConverter.characterWidth(text)

--- a/src/State/State__Response.res
+++ b/src/State/State__Response.res
@@ -135,7 +135,10 @@ let rec handle = async (
       // when it's on the same file
       let path = state.document->VSCode.TextDocument.fileName->Parser.filepath
       if path == filepath {
-        let point = state.document->VSCode.TextDocument.positionAt(offset - 1)
+        let text = Editor.Text.getAll(state.document)
+        let converter = Agda.OffsetConverter.make(text)
+        let offset_ = Agda.OffsetConverter.convert(converter, offset - 1)
+        let point = state.document->VSCode.TextDocument.positionAt(offset_)
         Editor.Cursor.set(state.editor, point)
       }
     | InteractionPoints(indices) => await State__Goal.instantiate(state, indices)

--- a/test/tests/TextEditor/Test__AgdaOffset.res
+++ b/test/tests/TextEditor/Test__AgdaOffset.res
@@ -140,14 +140,14 @@ describe("Conversion between Agda Offsets and Editor Offsets", () => {
     )
   })
 
-  describe("Editor.toUTF8Offset", () => {
+  describe("Editor.toCodepointOffset", () => {
     Async.it(
       "should do it right",
       async () => {
         let textEditor = await openEditorWithContent("𝐀a𝐁bb𝐂c\\na")
-        let f = n => textEditor->VSCode.TextEditor.document->Editor.toUTF8Offset(n)
+        let f = n => textEditor->VSCode.TextEditor.document->Editor.toCodepointOffset(n)
         Assert.equal(f(0), 0)
-        Assert.equal(f(1), 1) // cuts grapheme in half, toUTF8Offset is a partial function
+        Assert.equal(f(1), 1) // cuts grapheme in half, toCodepointOffset is a partial function
         Assert.equal(f(2), 1)
         Assert.equal(f(3), 2)
         Assert.equal(f(5), 3)
@@ -161,11 +161,11 @@ describe("Conversion between Agda Offsets and Editor Offsets", () => {
     )
 
     Async.it(
-      "should be a left inverse of Editor.fromUTF8Offset",
+      "should be a left inverse of Editor.fromCodepointOffset",
       async () => {
-        // toUTF8Offset . fromUTF8Offset = id
+        // toCodepointOffset . fromCodepointOffset = id
         let textEditor = await openEditorWithContent("𝐀a𝐁bb𝐂c\\na")
-        let f = n => textEditor->VSCode.TextEditor.document->Editor.toUTF8Offset(n)
+        let f = n => textEditor->VSCode.TextEditor.document->Editor.toCodepointOffset(n)
         let g = n =>
           Agda.OffsetConverter.computeUTF16SurrogatePairIndices("𝐀a𝐁bb𝐂c\\na")
           ->Agda.Indices.make
@@ -184,16 +184,16 @@ describe("Conversion between Agda Offsets and Editor Offsets", () => {
     )
 
     Async.it(
-      "should be a right inverse of Editor.fromUTF8Offset ()",
+      "should be a right inverse of Editor.fromCodepointOffset ()",
       async () => {
-        // NOTE: toUTF8Offset is a partial function
-        // fromUTF8Offset . toUTF8Offset = id
+        // NOTE: toCodepointOffset is a partial function
+        // fromCodepointOffset . toCodepointOffset = id
         let textEditor = await openEditorWithContent("𝐀a𝐁bb𝐂c\\na")
         let f = n =>
           Agda.OffsetConverter.computeUTF16SurrogatePairIndices("𝐀a𝐁bb𝐂c\\na")
           ->Agda.Indices.make
           ->Agda.Indices.convert(n)
-        let g = n => textEditor->VSCode.TextEditor.document->Editor.toUTF8Offset(n)
+        let g = n => textEditor->VSCode.TextEditor.document->Editor.toCodepointOffset(n)
         Assert.equal(f(g(0)), 0)
         Assert.equal(f(g(2)), 2)
         Assert.equal(f(g(3)), 3)


### PR DESCRIPTION
Fixes https://github.com/banacorn/agda-mode-vscode/issues/216.

Agda and VSCode disagree on how to count characters: Agda uses Unicode code points but treats CRLF as LF, while VSCode [uses](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments) UCS-2/UTF-16 code units. This leads to cursor misalignment when jumping to an error. Conveniently, we can just reuse the existing OffsetConverter to fix up the offset.

Also updates some names and comments to clarify that this has nothing to do with UTF-8.