### PR TITLE
Fix some of glitches of semantic highlighting if the user edits during a request is ongoing

### DIFF
--- a/lib/js/src/Main/Main.bs.js
+++ b/lib/js/src/Main/Main.bs.js
@@ -3,6 +3,7 @@
 
 var VSCode = require("rescript-vscode/lib/js/src/VSCode.bs.js");
 var Vscode = require("vscode");
+var Caml_obj = require("rescript/lib/js/caml_obj.js");
 var Caml_option = require("rescript/lib/js/caml_option.js");
 var Core__Option = require("@rescript/core/lib/js/src/Core__Option.bs.js");
 var Caml_splice_call = require("rescript/lib/js/caml_splice_call.js");
@@ -117,13 +118,17 @@ function initialize(platformDeps, channels, extensionUri, globalStorageUri, meme
             State__InputMethod$AgdaModeVscode.select(state, intervals);
           }));
   subscribe(Vscode.workspace.onDidChangeTextDocument(function ($$event) {
-            var changes = IM$AgdaModeVscode.Input.fromTextDocumentChangeEvent(editor, $$event);
-            State__InputMethod$AgdaModeVscode.keyUpdateEditorIM(state, changes);
-            Tokens$AgdaModeVscode.applyEdit(state.tokens, editor, $$event);
-            var changes$1 = $$event.contentChanges.map(TokenChange$AgdaModeVscode.fromTextDocumentContentChangeEvent).toReversed();
-            if (changes$1.length !== 0) {
-              Goals$AgdaModeVscode.scanAllGoals(state.goals, editor, changes$1);
-              return ;
+            if (Caml_obj.equal($$event.document, editor.document)) {
+              var changes = IM$AgdaModeVscode.Input.fromTextDocumentChangeEvent(editor, $$event);
+              State__InputMethod$AgdaModeVscode.keyUpdateEditorIM(state, changes);
+              Tokens$AgdaModeVscode.applyEdit(state.tokens, editor, $$event);
+              var changesForGoals = $$event.contentChanges.map(TokenChange$AgdaModeVscode.fromTextDocumentContentChangeEvent).toReversed();
+              if (changes.length !== 0) {
+                Goals$AgdaModeVscode.scanAllGoals(state.goals, editor, changesForGoals);
+                return ;
+              } else {
+                return ;
+              }
             }
             
           }));

--- a/lib/js/src/State/State.bs.js
+++ b/lib/js/src/State/State.bs.js
@@ -92,7 +92,8 @@ function make$1(id, platformDeps, channels, globalStorageUri, extensionUri, meme
           extensionUri: extensionUri,
           memento: memento,
           channels: channels,
-          isInRefineOrGiveOperation: false
+          isInRefineOrGiveOperation: false,
+          pendingLoad: undefined
         };
 }
 

--- a/lib/js/src/State/State__Command.bs.js
+++ b/lib/js/src/State/State__Command.bs.js
@@ -56,6 +56,7 @@ async function dispatchCommand(state, command) {
                 _0: "Loading ..."
               }, []);
           await state.document.save();
+          state.pendingLoad = Editor$AgdaModeVscode.$$Text.getAll(state.document);
           var options = VSCode.TextDocumentShowOptions.make(undefined, false, undefined, undefined, undefined);
           await Vscode.window.showTextDocument(state.document, options);
           return await sendAgdaRequest("Load");

