### PR TITLE
Fix flaky CI failures by feeding a workspace settings file to VS Code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,6 +194,8 @@ jobs:
 
       - name: 🚗 Run tests
         run: |
+          mkdir -p lib/js/.vscode
+          cp test/user-data/settings.json lib/js/.vscode
           if [[ ${{ runner.os }} == "Linux" ]]; then
             xvfb-run -a npm test 2>&1 | tee test-output.log
           else

--- a/lib/js/test/RunTestFromCLI.bs.js
+++ b/lib/js/test/RunTestFromCLI.bs.js
@@ -14,7 +14,8 @@ console.log("Running from the CLI, with\n  extensionDevelopmentPath: " + (extens
 
 TestElectron.runTests({
       extensionDevelopmentPath: extensionDevelopmentPath,
-      extensionTestsPath: extensionTestsPath
+      extensionTestsPath: extensionTestsPath,
+      launchArgs: [extensionDevelopmentPath]
     });
 
 exports.testSuiteAdapterFileName = testSuiteAdapterFileName;

--- a/test/RunTestFromCLI.res
+++ b/test/RunTestFromCLI.res
@@ -2,6 +2,7 @@
 type options = {
   extensionDevelopmentPath: string,
   extensionTestsPath: string,
+  launchArgs: array<string>,
 }
 
 @module("@vscode/test-electron")
@@ -26,4 +27,5 @@ Js.log(
 runTests({
   extensionDevelopmentPath,
   extensionTestsPath,
+  launchArgs: [extensionDevelopmentPath],
 })->Promise.done

--- a/test/user-data/settings.json
+++ b/test/user-data/settings.json
@@ -1,0 +1,1 @@
+{"agdaMode.connection.paths": ["agda"]}


### PR DESCRIPTION
CI failed randomly complaining Agda path cannot be found. This patch tries to include a settings file in the testing environment in hope that the value is settled down on the very first test case.