### PR TITLE
No syntax highlighting until the first edit #254

### DIFF
--- a/src/Editor.res
+++ b/src/Editor.res
@@ -220,6 +220,20 @@ module Provider = {
   }
 
   module Mock = {
+    // https://code.visualstudio.com/api/references/vscode-api#Event
+    module Event = {
+      type t<'a>
+    }
+
+    // https://code.visualstudio.com/api/references/vscode-api#EventEmitter
+    module EventEmitter = {
+      type t<'a>
+      @module("vscode") @new external make: unit => t<'a> = "EventEmitter"
+      @get external event: t<'a> => Event.t<'a> = "event"
+      @send external fire: (t<'a>, 'a) => unit = "fire"
+      @send external dispose: t<'a> => unit = "dispose"
+    }
+
     // https://code.visualstudio.com/api/references/vscode-api#SemanticsTokens
     module SemanticsTokens = {
       type t
@@ -294,8 +308,6 @@ module Provider = {
 
     // https://code.visualstudio.com/api/references/vscode-api#DocumentSemanticTokensProvider
     module DocumentSemanticTokensProvider = {
-      // missing: onDidChangeSemanticTokens
-
       type provideDocumentSemanticTokens = (
         TextDocument.t,
         CancellationToken.t,
@@ -314,15 +326,18 @@ module Provider = {
       >
 
       type t = {
+        onDidChangeSemanticTokens: option<Event.t<unit>>,
         provideDocumentSemanticTokens: option<provideDocumentSemanticTokens>,
         provideDocumentSemanticTokensEdits: option<provideDocumentSemanticTokensEdits>,
       }
 
       let make = (
+        ~onDidChangeSemanticTokens: option<Event.t<unit>>=?,
         ~provideDocumentSemanticTokens: option<provideDocumentSemanticTokens>=?,
         ~provideDocumentSemanticTokensEdits: option<provideDocumentSemanticTokensEdits>=?,
         (),
       ) => {
+        onDidChangeSemanticTokens,
         provideDocumentSemanticTokens,
         provideDocumentSemanticTokensEdits,
       }
@@ -340,9 +355,11 @@ module Provider = {
 
   let registerDocumentSemanticTokensProvider = (
     ~provideDocumentSemanticTokens: Mock.DocumentSemanticTokensProvider.provideDocumentSemanticTokens,
+    ~onDidChangeSemanticTokens: option<Mock.Event.t<unit>>=?,
     (tokenTypes, tokenModifiers),
   ) => {
     let documentSemanticTokensProvider = Mock.DocumentSemanticTokensProvider.make(
+      ~onDidChangeSemanticTokens?,
       ~provideDocumentSemanticTokens,
       // =(textDocument, _cancel) => {
       //   let builder = Mock.SemanticTokensBuilder.makeWithLegend(semanticTokensLegend)

--- a/src/State/State.res
+++ b/src/State/State.res
@@ -125,6 +125,7 @@ let destroy = async (state, alsoRemoveFromRegistry) => {
   state.channels.log->Chan.emit(Others("State.destroy: Disposed subscriptions"))
   state.channels.log->Chan.emit(TokensReset("State.destroy"))
   state.tokens->Tokens.reset
+  state.tokens->Tokens.destroyUpdateChannel
   state.channels.log->Chan.emit(Others("State.destroy: Tokens reset completed"))
   let result = await Connection.destroy(state.connection, state.channels.log)
   state.channels.log->Chan.emit(Others("State.destroy: Connection destroyed, destruction complete"))

--- a/test/tests/Test__Tokens.res
+++ b/test/tests/Test__Tokens.res
@@ -7,6 +7,21 @@ describe("Tokens", () => {
   This.timeout(10000)
   describe("Token generation", () => {
     Async.it(
+      "should emit `onUpdate` event when highlighting is generated",
+      async () => {
+        let ctx = await AgdaMode.makeAndLoad("GotoDefinition.agda")
+        let (promise, resolve, _) = Util.Promise_.pending()
+
+        let _disposable = ctx.state.tokens->Tokens.onUpdate->Chan.on(resolve)
+
+        ctx.state.tokens->Tokens.generateHighlighting(ctx.state.editor)
+
+        await promise
+        Assert.ok(true)
+      },
+    )
+
+    Async.it(
       "should produce 28 tokens",
       async () => {
         let ctx = await AgdaMode.makeAndLoad("GotoDefinition.agda")


### PR DESCRIPTION
The root cause is that VSCode was not notified that semantic tokens had changed.

This PR implements the onDidChangeSemanticTokens event to push updates to VSCode, and wires the extension's internal highlighting generation to this emitter, ensuring immediate visual refreshes upon every load.