### PR TITLE
Update semantic token definitions to allow styling more token types

### DIFF
--- a/lib/js/src/Highlighting/Highlighting__AgdaAspect.bs.js
+++ b/lib/js/src/Highlighting/Highlighting__AgdaAspect.bs.js
@@ -363,7 +363,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Operator",
-                  ["Agda"]
+                  []
                 ],
                 undefined
               ];

--- a/lib/js/src/Highlighting/Highlighting__AgdaAspect.bs.js
+++ b/lib/js/src/Highlighting/Highlighting__AgdaAspect.bs.js
@@ -157,239 +157,6 @@ function parse(x) {
   }
 }
 
-function toDecoration(x) {
-  switch (x) {
-    case "Comment" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#B0B0B0"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#505050"
-                }
-              };
-    case "Keyword" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#CD6600"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#FF9932"
-                }
-              };
-    case "String" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#B22222"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#DD4D4D"
-                }
-              };
-    case "Number" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#800080"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#9010E0"
-                }
-              };
-    case "Symbol" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#404040"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#BFBFBF"
-                }
-              };
-    case "Error" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#FF0000"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#FF0000"
-                }
-              };
-    case "UnsolvedMeta" :
-    case "UnsolvedConstraint" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#FFFF00"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#806B00"
-                }
-              };
-    case "TerminationProblem" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#FFA07A"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#802400"
-                }
-              };
-    case "PositivityProblem" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#CD853F"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#803F00"
-                }
-              };
-    case "Deadcode" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#A9A9A9"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#808080"
-                }
-              };
-    case "CoverageProblem" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#F5DEB3"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#805300"
-                }
-              };
-    case "IncompletePattern" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#800080"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#800080"
-                }
-              };
-    case "CatchallClause" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#F5F5F5"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#404040"
-                }
-              };
-    case "ConfluenceProblem" :
-        return {
-                light: {
-                  TAG: "Background",
-                  _0: "#FFC0CB"
-                },
-                dark: {
-                  TAG: "Background",
-                  _0: "#800080"
-                }
-              };
-    case "ConstructorInductive" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#008B00"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#29CC29"
-                }
-              };
-    case "ConstructorCoInductive" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#996600"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#FFEA75"
-                }
-              };
-    case "Field" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#EE1289"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#F570B7"
-                }
-              };
-    case "Module" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#800080"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#CD80FF"
-                }
-              };
-    case "PrimitiveType" :
-    case "Datatype" :
-    case "Function" :
-    case "Postulate" :
-    case "Primitive" :
-    case "Record" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#0000CD"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#8080FF"
-                }
-              };
-    case "Macro" :
-        return {
-                light: {
-                  TAG: "Foreground",
-                  _0: "#458B74"
-                },
-                dark: {
-                  TAG: "Foreground",
-                  _0: "#73BAA2"
-                }
-              };
-    default:
-      return ;
-  }
-}
-
 function toTokenTypeAndModifiersAndDecoration(x) {
   var nothing_0 = [
     undefined,
@@ -422,7 +189,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Comment",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -430,7 +197,15 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Keyword",
-                  []
+                  ["Agda"]
+                ],
+                undefined
+              ];
+    case "String" :
+        return [
+                [
+                  "String",
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -438,7 +213,18 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Number",
-                  []
+                  ["Agda"]
+                ],
+                undefined
+              ];
+    case "PrimitiveType" :
+        return [
+                [
+                  "Type",
+                  [
+                    "Primitive",
+                    "Agda"
+                  ]
                 ],
                 undefined
               ];
@@ -446,7 +232,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   undefined,
-                  ["Deprecated"]
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -472,33 +258,50 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Variable",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
     case "ConstructorInductive" :
+        return [
+                [
+                  "EnumMember",
+                  ["Agda"]
+                ],
+                undefined
+              ];
     case "ConstructorCoInductive" :
         return [
                 [
                   "EnumMember",
-                  []
+                  [
+                    "CoInductive",
+                    "Agda"
+                  ]
                 ],
                 undefined
               ];