--- a/lib/js/src/State/State__Response.bs.js
+++ b/lib/js/src/State/State__Response.bs.js
@@ -205,7 +205,13 @@ async function handle$1(state, dispatchCommand, response) {
         case "ClearHighlighting" :
             return Tokens$AgdaModeVscode.reset(state.tokens);
         case "CompleteHighlightingAndMakePromptReappear" :
-            await Tokens$AgdaModeVscode.readTempFiles(state.tokens, state.editor);
+            var text = state.pendingLoad;
+            if (text !== undefined) {
+              await Tokens$AgdaModeVscode.readTempFiles(state.tokens, state.editor, text);
+            } else {
+              await Tokens$AgdaModeVscode.readTempFiles(state.tokens, state.editor, undefined);
+            }
+            state.pendingLoad = undefined;
             return Tokens$AgdaModeVscode.generateHighlighting(state.tokens, state.editor);
         default:
           return ;
@@ -213,10 +219,15 @@ async function handle$1(state, dispatchCommand, response) {
     } else {
       switch (response.TAG) {
         case "HighlightingInfoDirect" :
-            if (!state.isInRefineOrGiveOperation) {
-              return Tokens$AgdaModeVscode.insertTokens(state.tokens, state.editor, response._1);
-            } else {
+            if (state.isInRefineOrGiveOperation) {
               return ;
+            }
+            var annotations = response._1;
+            var text$1 = state.pendingLoad;
+            if (text$1 !== undefined) {
+              return Tokens$AgdaModeVscode.insertTokensWithText(state.tokens, text$1, annotations);
+            } else {
+              return Tokens$AgdaModeVscode.insertTokens(state.tokens, state.editor, annotations);
             }
         case "HighlightingInfoIndirect" :
             if (!state.isInRefineOrGiveOperation) {
@@ -237,8 +248,8 @@ async function handle$1(state, dispatchCommand, response) {
             if (path !== response._0) {
               return ;
             }
-            var text = Editor$AgdaModeVscode.$$Text.getAll(state.document);
-            var converter = Agda$AgdaModeVscode.OffsetConverter.make(text);
+            var text$2 = Editor$AgdaModeVscode.$$Text.getAll(state.document);
+            var converter = Agda$AgdaModeVscode.OffsetConverter.make(text$2);
             var offset_ = Agda$AgdaModeVscode.OffsetConverter.convert(converter, response._1 - 1 | 0);
             var point = state.document.positionAt(offset_);
             return Editor$AgdaModeVscode.Cursor.set(state.editor, point);

--- a/lib/js/src/Tokens.bs.js
+++ b/lib/js/src/Tokens.bs.js
@@ -162,9 +162,7 @@ function insertWithVSCodeOffsets(self, token) {
   
 }
 
-function insertTokens(self, editor, tokens) {
-  var $$document = editor.document;
-  var text = Editor$AgdaModeVscode.$$Text.getAll($$document);
+function insertTokensWithText(self, text, tokens) {
   var offsetConverter = Agda$AgdaModeVscode.OffsetConverter.make(text);
   tokens.forEach(function (token) {
         var start = Agda$AgdaModeVscode.OffsetConverter.convert(offsetConverter, token.start);
@@ -178,6 +176,12 @@ function insertTokens(self, editor, tokens) {
               source: token.source
             });
       });
+}
+
+function insertTokens(self, editor, tokens) {
+  var $$document = editor.document;
+  var text = Editor$AgdaModeVscode.$$Text.getAll($$document);
+  insertTokensWithText(self, text, tokens);
 }
 
 function addEmacsFilePath(self, filepath) {
@@ -194,12 +198,16 @@ function addJSONFilePath(self, filepath) {
       });
 }
 
-async function readTempFiles(self, editor) {
+async function readTempFiles(self, editor, requestText) {
   var xs = await Promise.all(self.tempFiles.map(readAndParse));
   var tokens = xs.map(function (prim) {
           return prim[1];
         }).flat();
-  insertTokens(self, editor, tokens);
+  if (requestText !== undefined) {
+    insertTokensWithText(self, requestText, tokens);
+  } else {
+    insertTokens(self, editor, tokens);
+  }
   self.tempFiles = [];
 }
 
@@ -458,6 +466,7 @@ var Module = {
   readTempFiles: readTempFiles,
   insertWithVSCodeOffsets: insertWithVSCodeOffsets,
   insertTokens: insertTokens,
+  insertTokensWithText: insertTokensWithText,
   reset: reset,
   destroyUpdateChannel: destroyUpdateChannel,
   goToDefinition: goToDefinition,
@@ -486,6 +495,7 @@ exports.addJSONFilePath = addJSONFilePath;
 exports.readTempFiles = readTempFiles;
 exports.insertWithVSCodeOffsets = insertWithVSCodeOffsets;
 exports.insertTokens = insertTokens;
+exports.insertTokensWithText = insertTokensWithText;
 exports.reset = reset;
 exports.destroyUpdateChannel = destroyUpdateChannel;
 exports.goToDefinition = goToDefinition;

--- a/src/Main/Main.res
+++ b/src/Main/Main.res
@@ -123,23 +123,33 @@ let initialize = (
 
     State__InputMethod.select(state, intervals)->ignore
   })->subscribe
+
   VSCode.Workspace.onDidChangeTextDocument(event => {
-    // update the input method accordingly
-    let changes = IM.Input.fromTextDocumentChangeEvent(editor, event)
-    State__InputMethod.keyUpdateEditorIM(state, changes)->ignore
-    // updates positions of semantic highlighting tokens accordingly
-    state.tokens->Tokens.applyEdit(editor, event)
-    // updates positions of goals accordingly
-    let changes =
-      event
-      ->VSCode.TextDocumentChangeEvent.contentChanges
-      ->Array.map(TokenChange.fromTextDocumentContentChangeEvent)
-      ->Array.toReversed
-    if Array.length(changes) != 0 {
-      state.goals->Goals.scanAllGoals(editor, changes)->Promise.done
+    let handleTextDocumentChange = (event: VSCode.TextDocumentChangeEvent.t) => {
+      // update the input method accordingly
+      let changes = IM.Input.fromTextDocumentChangeEvent(editor, event)
+      State__InputMethod.keyUpdateEditorIM(state, changes)->ignore
+
+      // updates positions of semantic highlighting tokens accordingly
+      state.tokens->Tokens.applyEdit(editor, event)
+
+      // updates positions of goals accordingly
+      let changesForGoals = event
+        ->VSCode.TextDocumentChangeEvent.contentChanges
+        ->Array.map(TokenChange.fromTextDocumentContentChangeEvent)
+        ->Array.toReversed
+
+      if Array.length(changes) != 0 {
+        state.goals->Goals.scanAllGoals(editor, changesForGoals)->Promise.done
+      }
+
+      // state.highlighting->Highlighting.updateSemanticHighlighting(event)->Promise.done
     }
 
-    // state.highlighting->Highlighting.updateSemanticHighlighting(event)->Promise.done
+    // only apply changes that matches the editor
+    if (event->VSCode.TextDocumentChangeEvent.document == VSCode.TextEditor.document(editor)) {
+      handleTextDocumentChange(event)
+    }
   })->subscribe
 
   // definition provider for go-to-definition

--- a/src/State/State.res
+++ b/src/State/State.res
@@ -76,6 +76,8 @@ type t = {
   // Skip HighlightingInfo during refine & give operations because Agda sends faulty token positions
   // that conflict with the extension's correctly calculated positions.
   mutable isInRefineOrGiveOperation: bool,
+  // the text when the request is emitted
+  mutable pendingLoad: option<string>,
 }
 
 let make = (
@@ -108,6 +110,7 @@ let make = (
   memento,
   channels,
   isInRefineOrGiveOperation: false,
+  pendingLoad: None,
 }
 
 // construction/destruction

--- a/src/State/State__Command.res
+++ b/src/State/State__Command.res
@@ -20,6 +20,8 @@ let rec dispatchCommand = async (state: State.t, command): unit => {
     await State__View.Panel.display(state, Plain("Loading ..."), [])
     // save the document before loading
     let _ = await VSCode.TextDocument.save(state.document)
+    // snapshot the current document
+    state.pendingLoad = Some(Editor.Text.getAll(state.document))
     // Issue #26 - don't load the document in preview mode
     let options = Some(VSCode.TextDocumentShowOptions.make(~preview=false, ()))
     let _ = await VSCode.Window.showTextDocumentWithShowOptions(state.document, options)

--- a/src/State/State__Response.res
+++ b/src/State/State__Response.res
@@ -99,7 +99,10 @@ let rec handle = async (
     switch response {
     | HighlightingInfoDirect(_keep, annotations) =>
       if !state.isInRefineOrGiveOperation {
-        state.tokens->Tokens.insertTokens(state.editor, annotations)
+        switch state.pendingLoad {
+        | Some(text) => state.tokens->Tokens.insertTokensWithText(text, annotations)
+        | None => state.tokens->Tokens.insertTokens(state.editor, annotations)
+        }
       }
     | HighlightingInfoIndirect(filepath) =>
       if !state.isInRefineOrGiveOperation {
@@ -312,7 +315,11 @@ let rec handle = async (
       await State__View.DebugBuffer.displayInAppendMode([(verbosity, message)])
     | CompleteHighlightingAndMakePromptReappear =>
       // apply decoration before handling Last Responses
-      await Tokens.readTempFiles(state.tokens, state.editor)
+      switch state.pendingLoad {
+      | Some(text) => await Tokens.readTempFiles(state.tokens, state.editor, ~requestText=text)
+      | None => await Tokens.readTempFiles(state.tokens, state.editor)
+      }
+      state.pendingLoad = None
       // generate highlighting
       state.tokens->Tokens.generateHighlighting(state.editor)
     | _ => ()

--- a/src/Tokens.res
+++ b/src/Tokens.res
@@ -17,9 +17,10 @@ module type Module = {
   // Receive tokens from Agda
   let addEmacsFilePath: (t, string) => unit
   let addJSONFilePath: (t, string) => unit
-  let readTempFiles: (t, VSCode.TextEditor.t) => promise<unit>
+  let readTempFiles: (t, VSCode.TextEditor.t, ~requestText: string=?) => promise<unit>
   let insertWithVSCodeOffsets: (t, Token.t<vscodeOffset>) => unit
   let insertTokens: (t, VSCode.TextEditor.t, array<Token.t<agdaOffset>>) => unit
+  let insertTokensWithText: (t, string, array<Token.t<agdaOffset>>) => unit
 
   // Remove everything
   let reset: t => unit
@@ -201,18 +202,15 @@ module Module: Module = {
     }
   }
 
-  // insert a bunch of Tokens
+  // insert a bunch of Tokens referring from the given snapshot
   // merge Aspects with the existing Token that occupies the same Range
-  let insertTokens = (self, editor, tokens: array<Token.t<agdaOffset>>) => {
-    let document = editor->VSCode.TextEditor.document
-    let text = Editor.Text.getAll(document)
+  let insertTokensWithText = (self, text, tokens: array<Token.t<agdaOffset>>) => {
     let offsetConverter = Agda.OffsetConverter.make(text)
-    
+
     tokens->Array.forEach(token => {
       let start = Agda.OffsetConverter.convert(offsetConverter, token.start)
       let end = Agda.OffsetConverter.convert(offsetConverter, token.end)
-      
-      
+
       insertWithVSCodeOffsets(
         self,
         {
@@ -224,15 +222,24 @@ module Module: Module = {
     })
   }
 
+  let insertTokens = (self, editor, tokens: array<Token.t<agdaOffset>>) => {
+    let document = editor->VSCode.TextEditor.document
+    let text = Editor.Text.getAll(document)
+    insertTokensWithText(self, text, tokens)
+  }
+
   let addEmacsFilePath = (self, filepath) => self.tempFiles->Array.push(TempFile.Emacs(filepath))
   let addJSONFilePath = (self, filepath) => self.tempFiles->Array.push(TempFile.JSON(filepath))
 
   // read temp files and add Tokens added from "addEmacsFilePath" or "addJSONFilePath"
-  let readTempFiles = async (self, editor) => {
+  let readTempFiles = async (self, editor, ~requestText=?) => {
     // read and parse and concat them
     let xs = await self.tempFiles->Array.map(TempFile.readAndParse)->Promise.all
     let tokens = xs->Array.map(snd)->Array.flat
-    insertTokens(self, editor, tokens)
+    switch requestText {
+    | Some(text) => insertTokensWithText(self, text, tokens)
+    | None => insertTokens(self, editor, tokens)
+    }
     self.tempFiles = []
   }
 


### PR DESCRIPTION
Note: This PR is derived from code written by Codex, but is rewritten and annotated by me.

If you edit the buffer between a request is emitted and the response is received, the token highlighting will be off. The reason is that the offset is converted against the new document. This PR fixes that by recording the old document and changes until the highlighting response is returned. We can then reply the delta to yield the correct highlight.

With this snapshot + delta technique, we should be able to fix more glitches including hole-expansion like #264. (Codex struggles but I believe that human can make it!)

edit: Codex actually did not fix anything...
