### PR TITLE
Don't add path to the config when obtained via command lookup

### DIFF
--- a/lib/js/src/Connection/Connection.bs.js
+++ b/lib/js/src/Connection/Connection.bs.js
@@ -567,18 +567,14 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
   var match = errors._0;
   var connection = match[0];
   logConnection(connection);
-  var exit = 0;
   switch (match[1]) {
     case "FromPaths" :
-        break;
     case "FromCommands" :
+        break;
     case "FromDownloads" :
-        exit = 1;
+        await Config$AgdaModeVscode.Connection.addAgdaPath(logChannel, getPath(connection));
         break;
     
-  }
-  if (exit === 1) {
-    await Config$AgdaModeVscode.Connection.addAgdaPath(logChannel, getPath(connection));
   }
   await Memento$AgdaModeVscode.Module.PickedConnection.set(memento, getPath(connection));
   return {

--- a/lib/js/src/Main/Main.bs.js
+++ b/lib/js/src/Main/Main.bs.js
@@ -65,7 +65,7 @@ var Inputs = {
   onTriggerCommand: onTriggerCommand
 };
 
-function initialize(platformDeps, channels, extensionUri, globalStorageUri, memento, editor, semanticTokensRequest) {
+function initialize(platformDeps, channels, extensionUri, globalStorageUri, memento, editor, semanticTokensRequest, semanticTokensEventEmitter) {
   var panel = Singleton$AgdaModeVscode.Panel.make(extensionUri);
   WebviewPanel$AgdaModeVscode.onceDestroyed(panel).finally(function () {
         Registry$AgdaModeVscode.removeAndDestroyAll();
@@ -75,6 +75,11 @@ function initialize(platformDeps, channels, extensionUri, globalStorageUri, meme
   var subscribe = function (disposable) {
     state.subscriptions.push(disposable);
   };
+  Core__Option.forEach(semanticTokensEventEmitter, (function (emitter) {
+          subscribe(new Vscode.Disposable(Chan$AgdaModeVscode.on(Tokens$AgdaModeVscode.onUpdate(state.tokens), (function () {
+                          emitter.fire();
+                        }))));
+        }));
   var getCurrentEditor = function () {
     var editor = Vscode.window.activeTextEditor;
     if (editor !== undefined) {
@@ -126,7 +131,7 @@ function initialize(platformDeps, channels, extensionUri, globalStorageUri, meme
   return state;
 }
 
-function registerDocumentSemanticTokensProvider() {
+function registerDocumentSemanticTokensProvider(onDidChangeSemanticTokens) {
   var tokenTypes = Highlighting__SemanticToken$AgdaModeVscode.TokenType.enumurate;
   var tokenModifiers = Highlighting__SemanticToken$AgdaModeVscode.TokenModifier.enumurate;
   var provideDocumentSemanticTokens = function ($$document, _cancel) {
@@ -141,7 +146,7 @@ function registerDocumentSemanticTokensProvider() {
                     return builder.build();
                   }));
   };
-  return Editor$AgdaModeVscode.Provider.registerDocumentSemanticTokensProvider(provideDocumentSemanticTokens, [
+  return Editor$AgdaModeVscode.Provider.registerDocumentSemanticTokensProvider(provideDocumentSemanticTokens, onDidChangeSemanticTokens, [
               tokenTypes,
               tokenModifiers
             ]);
@@ -251,6 +256,11 @@ function activateWithoutContext(platformDeps, subscriptions, extensionUri, globa
   var subscribeMany = function (xs) {
     Caml_splice_call.spliceObjApply(subscriptions, "push", [xs]);
   };
+  var semanticTokensEventEmitter = new Vscode.EventEmitter();
+  subscribe(new Vscode.Disposable((function () {
+              semanticTokensEventEmitter.dispose();
+            })));
+  var onDidChangeSemanticTokens = semanticTokensEventEmitter.event;
   var channels_inputMethod = Chan$AgdaModeVscode.make();
   var channels_responseHandled = Chan$AgdaModeVscode.make();
   var channels_commandHandled = Chan$AgdaModeVscode.make();
@@ -336,12 +346,12 @@ function activateWithoutContext(platformDeps, subscriptions, extensionUri, globa
               if (entry !== undefined) {
                 var match = entry.state;
                 if (match === undefined) {
-                  var state = initialize(platformDeps, channels, extensionUri, globalStorageUri, memento, editor, Caml_option.some(entry.semanticTokens));
+                  var state = initialize(platformDeps, channels, extensionUri, globalStorageUri, memento, editor, Caml_option.some(entry.semanticTokens), Caml_option.some(semanticTokensEventEmitter));
                   Registry$AgdaModeVscode.add($$document, state);
                 }
                 
               } else {
-                var state$1 = initialize(platformDeps, channels, extensionUri, globalStorageUri, memento, editor, undefined);
+                var state$1 = initialize(platformDeps, channels, extensionUri, globalStorageUri, memento, editor, undefined, Caml_option.some(semanticTokensEventEmitter));
                 Registry$AgdaModeVscode.add($$document, state$1);
               }
             }
@@ -357,7 +367,7 @@ function activateWithoutContext(platformDeps, subscriptions, extensionUri, globa
             }
             
           }));
-  subscribe(registerDocumentSemanticTokensProvider());
+  subscribe(registerDocumentSemanticTokensProvider(Caml_option.some(onDidChangeSemanticTokens)));
   subscribe(registerInputMethodHintHoverProvider());
   return channels;
 }

--- a/lib/js/src/State/State.bs.js
+++ b/lib/js/src/State/State.bs.js
@@ -135,6 +135,7 @@ async function destroy(state, alsoRemoveFromRegistry) {
         _0: "State.destroy"
       });
   Tokens$AgdaModeVscode.reset(state.tokens);
+  Tokens$AgdaModeVscode.destroyUpdateChannel(state.tokens);
   Chan$AgdaModeVscode.emit(state.channels.log, {
         TAG: "Others",
         _0: "State.destroy: Tokens reset completed"

--- a/lib/js/test/tests/Connection/Test__Connection__Config.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Config.bs.js
@@ -140,23 +140,15 @@ describe("Config.Connection paths", (function () {
                       }));
               }));
         describe("Broken config paths", (function () {
-                it("should add discovered path when all config paths are broken and auto discovery succeeds", (async function () {
+                it("should not add discovered path when all config paths are broken and auto discovery succeeds", (async function () {
                         var configPaths = [
                           brokenAgda.contents,
                           "/another/broken"
                         ];
                         var match = await makeConnection(configPaths, platformWithDiscovery);
                         var result = match[1];
-                        var expectedConfig = configPaths.concat([systemAgda.contents]);
-                        Curry._3(Assert.deepStrictEqual, match[0], [{
-                                TAG: "Config",
-                                _0: {
-                                  TAG: "Changed",
-                                  _0: configPaths,
-                                  _1: expectedConfig
-                                }
-                              }], undefined);
-                        Curry._3(Assert.deepStrictEqual, Config$AgdaModeVscode.Connection.getAgdaPaths(), expectedConfig, undefined);
+                        Curry._3(Assert.deepStrictEqual, match[0], [], undefined);
+                        Curry._3(Assert.deepStrictEqual, Config$AgdaModeVscode.Connection.getAgdaPaths(), configPaths, undefined);
                         if (result.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), systemAgda.contents, undefined);
                         }
@@ -178,19 +170,12 @@ describe("Config.Connection paths", (function () {
                       }));
               }));
         describe("Empty config paths", (function () {
-                it("should add discovered path when config is empty and auto discovery succeeds", (async function () {
+                it("should not add discovered path when config is empty and auto discovery succeeds", (async function () {
                         var configPaths = [];
                         var match = await makeConnection(configPaths, platformWithDiscovery);
                         var result = match[1];
-                        var expectedConfig = [systemAgda.contents];
-                        Curry._3(Assert.deepStrictEqual, match[0], [{
-                                TAG: "Config",
-                                _0: {
-                                  TAG: "Changed",
-                                  _0: [],
-                                  _1: expectedConfig
-                                }
-                              }], undefined);
+                        var expectedConfig = [];
+                        Curry._3(Assert.deepStrictEqual, match[0], [], undefined);
                         Curry._3(Assert.deepStrictEqual, Config$AgdaModeVscode.Connection.getAgdaPaths(), expectedConfig, undefined);
                         if (result.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), systemAgda.contents, undefined);

--- a/lib/js/test/tests/Test__Tokens.bs.js
+++ b/lib/js/test/tests/Test__Tokens.bs.js
@@ -6,6 +6,7 @@ var Assert = require("assert");
 var Vscode = require("vscode");
 var FastCheck = require("fast-check");
 var Caml_option = require("rescript/lib/js/caml_option.js");
+var Chan$AgdaModeVscode = require("../../src/Util/Chan.bs.js");
 var Util$AgdaModeVscode = require("../../src/Util/Util.bs.js");
 var Token$AgdaModeVscode = require("../../src/Tokens/Token.bs.js");
 var Editor$AgdaModeVscode = require("../../src/Editor.bs.js");
@@ -18,6 +19,14 @@ var TokenIntervals$AgdaModeVscode = require("../../src/Tokens/TokenIntervals.bs.
 describe("Tokens", (function () {
         this.timeout(10000);
         describe("Token generation", (function () {
+                it("should emit `onUpdate` event when highlighting is generated", (async function () {
+                        var ctx = await Test__Util$AgdaModeVscode.AgdaMode.makeAndLoad("GotoDefinition.agda");
+                        var match = Util$AgdaModeVscode.Promise_.pending();
+                        Chan$AgdaModeVscode.on(Tokens$AgdaModeVscode.onUpdate(ctx.state.tokens), match[1]);
+                        Tokens$AgdaModeVscode.generateHighlighting(ctx.state.tokens, ctx.state.editor);
+                        await match[0];
+                        Assert.ok(true);
+                      }));
                 it("should produce 28 tokens", (async function () {
                         var ctx = await Test__Util$AgdaModeVscode.AgdaMode.makeAndLoad("GotoDefinition.agda");
                         var tokens = Tokens$AgdaModeVscode.toTokenArray(ctx.state.tokens).map(function (token) {

--- a/src/Connection/Connection.res
+++ b/src/Connection/Connection.res
@@ -399,8 +399,8 @@ module Module: Module = {
       logConnection(connection)
       // Only add to config if connection succeeded from fallback methods (not from config paths)
       switch from {
-      | FromPaths => () // Never modify config when using existing config paths
-      | FromCommands | FromDownloads =>
+      | FromPaths | FromCommands => () // Never modify config when using existing config paths
+      | FromDownloads =>
         await Config.Connection.addAgdaPath(logChannel, getPath(connection))
       }
 

--- a/test/tests/Connection/Test__Connection__Config.res
+++ b/test/tests/Connection/Test__Connection__Config.res
@@ -7,10 +7,10 @@ open Test__Util
 // │   ├── Multiple working paths → should not modify config
 // │   └── Mixed working/broken paths → should not modify config (working paths exist)
 // ├── Broken config paths
-// │   ├── All broken, auto discovery succeeds → should add discovered path to config
+// │   ├── All broken, auto discovery succeeds → should not add discovered path to config
 // │   └── All broken, auto discovery fails → should fail without modifying config
 // ├── Empty config paths
-// │   ├── Auto discovery succeeds → should add discovered path to config
+// │   ├── Auto discovery succeeds → should not add discovered path to config
 // │   └── Auto discovery fails → should fail without modifying config
 // └── UI-triggered additions
 //     └── Switch version UI selection → should add selected path to config
@@ -152,14 +152,14 @@ describe("Config.Connection paths", () => {
 
   describe("Broken config paths", () => {
     Async.it(
-      "should add discovered path when all config paths are broken and auto discovery succeeds",
+      "should not add discovered path when all config paths are broken and auto discovery succeeds",
       async () => {
         let configPaths = [brokenAgda.contents, "/another/broken"]
         let (logs, result) = await makeConnection(configPaths, platformWithDiscovery)
 
         // should add discovered path to config
-        let expectedConfig = Array.concat(configPaths, [systemAgda.contents])
-        Assert.deepStrictEqual(logs, [Log.Config(Changed(configPaths, expectedConfig))])
+        let expectedConfig = configPaths
+        Assert.deepStrictEqual(logs, [])
         Assert.deepStrictEqual(Config.Connection.getAgdaPaths(), expectedConfig)
 
         switch result {
@@ -193,14 +193,14 @@ describe("Config.Connection paths", () => {
 
   describe("Empty config paths", () => {
     Async.it(
-      "should add discovered path when config is empty and auto discovery succeeds",
+      "should not add discovered path when config is empty and auto discovery succeeds",
       async () => {
         let configPaths = []
         let (logs, result) = await makeConnection(configPaths, platformWithDiscovery)
 
         // should add discovered path to config
-        let expectedConfig = [systemAgda.contents]
-        Assert.deepStrictEqual(logs, [Log.Config(Changed([], expectedConfig))])
+        let expectedConfig = []
+        Assert.deepStrictEqual(logs, [])
         Assert.deepStrictEqual(Config.Connection.getAgdaPaths(), expectedConfig)
 
         switch result {


### PR DESCRIPTION
Fixes https://github.com/banacorn/agda-mode-vscode/issues/255. When the Agda executable is discovered by looking up the `agda` command in `PATH`, don't store the result in the user's configuration. This makes it possible to switch between environments with different versions of Agda without having to erase the paths every time.