### PR TITLE
Add built-in markdown preview keybindings for literate agda markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1148,6 +1148,16 @@
 				"command": "agda-mode.lookup-symbol",
 				"key": "ctrl+x ctrl+=",
 				"when": "editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && !terminalFocus"
+			},
+			{
+				"command": "markdown.showPreview",
+				"key": "shift+cmd+v",
+				"when": "!notebookEditorFocused && editorLangId == 'lagda-markdown'"
+			},
+			{
+				"command": "markdown.showPreviewToSide",
+				"key": "cmd+k v",
+				"when": "!notebookEditorFocused && editorLangId == 'lagda-markdown'"
 			}
 		],
 		"configuration": {


### PR DESCRIPTION
As discussed in #247, these keybindings got broken again at some point, so this PR adds them explicitly as part of the extension. Fixes #108 again.