-    case "PrimitiveType" :
     case "Datatype" :
         return [
                 [
                   "Type",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
     case "Field" :
         return [
                 [
-                  "Member",
-                  []
+                  "Property",
+                  ["Agda"]
+                ],
+                undefined
+              ];
+    case "Function" :
+        return [
+                [
+                  "Function",
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -506,25 +309,29 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Namespace",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
-    case "Function" :
     case "Postulate" :
         return [
                 [
                   "Function",
-                  []
+                  [
+                    "Abstract",
+                    "Agda"
+                  ]
                 ],
                 undefined
               ];
-    case "String" :
     case "Primitive" :
         return [
                 [
                   "String",
-                  []
+                  [
+                    "Primitive",
+                    "Agda"
+                  ]
                 ],
                 undefined
               ];
@@ -532,7 +339,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Struct",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -540,7 +347,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Parameter",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -548,7 +355,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Macro",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -556,7 +363,7 @@ function toTokenTypeAndModifiersAndDecoration(x) {
         return [
                 [
                   "Operator",
-                  []
+                  ["Agda"]
                 ],
                 undefined
               ];
@@ -567,6 +374,5 @@ function toTokenTypeAndModifiersAndDecoration(x) {
 
 exports.toString = toString;
 exports.parse = parse;
-exports.toDecoration = toDecoration;
 exports.toTokenTypeAndModifiersAndDecoration = toTokenTypeAndModifiersAndDecoration;
 /* No side effect */

--- a/lib/js/src/Highlighting/Highlighting__SemanticToken.bs.js
+++ b/lib/js/src/Highlighting/Highlighting__SemanticToken.bs.js
@@ -34,8 +34,8 @@ function toString(x) {
         return "event";
     case "Function" :
         return "function";
-    case "Member" :
-        return "member";
+    case "Method" :
+        return "method";
     case "Macro" :
         return "macro";
     case "Label" :
@@ -71,7 +71,7 @@ var enumurate = [
   "decorator",
   "event",
   "function",
-  "member",
+  "method",
   "macro",
   "label",
   "comment",
@@ -109,6 +109,12 @@ function toString$1(x) {
         return "documentation";
     case "DefaultLibrary" :
         return "defaultLibrary";
+    case "Agda" :
+        return "agda";
+    case "Primitive" :
+        return "primitive";
+    case "CoInductive" :
+        return "coInductive";
     
   }
 }
@@ -123,7 +129,10 @@ var enumurate$1 = [
   "async",
   "modification",
   "documentation",
-  "defaultLibrary"
+  "defaultLibrary",
+  "primitive",
+  "coInductive",
+  "agda"
 ];
 
 var TokenModifier = {

--- a/lib/js/src/Highlighting/Highlighting__SemanticToken.bs.js
+++ b/lib/js/src/Highlighting/Highlighting__SemanticToken.bs.js
@@ -8,8 +8,6 @@ function toString(x) {
   switch (x) {
     case "Namespace" :
         return "namespace";
-    case "Type" :
-        return "type";
     case "Class" :
         return "class";
     case "Enum" :
@@ -20,6 +18,8 @@ function toString(x) {
         return "struct";
     case "TypeParameter" :
         return "typeParameter";
+    case "Type" :
+        return "type";
     case "Parameter" :
         return "parameter";
     case "Variable" :
@@ -28,6 +28,8 @@ function toString(x) {
         return "property";
     case "EnumMember" :
         return "enumMember";
+    case "Decorator" :
+        return "decorator";
     case "Event" :
         return "event";
     case "Function" :
@@ -56,16 +58,17 @@ function toString(x) {
 
 var enumurate = [
   "namespace",
-  "type",
   "class",
   "enum",
   "interface",
   "struct",
   "typeParameter",
+  "type",
   "parameter",
   "variable",
   "property",
   "enumMember",
+  "decorator",
   "event",
   "function",
   "member",
@@ -88,6 +91,8 @@ function toString$1(x) {
   switch (x) {
     case "Declaration" :
         return "declaration";
+    case "Definition" :
+        return "definition";
     case "Readonly" :
         return "readonly";
     case "Static" :
@@ -110,6 +115,7 @@ function toString$1(x) {
 
 var enumurate$1 = [
   "declaration",
+  "definition",
   "readonly",
   "static",
   "deprecated",

--- a/lib/js/test/tests/Test__TokenBookkeeping.bs.js
+++ b/lib/js/test/tests/Test__TokenBookkeeping.bs.js
@@ -25,13 +25,13 @@ describe("Token Bookkeeping\n", (function () {
                 var ctx = await Test__Util$AgdaModeVscode.AgdaMode.makeAndLoad(filename);
                 await Editor$AgdaModeVscode.$$Text.insert(ctx.state.document, new Vscode.Position(6, 0), "\n");
                 var expected = [
-                  "(7:0-3) function",
-                  "(7:6-7) type",
-                  "(7:10-11) type",
-                  "(7:14-15) type",
-                  "(8:0-1) variable",
-                  "(8:2-3) function",
-                  "(8:4-5) variable"
+                  "(7:0-3) function [agda]",
+                  "(7:6-7) type [agda]",
+                  "(7:10-11) type [agda]",
+                  "(7:14-15) type [agda]",
+                  "(8:0-1) variable [agda]",
+                  "(8:2-3) function [agda]",
+                  "(8:4-5) variable [agda]"
                 ];
                 var tokens = await Resource$AgdaModeVscode.get(Tokens$AgdaModeVscode.getVSCodeTokens(ctx.state.tokens));
                 var actual = tokens.slice(12).map(Highlighting__SemanticToken$AgdaModeVscode.toString);
@@ -41,13 +41,13 @@ describe("Token Bookkeeping\n", (function () {
                 var ctx = await Test__Util$AgdaModeVscode.AgdaMode.makeAndLoad(filename);
                 await Editor$AgdaModeVscode.$$Text.$$delete(ctx.state.document, new Vscode.Range(new Vscode.Position(5, 0), new Vscode.Position(6, 0)));
                 var expected = [
-                  "(5:0-3) function",
-                  "(5:6-7) type",
-                  "(5:10-11) type",
-                  "(5:14-15) type",
-                  "(6:0-1) variable",
-                  "(6:2-3) function",
-                  "(6:4-5) variable"
+                  "(5:0-3) function [agda]",
+                  "(5:6-7) type [agda]",
+                  "(5:10-11) type [agda]",
+                  "(5:14-15) type [agda]",
+                  "(6:0-1) variable [agda]",
+                  "(6:2-3) function [agda]",
+                  "(6:4-5) variable [agda]"
                 ];
                 var tokens = await Resource$AgdaModeVscode.get(Tokens$AgdaModeVscode.getVSCodeTokens(ctx.state.tokens));
                 var actual = tokens.slice(12).map(Highlighting__SemanticToken$AgdaModeVscode.toString);
@@ -57,9 +57,9 @@ describe("Token Bookkeeping\n", (function () {
                 var ctx = await Test__Util$AgdaModeVscode.AgdaMode.makeAndLoad(filename);
                 await Editor$AgdaModeVscode.$$Text.$$delete(ctx.state.document, new Vscode.Range(new Vscode.Position(5, 0), new Vscode.Position(7, 0)));
                 var expected = [
-                  "(5:0-1) variable",
-                  "(5:2-3) function",
-                  "(5:4-5) variable"
+                  "(5:0-1) variable [agda]",
+                  "(5:2-3) function [agda]",
+                  "(5:4-5) variable [agda]"
                 ];
                 var tokens = await Resource$AgdaModeVscode.get(Tokens$AgdaModeVscode.getVSCodeTokens(ctx.state.tokens));
                 var actual = tokens.slice(12).map(Highlighting__SemanticToken$AgdaModeVscode.toString);

--- a/package.json
+++ b/package.json
@@ -64,6 +64,20 @@
 		"vscode-languageclient": "^8.0.0"
 	},
 	"contributes": {
+		"semanticTokenModifiers": [
+			{
+				"id": "agda",
+				"description": "To tag Agda Aspects and NameKinds for styling"
+			},
+			{
+				"id": "primitive",
+				"description": "To indicate that a data type or name is primitive"
+			},
+			{
+				"id": "coInductive",
+				"description": "To distinguish between inductive and coinductive constructors"
+			}
+		],
 		"languages": [
 			{
 				"id": "agda",

--- a/src/Highlighting/Highlighting__AgdaAspect.res
+++ b/src/Highlighting/Highlighting__AgdaAspect.res
@@ -130,150 +130,6 @@ let parse = x =>
   | _others => Operator
   }
 
-let toDecoration = (x: t): option<Highlighting__Decoration.t> =>
-  switch x {
-  | Hole => None
-  | Comment =>
-    Some({
-      light: Foreground("#B0B0B0"),
-      dark: Foreground("#505050"),
-    })
-  | Keyword =>
-    Some({
-      light: Foreground("#CD6600"),
-      dark: Foreground("#FF9932"),
-    })
-  | String =>
-    Some({
-      light: Foreground("#B22222"),
-      dark: Foreground("#DD4D4D"),
-    })
-  | Number =>
-    Some({
-      light: Foreground("#800080"),
-      dark: Foreground("#9010E0"),
-    })
-  | Symbol =>
-    Some({
-      light: Foreground("#404040"),
-      dark: Foreground("#BFBFBF"),
-    })
-  | PrimitiveType =>
-    Some({
-      light: Foreground("#0000CD"),
-      dark: Foreground("#8080FF"),
-    })
-  | Pragma => None
-  | Background => None
-  | Markup => None
-  | Error =>
-    Some({
-      light: Foreground("#FF0000"),
-      dark: Foreground("#FF0000"),
-    })
-  | DottedPattern => None
-  | UnsolvedMeta =>
-    Some({
-      light: Background("#FFFF00"),
-      dark: Background("#806B00"),
-    })
-  | UnsolvedConstraint =>
-    Some({
-      light: Background("#FFFF00"),
-      dark: Background("#806B00"),
-    })
-  | TerminationProblem =>
-    Some({
-      light: Background("#FFA07A"),
-      dark: Background("#802400"),
-    })
-  | PositivityProblem =>
-    Some({
-      light: Background("#CD853F"),
-      dark: Background("#803F00"),
-    })
-  | Deadcode =>
-    Some({
-      light: Background("#A9A9A9"),
-      dark: Background("#808080"),
-    })
-  | CoverageProblem =>
-    Some({
-      light: Background("#F5DEB3"),
-      dark: Background("#805300"),
-    })
-  | IncompletePattern =>
-    Some({
-      light: Background("#800080"),
-      dark: Background("#800080"),
-    })
-  | TypeChecks => None
-  | CatchallClause =>
-    Some({
-      light: Background("#F5F5F5"),
-      dark: Background("#404040"),
-    })
-  | ConfluenceProblem =>
-    Some({
-      light: Background("#FFC0CB"),
-      dark: Background("#800080"),
-    })
-  | Bound => None
-  | Generalizable => None
-  | ConstructorInductive =>
-    Some({
-      light: Foreground("#008B00"),
-      dark: Foreground("#29CC29"),
-    })
-  | ConstructorCoInductive =>
-    Some({
-      light: Foreground("#996600"),
-      dark: Foreground("#FFEA75"),
-    })
-  | Datatype =>
-    Some({
-      light: Foreground("#0000CD"),
-      dark: Foreground("#8080FF"),
-    })
-  | Field =>
-    Some({
-      light: Foreground("#EE1289"),
-      dark: Foreground("#F570B7"),
-    })
-  | Function =>
-    Some({
-      light: Foreground("#0000CD"),
-      dark: Foreground("#8080FF"),
-    })
-  | Module =>
-    Some({
-      light: Foreground("#800080"),
-      dark: Foreground("#CD80FF"),
-    })
-  | Postulate =>
-    Some({
-      light: Foreground("#0000CD"),
-      dark: Foreground("#8080FF"),
-    })
-  | Primitive =>
-    Some({
-      light: Foreground("#0000CD"),
-      dark: Foreground("#8080FF"),
-    })
-  | Record =>
-    Some({
-      light: Foreground("#0000CD"),
-      dark: Foreground("#8080FF"),
-    })
-  | Argument => None
-  | Macro =>
-    Some({
-      light: Foreground("#458B74"),
-      dark: Foreground("#73BAA2"),
-    })
-  | Operator => None
-  }
-
 let toTokenTypeAndModifiersAndDecoration: t => (
   (
     option<Highlighting__SemanticToken.TokenType.t>,
@@ -282,7 +138,10 @@ let toTokenTypeAndModifiersAndDecoration: t => (
   option<Highlighting__Decoration.t>, // background decoration colors of light/dark themes
 ) = x => {
   // helper constructor
-  let typeOnly = (t: Highlighting__SemanticToken.TokenType.t) => ((Some(t), []), None)
+  let typeOnly = (t: Highlighting__SemanticToken.TokenType.t) =>
+    ((Some(t), [Highlighting__SemanticToken.TokenModifier.Agda]), None)
+  let typeWithModifier = (t: Highlighting__SemanticToken.TokenType.t, m: Highlighting__SemanticToken.TokenModifier.t) =>
+    ((Some(t), [m, Agda]), None)
   let nothing = ((None, []), None)
   let backgroundOnly = (light, dark) => (
     (None, []),
@@ -297,12 +156,12 @@ let toTokenTypeAndModifiersAndDecoration: t => (
   | String => typeOnly(String)
   | Number => typeOnly(Number)
   | Symbol => nothing // we choose not to color Symbols for aesthetic reasons
-  | PrimitiveType => typeOnly(Type)
+  | PrimitiveType => typeWithModifier(Type, Primitive)
   | Pragma => nothing
   | Background => nothing
   | Markup => nothing
   // the OtherAspect part
-  | Error => ((None, [Deprecated]), None)
+  | Error => ((None, [Agda]), None)
   | DottedPattern => nothing
   | UnsolvedMeta => backgroundOnly("#FFFF00", "#806B00")
   | UnsolvedConstraint => backgroundOnly("#FFA07A", "#802400")
@@ -318,13 +177,13 @@ let toTokenTypeAndModifiersAndDecoration: t => (
   | Bound => typeOnly(Variable)
   | Generalizable => typeOnly(Variable)
   | ConstructorInductive => typeOnly(EnumMember)
-  | ConstructorCoInductive => typeOnly(EnumMember)
+  | ConstructorCoInductive => typeWithModifier(EnumMember, CoInductive)
   | Datatype => typeOnly(Type)
-  | Field => typeOnly(Member)
+  | Field => typeOnly(Property)
   | Function => typeOnly(Function)
   | Module => typeOnly(Namespace)
-  | Postulate => typeOnly(Function)
-  | Primitive => typeOnly(String)
+  | Postulate => typeWithModifier(Function, Abstract)
+  | Primitive => typeWithModifier(String, Primitive)
   | Record => typeOnly(Struct)
   | Argument => typeOnly(Parameter)
   | Macro => typeOnly(Macro)

--- a/src/Highlighting/Highlighting__AgdaAspect.res
+++ b/src/Highlighting/Highlighting__AgdaAspect.res
@@ -188,6 +188,6 @@ let toTokenTypeAndModifiersAndDecoration: t => (
   | Argument => typeOnly(Parameter)
   | Macro => typeOnly(Macro)
   // when the second field of Aspect.Name is True
-  | Operator => typeOnly(Operator)
+  | Operator => ((Some(Operator), []), None)
   }
 }

--- a/src/Highlighting/Highlighting__SemanticToken.res
+++ b/src/Highlighting/Highlighting__SemanticToken.res
@@ -16,7 +16,7 @@ module TokenType = {
     | Decorator
     | Event
     | Function
-    | Member
+    | Method
     | Macro
     | Label
     | Comment
@@ -42,7 +42,7 @@ module TokenType = {
     | Decorator => "decorator"
     | Event => "event"
     | Function => "function"
-    | Member => "member"
+    | Method => "method"
     | Macro => "macro"
     | Label => "label"
     | Comment => "comment"
@@ -68,7 +68,7 @@ module TokenType = {
     "decorator",
     "event",
     "function",
-    "member",
+    "method",
     "macro",
     "label",
     "comment",
@@ -94,6 +94,12 @@ module TokenModifier = {
     | Modification
     | Documentation
     | DefaultLibrary
+    // non-standard modifiers for styling purpose; see Highlighting__AgdaAspect.res
+    // -- for tagging Aspects and NameKinds
+    | Agda
+    // -- for disambiguation
+    | Primitive
+    | CoInductive
 
   let toString = x =>
     switch x {
@@ -107,6 +113,9 @@ module TokenModifier = {
     | Modification => "modification"
     | Documentation => "documentation"
     | DefaultLibrary => "defaultLibrary"
+    | Agda => "agda"
+    | Primitive => "primitive"
+    | CoInductive => "coInductive"
     }
 
   let enumurate = [
@@ -120,6 +129,9 @@ module TokenModifier = {
     "modification",
     "documentation",
     "defaultLibrary",
+    "primitive",
+    "coInductive",
+    "agda",
   ]
 }
 

--- a/src/Highlighting/Highlighting__SemanticToken.res
+++ b/src/Highlighting/Highlighting__SemanticToken.res
@@ -3,16 +3,17 @@
 module TokenType = {
   type t =
     | Namespace
-    | Type
     | Class
     | Enum
     | Interface
     | Struct
     | TypeParameter
+    | Type
     | Parameter
     | Variable
     | Property
     | EnumMember
+    | Decorator
     | Event
     | Function
     | Member
@@ -28,16 +29,17 @@ module TokenType = {
   let toString = x =>
     switch x {
     | Namespace => "namespace"
-    | Type => "type"
     | Class => "class"
     | Enum => "enum"
     | Interface => "interface"
     | Struct => "struct"
     | TypeParameter => "typeParameter"
+    | Type => "type"
     | Parameter => "parameter"
     | Variable => "variable"
     | Property => "property"
     | EnumMember => "enumMember"
+    | Decorator => "decorator"
     | Event => "event"
     | Function => "function"
     | Member => "member"
@@ -53,16 +55,17 @@ module TokenType = {
 
   let enumurate = [
     "namespace",
-    "type",
     "class",
     "enum",
     "interface",
     "struct",
     "typeParameter",
+    "type",
     "parameter",
     "variable",
     "property",
     "enumMember",
+    "decorator",
     "event",
     "function",
     "member",
@@ -82,6 +85,7 @@ module TokenType = {
 module TokenModifier = {
   type t =
     | Declaration
+    | Definition
     | Readonly
     | Static
     | Deprecated
@@ -94,6 +98,7 @@ module TokenModifier = {
   let toString = x =>
     switch x {
     | Declaration => "declaration"
+    | Definition => "definition"
     | Readonly => "readonly"
     | Static => "static"
     | Deprecated => "deprecated"
@@ -106,6 +111,7 @@ module TokenModifier = {
 
   let enumurate = [
     "declaration",
+    "definition",
     "readonly",
     "static",
     "deprecated",

--- a/test/tests/Test__TokenBookkeeping.res
+++ b/test/tests/Test__TokenBookkeeping.res
@@ -15,13 +15,13 @@ describe(
       let _ = await Editor.Text.insert(ctx.state.document, VSCode.Position.make(6, 0), "\n")
 
       let expected = [
-        "(7:0-3) function",
-        "(7:6-7) type",
-        "(7:10-11) type",
-        "(7:14-15) type",
-        "(8:0-1) variable",
-        "(8:2-3) function",
-        "(8:4-5) variable",
+        "(7:0-3) function [agda]",
+        "(7:6-7) type [agda]",
+        "(7:10-11) type [agda]",
+        "(7:14-15) type [agda]",
+        "(8:0-1) variable [agda]",
+        "(8:2-3) function [agda]",
+        "(8:4-5) variable [agda]",
       ]
 
       let tokens = await ctx.state.tokens->Tokens.getVSCodeTokens->Resource.get
@@ -40,13 +40,13 @@ describe(
       )
 
       let expected = [
-        "(5:0-3) function",
-        "(5:6-7) type",
-        "(5:10-11) type",
-        "(5:14-15) type",
-        "(6:0-1) variable",
-        "(6:2-3) function",
-        "(6:4-5) variable",
+        "(5:0-3) function [agda]",
+        "(5:6-7) type [agda]",
+        "(5:10-11) type [agda]",
+        "(5:14-15) type [agda]",
+        "(6:0-1) variable [agda]",
+        "(6:2-3) function [agda]",
+        "(6:4-5) variable [agda]",
       ]
       let tokens = await ctx.state.tokens->Tokens.getVSCodeTokens->Resource.get
       let actual =
@@ -62,7 +62,7 @@ describe(
         VSCode.Range.make(VSCode.Position.make(5, 0), VSCode.Position.make(7, 0)),
       )
 
-      let expected = ["(5:0-1) variable", "(5:2-3) function", "(5:4-5) variable"]
+      let expected = ["(5:0-1) variable [agda]", "(5:2-3) function [agda]", "(5:4-5) variable [agda]"]
       let tokens = await ctx.state.tokens->Tokens.getVSCodeTokens->Resource.get
       let actual =
         tokens->Array.sliceToEnd(~start=12)->Array.map(Highlighting__SemanticToken.toString)


### PR DESCRIPTION
As discussed in #283, I took a look if we can reproduce agda-mode's classic color scheme on Emacs side. 

First, some background: Originally the extension used decorations to specify colors for each token. It then switched to semantic tokens to improve efficiency and to adapt to the user's theme setting, and eventually the fixed color scheme was only applied to non-tokens aka "other aspects".

To dictate how to style semantic tokens, we can specify a list of styles in settings via selectors of the form `tokenType.modifier1.modifier2:language`. However, the current mapping between token types to semantic token is not injective (one-to-one). Thus this patch introduces a minimal number of modifiers to disambiguate all interesting aspects. This way, it becomes possible to color each kind of token like in Emacs while also maintaining backward compatibility.

Sample highlighting using [Emacs' fixed-color theme](https://github.com/agda/agda/blob/master/src/data/emacs-mode/agda2-highlight.el) (code taken from [the official doc.](https://agda.readthedocs.io/en/latest/language/coinduction.html#coinductive-record-constructors)):

<img width="985" height="650" src="https://github.com/user-attachments/assets/a001b15e-fa8a-4068-a6c7-4f15930c72c9" />

Note that the coinductive constructor `cons` cannot be independently styled before.

The ported theme for reference (language ID `lagda-tex` can be substituted):

<details>

<summary>(obsolete, see below)</summary>

```json
{
    "editor.semanticTokenColorCustomizations": {
        "enabled": true,
        "rules": {
            "keyword:lagda-tex": { "foreground": "#FF9932" }, 
            "string:lagda-tex": { "foreground": "#DD4D4D" }, 
            "number:lagda-tex": { "foreground": "#9010E0" }, 
            "type.primitive:lagda-tex": { "foreground": "#8080FF" }, 
            "enumMember:lagda-tex": { "foreground": "#29CC29" }, 
            "enumMember.coInductive:lagda-tex": { "foreground": "#FFEA75" },
            "type:lagda-tex": { "foreground": "#8080FF" }, 
            "member:lagda-tex": { "foreground": "#F570B7" }, 
            "function:lagda-tex": { "foreground": "#8080FF" }, 
            "namespace:lagda-tex": { "foreground": "#CD80FF" }, 
            "function.abstract:lagda-tex": { "foreground": "#8080FF" }, 
            "string.primitive:lagda-tex": { "foreground": "#8080FF" }, 
            "struct:lagda-tex": { "foreground": "#8080FF" }, 
            "macro:lagda-tex": { "foreground": "#73BAA2" }
        }
    }
}
```

</details>
