### PR TITLE
provide hover text about how to type a symbol

### DIFF
--- a/lib/js/src/Main/Main.bs.js
+++ b/lib/js/src/Main/Main.bs.js
@@ -158,7 +158,15 @@ function registerInputMethodHintHoverProvider() {
                   }),
               VSCode.StringOr.make({
                     TAG: "String",
+                    _0: "markdown"
+                  }),
+              VSCode.StringOr.make({
+                    TAG: "String",
                     _0: "lagda-typst"
+                  }),
+              VSCode.StringOr.make({
+                    TAG: "String",
+                    _0: "typst"
                   }),
               VSCode.StringOr.make({
                     TAG: "String",
@@ -174,25 +182,50 @@ function registerInputMethodHintHoverProvider() {
                   }),
               VSCode.StringOr.make({
                     TAG: "String",
+                    _0: "org"
+                  }),
+              VSCode.StringOr.make({
+                    TAG: "String",
                     _0: "lagda-forester"
+                  }),
+              VSCode.StringOr.make({
+                    TAG: "String",
+                    _0: "forester"
                   })
             ], {
               provideHover: (function ($$document, position, _token) {
                   var text = $$document.lineAt(position.line).text;
-                  var c = text.charAt(position.character);
-                  var found_input_methods = Core__Option.flatMap(Core__Option.map(c.codePointAt(0), (function (prim) {
-                              return String(prim);
-                            })), (function (extra) {
-                          return rawTable[extra];
-                        }));
-                  if (found_input_methods === undefined) {
+                  var $$char = text.charAt(position.character);
+                  var ignoredChars = [" "];
+                  var foundInputMethods = ignoredChars.includes($$char) ? undefined : Core__Option.flatMap(Core__Option.map($$char.codePointAt(0), (function (prim) {
+                                return String(prim);
+                              })), (function (extra) {
+                            return rawTable[extra];
+                          }));
+                  if (foundInputMethods === undefined) {
                     return ;
                   }
-                  var methods_text = found_input_methods.map(function (m) {
-                          return "`\\".concat(m, "`");
-                        }).join("or");
+                  var sortedMethods = foundInputMethods.toSorted(function (a, b) {
+                        return a.length - b.length | 0;
+                      });
+                  var match = sortedMethods.length;
+                  var methodsText;
+                  if (match !== 1) {
+                    if (match !== 2) {
+                      var lastMethod = sortedMethods.at(-1);
+                      var otherMethods = sortedMethods.slice(0, -1);
+                      methodsText = otherMethods.map(function (m) {
+                              return "`\\" + m + "`";
+                            }).join(", ") + ", or `\\" + lastMethod + "`";
+                    } else {
+                      methodsText = "`\\" + sortedMethods[0] + "` or `\\" + sortedMethods[1] + "`";
+                    }
+                  } else {
+                    methodsText = "`\\" + sortedMethods[0] + "`";
+                  }
+                  var hoverText = "Input sequence: " + methodsText;
                   return Caml_option.some(new Promise((function (resolve, _reject) {
-                                    resolve(new Vscode.Hover([new Vscode.MarkdownString("Type`".concat(c, "`using", methods_text))]));
+                                    resolve(new Vscode.Hover([new Vscode.MarkdownString(hoverText)]));
                                   })));
                 })
             });


### PR DESCRIPTION
As title described, when user put mouse cursor on to a symbol, this hover provide will check if that's something need agda input method to produce, then show a hover text about how to type it.

## Screenshot

<img width="739" height="177" alt="image" src="https://github.com/user-attachments/assets/d25b5114-ef64-40ef-94d6-cd46c748ec8e" />
