### PR TITLE
[ fix ] Fix CI for building Agda 2.6.4 with Stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,9 @@ jobs:
       - name: ⏬ Install Agda
         if: ${{ steps.check-agda.outcome == 'failure'}}
         run: |
-          stack install --resolver=lts-24.1 --allow-different-user ${{ matrix.agda }}
+          AGDA_PKGNAME=${{ matrix.agda }}
+          STACK_RESOLVER=$([ "$AGDA_PKGNAME" == "Agda-2.6.4" ] && echo "nightly-2023-10-03" || echo "lts-24.1")
+          stack install --resolver=$STACK_RESOLVER --allow-different-user "$AGDA_PKGNAME"
           echo "STACK_LOCAL_BIN=$(stack path --local-bin)" >> "$GITHUB_ENV"
 
       - name: 📦 Move artefacts to ${{ env.DIST }}


### PR DESCRIPTION
The updated resolver `lts-24.1` is too new for Agda 2.6.4 causing CI failures. Same for Agda 2.6.4.3. I adapted the nightly tag from that in Agda's source repository, specified in `stack-*.yaml`.

It is also sensible to update the testing target to v2.6.4.3 later.
