### PR TITLE
Integrate ALS WASM Loader's library management API

### DIFF
--- a/lib/js/src/Connection/Binding/WASMLoader.bs.js
+++ b/lib/js/src/Connection/Binding/WASMLoader.bs.js
@@ -51,20 +51,27 @@ async function downloadStdlib() {
   }
 }
 
+function libsDescToLines(desc) {
+  return desc.paths.map(function (path) {
+                return desc.base + "/" + path + "\n";
+              }).join("");
+}
+
 async function make(extension, raw) {
   var $$exports = extension.exports;
   var agdaLanguageServerFactory = $$exports.AgdaLanguageServerFactory;
   var wasmAPILoader = $$exports.WasmAPILoader;
   var createUriConverters = $$exports.createUriConverters;
   var memfsUnzip = $$exports.memfsUnzip;
+  var listInstalledLibraries = $$exports.listInstalledLibraries;
   var wasm = wasmAPILoader.load();
   var mod = await WebAssembly.compile(raw);
   var factory = createFactory(agdaLanguageServerFactory, wasm, mod);
-  var memfs = memfsAgdaDataDirCache.contents;
+  var cached = memfsAgdaDataDirCache.contents;
   var match;
-  if (memfs !== undefined) {
+  if (cached !== undefined) {
     match = [
-      Caml_option.valFromOption(memfs),
+      Caml_option.valFromOption(cached),
       {
         TAG: "Ok",
         _0: undefined
@@ -72,47 +79,53 @@ async function make(extension, raw) {
     ];
   } else {
     var memfsAgdaDataDir = await wasm.createMemoryFileSystem();
-    var err = await downloadStdlib();
     var stdlibSetupResult;
-    if (err.TAG === "Ok") {
-      try {
-        await memfsUnzip(memfsAgdaDataDir, err._0);
+    if (listInstalledLibraries !== undefined) {
+      stdlibSetupResult = {
+        TAG: "Ok",
+        _0: undefined
+      };
+    } else {
+      var err = await downloadStdlib();
+      if (err.TAG === "Ok") {
+        try {
+          await memfsUnzip(memfsAgdaDataDir, err._0);
+          memfsAgdaDataDirCache.contents = Caml_option.some(memfsAgdaDataDir);
+          stdlibSetupResult = {
+            TAG: "Ok",
+            _0: undefined
+          };
+        }
+        catch (raw_err){
+          var err$1 = Caml_js_exceptions.internalToOCamlException(raw_err);
+          if (err$1.RE_EXN_ID === Js_exn.$$Error) {
+            stdlibSetupResult = {
+              TAG: "Error",
+              _0: [
+                "Error unzipping downloaded archive.",
+                err$1._1
+              ]
+            };
+          } else {
+            throw err$1;
+          }
+        }
+      } else {
         stdlibSetupResult = {
-          TAG: "Ok",
-          _0: undefined
+          TAG: "Error",
+          _0: err._0
         };
       }
-      catch (raw_err){
-        var err$1 = Caml_js_exceptions.internalToOCamlException(raw_err);
-        if (err$1.RE_EXN_ID === Js_exn.$$Error) {
-          stdlibSetupResult = {
-            TAG: "Error",
-            _0: [
-              "Error unzipping downloaded archive.",
-              err$1._1
-            ]
-          };
-        } else {
-          throw err$1;
-        }
-      }
-    } else {
-      stdlibSetupResult = {
-        TAG: "Error",
-        _0: err._0
-      };
     }
-    memfsAgdaDataDirCache.contents = Caml_option.some(memfsAgdaDataDir);
     match = [
       memfsAgdaDataDir,
       stdlibSetupResult
     ];
   }
   var stdlibSetupResult$1 = match[1];
-  var desc = await $$exports.listInstalledLibraries();
-  var libsContent = desc.paths.map(function (path) {
-          return desc.base + "/" + path + "\n";
-        }).join("");
+  var libsContent = await Core__Option.mapOr(listInstalledLibraries, Promise.resolve("/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n"), (function (fn) {
+          return fn().then(libsDescToLines);
+        }));
   var presetupCallback = async function (param) {
     var memfsHome = param.memfsHome;
     var memfsSetupResult;
@@ -121,7 +134,7 @@ async function make(extension, raw) {
         memfsHome.createDirectory(".config");
         memfsHome.createDirectory(".config/agda");
         ((function(memfsHome, createFile, libsContent) {
-            const content = new TextEncoder().encode('/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n' + libsContent);
+            const content = new TextEncoder().encode(libsContent);
             createFile(memfsHome, '.config/agda/libraries', {
               size: BigInt(content.length),
               reader: () => Promise.resolve(content)
@@ -173,5 +186,6 @@ exports.memfsAgdaDataDirCache = memfsAgdaDataDirCache;
 exports.createFile = createFile;
 exports.createFactory = createFactory;
 exports.downloadStdlib = downloadStdlib;
+exports.libsDescToLines = libsDescToLines;
 exports.make = make;
 /* isDesktop Not a pure module */

--- a/lib/js/src/Connection/Binding/WASMLoader.bs.js
+++ b/lib/js/src/Connection/Binding/WASMLoader.bs.js
@@ -3,8 +3,15 @@
 
 var Js_exn = require("rescript/lib/js/js_exn.js");
 var Vscode = require("vscode");
+var Caml_option = require("rescript/lib/js/caml_option.js");
 var Core__Option = require("@rescript/core/lib/js/src/Core__Option.bs.js");
 var Caml_js_exceptions = require("rescript/lib/js/caml_js_exceptions.js");
+
+var isDesktop = (Vscode.env.uiKind === Vscode.UIKind.Desktop);
+
+var memfsAgdaDataDirCache = {
+  contents: undefined
+};
 
 var createFile = (function(memfs, path, options) {
     memfs.createFile(path, options);
@@ -14,7 +21,12 @@ var createFactory = (function(constructor, wasm, mod) { return new constructor(w
 
 async function downloadStdlib() {
   try {
-    var response = await fetch("https://raw.githubusercontent.com/banacorn/agda-library-proxy/master/agda-stdlib-2.3.zip", {});
+    var response = await fetch("https://raw.githubusercontent.com/banacorn/agda-library-proxy/master/agda-stdlib-2.3.zip", isDesktop ? ({
+              method: "GET",
+              headers: Caml_option.some(new Headers({
+                        "User-Agent": "agda-mode-vscode"
+                      }))
+            }) : ({}));
     if (response.ok) {
       return {
               TAG: "Ok",
@@ -48,51 +60,73 @@ async function make(extension, raw) {
   var wasm = wasmAPILoader.load();
   var mod = await WebAssembly.compile(raw);
   var factory = createFactory(agdaLanguageServerFactory, wasm, mod);
-  var memfsAgdaDataDir = await wasm.createMemoryFileSystem();
-  var err = await downloadStdlib();
-  var stdlibSetupResult;
-  if (err.TAG === "Ok") {
-    try {
-      await memfsUnzip(memfsAgdaDataDir, err._0);
-      stdlibSetupResult = {
+  var memfs = memfsAgdaDataDirCache.contents;
+  var match;
+  if (memfs !== undefined) {
+    match = [
+      Caml_option.valFromOption(memfs),
+      {
         TAG: "Ok",
         _0: undefined
+      }
+    ];
+  } else {
+    var memfsAgdaDataDir = await wasm.createMemoryFileSystem();
+    var err = await downloadStdlib();
+    var stdlibSetupResult;
+    if (err.TAG === "Ok") {
+      try {
+        await memfsUnzip(memfsAgdaDataDir, err._0);
+        stdlibSetupResult = {
+          TAG: "Ok",
+          _0: undefined
+        };
+      }
+      catch (raw_err){
+        var err$1 = Caml_js_exceptions.internalToOCamlException(raw_err);
+        if (err$1.RE_EXN_ID === Js_exn.$$Error) {
+          stdlibSetupResult = {
+            TAG: "Error",
+            _0: [
+              "Error unzipping downloaded archive.",
+              err$1._1
+            ]
+          };
+        } else {
+          throw err$1;
+        }
+      }
+    } else {
+      stdlibSetupResult = {
+        TAG: "Error",
+        _0: err._0
       };
     }
-    catch (raw_err){
-      var err$1 = Caml_js_exceptions.internalToOCamlException(raw_err);
-      if (err$1.RE_EXN_ID === Js_exn.$$Error) {
-        stdlibSetupResult = {
-          TAG: "Error",
-          _0: [
-            "Error unzipping downloaded archive.",
-            err$1._1
-          ]
-        };
-      } else {
-        throw err$1;
-      }
-    }
-  } else {
-    stdlibSetupResult = {
-      TAG: "Error",
-      _0: err._0
-    };
+    memfsAgdaDataDirCache.contents = Caml_option.some(memfsAgdaDataDir);
+    match = [
+      memfsAgdaDataDir,
+      stdlibSetupResult
+    ];
   }
+  var stdlibSetupResult$1 = match[1];
+  var desc = await $$exports.listInstalledLibraries();
+  var libsContent = desc.paths.map(function (path) {
+          return desc.base + "/" + path + "\n";
+        }).join("");
   var presetupCallback = async function (param) {
     var memfsHome = param.memfsHome;
     var memfsSetupResult;
-    if (stdlibSetupResult.TAG === "Ok") {
+    if (stdlibSetupResult$1.TAG === "Ok") {
       try {
         memfsHome.createDirectory(".config");
         memfsHome.createDirectory(".config/agda");
-        ((function(memfsHome, createFile) {
-            const content = new TextEncoder().encode('/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n');
+        ((function(memfsHome, createFile, libsContent) {
+            const content = new TextEncoder().encode('/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n' + libsContent);
             createFile(memfsHome, '.config/agda/libraries', {
               size: BigInt(content.length),
               reader: () => Promise.resolve(content)
             });
-          })(memfsHome, createFile));
+          })(memfsHome, createFile, libsContent));
         memfsSetupResult = {
           TAG: "Ok",
           _0: undefined
@@ -115,7 +149,7 @@ async function make(extension, raw) {
     } else {
       memfsSetupResult = {
         TAG: "Error",
-        _0: stdlibSetupResult._0
+        _0: stdlibSetupResult$1._0
       };
     }
     if (memfsSetupResult.TAG === "Ok") {
@@ -128,14 +162,16 @@ async function make(extension, raw) {
   return {
           factory: factory,
           wasm: wasm,
-          memfsAgdaDataDir: memfsAgdaDataDir,
+          memfsAgdaDataDir: match[0],
           createUriConverters: createUriConverters,
           presetupCallback: presetupCallback
         };
 }
 
+exports.isDesktop = isDesktop;
+exports.memfsAgdaDataDirCache = memfsAgdaDataDirCache;
 exports.createFile = createFile;
 exports.createFactory = createFactory;
 exports.downloadStdlib = downloadStdlib;
 exports.make = make;
-/* vscode Not a pure module */
+/* isDesktop Not a pure module */

--- a/lib/js/src/Connection/Binding/WASMLoader.bs.js
+++ b/lib/js/src/Connection/Binding/WASMLoader.bs.js
@@ -81,6 +81,7 @@ async function make(extension, raw) {
     var memfsAgdaDataDir = await wasm.createMemoryFileSystem();
     var stdlibSetupResult;
     if (listInstalledLibraries !== undefined) {
+      memfsAgdaDataDirCache.contents = Caml_option.some(memfsAgdaDataDir);
       stdlibSetupResult = {
         TAG: "Ok",
         _0: undefined
@@ -90,7 +91,6 @@ async function make(extension, raw) {
       if (err.TAG === "Ok") {
         try {
           await memfsUnzip(memfsAgdaDataDir, err._0);
-          memfsAgdaDataDirCache.contents = Caml_option.some(memfsAgdaDataDir);
           stdlibSetupResult = {
             TAG: "Ok",
             _0: undefined
@@ -128,18 +128,19 @@ async function make(extension, raw) {
         }));
   var presetupCallback = async function (param) {
     var memfsHome = param.memfsHome;
+    var doCreateFile = ((memfsHome, createFile) => (path, content) =>
+        createFile(memfsHome, path, new TextEncoder().encode(content)))(memfsHome, createFile);
     var memfsSetupResult;
     if (stdlibSetupResult$1.TAG === "Ok") {
       try {
         memfsHome.createDirectory(".config");
         memfsHome.createDirectory(".config/agda");
-        ((function(memfsHome, createFile, libsContent) {
-            const content = new TextEncoder().encode(libsContent);
-            createFile(memfsHome, '.config/agda/libraries', {
-              size: BigInt(content.length),
-              reader: () => Promise.resolve(content)
-            });
-          })(memfsHome, createFile, libsContent));
+        doCreateFile(".config/agda/libraries", libsContent);
+        if (listInstalledLibraries !== undefined) {
+          
+        } else {
+          doCreateFile(".config/agda/defaults", "standard-library");
+        }
         memfsSetupResult = {
           TAG: "Ok",
           _0: undefined

--- a/src/Connection/Binding/WASMLoader.res
+++ b/src/Connection/Binding/WASMLoader.res
@@ -16,6 +16,12 @@ type presetupCallbackArgs = {
 }
 type presetupCallback = presetupCallbackArgs => promise<unit>
 
+type installedLibrariesDesc = {
+  base: string,
+  prefix: string,
+  paths: array<string>,
+}
+
 // Setup result type
 type t = {
   factory: agdaLanguageServerFactory,
@@ -30,6 +36,10 @@ type t = {
 @send external createMemoryFileSystem: wasmAPI => promise<memoryFileSystem> = "createMemoryFileSystem"
 @send external bytes: Fetch.Response.t => promise<Uint8Array.t> = "bytes"
 @send external createDirectory: (memoryFileSystem, string) => unit = "createDirectory"
+@send external listInstalledLibraries: unit => promise<installedLibrariesDesc> = "listInstalledLibraries"
+
+let isDesktop = %raw("Vscode.env.uiKind === Vscode.UIKind.Desktop")
+let memfsAgdaDataDirCache = ref(None)
 
 let createFile: (memoryFileSystem, string, 'a) => unit = %raw(`
   function(memfs, path, options) {
@@ -44,11 +54,12 @@ let downloadStdlib = async () => {
   try {
     let response = await Fetch.fetch(
       "https://raw.githubusercontent.com/banacorn/agda-library-proxy/master/agda-stdlib-2.3.zip",
+      isDesktop ? {
+        method: #GET,
+        headers: Fetch.Headers.make(Fetch.Headers.Init.object({"User-Agent": "agda-mode-vscode"})),
+      } :
       // Cannot send additional headers because GitHub responds 403 to the CORS preflight request
-      {
-        // method: #GET,
-        // headers: Fetch.Headers.make(Fetch.Headers.Init.object({"User-Agent": "agda-mode-vscode"})),
-      },
+      {},
     )
     if Fetch.Response.ok(response) {
       Ok(await bytes(response))
@@ -70,19 +81,33 @@ let make = async (extension, raw: Uint8Array.t) => {
   let wasm = wasmAPILoader->load
   let mod = await WebAssembly.compile(raw)
   let factory = createFactory(agdaLanguageServerFactory, wasm, mod)
-  let memfsAgdaDataDir = await wasm->createMemoryFileSystem
 
-  // Populate memfsAgdaDataDir with standard library using extension's memfsUnzip
-  let stdlibSetupResult = switch await downloadStdlib() {
-  | Error(err) => Error(err)
-  | Ok(zipData) =>
-      try {
-        let _ = await memfsUnzip(memfsAgdaDataDir, zipData)
-        Ok()
-      } catch {
-      | Exn.Error(err) => Error(("Error unzipping downloaded archive.", err))
+  let (memfsAgdaDataDir, stdlibSetupResult) = {
+    switch memfsAgdaDataDirCache.contents {
+    | Some(memfs) => (memfs, Ok())
+    | None => {
+      let memfsAgdaDataDir = await wasm->createMemoryFileSystem
+
+      // Populate memfsAgdaDataDir with standard library using extension's memfsUnzip
+      let stdlibSetupResult = switch await downloadStdlib() {
+      | Error(err) => Error(err)
+      | Ok(zipData) =>
+        try {
+          let _ = await memfsUnzip(memfsAgdaDataDir, zipData)
+          Ok()
+        } catch {
+        | Exn.Error(err) => Error(("Error unzipping downloaded archive.", err))
+        }
       }
+
+      memfsAgdaDataDirCache.contents = Some(memfsAgdaDataDir)
+      (memfsAgdaDataDir, stdlibSetupResult)
+    }
+    }
   }
+
+  let desc = await exports["listInstalledLibraries"]()
+  let libsContent = desc.paths->Array.map(path => desc.base ++ "/" ++ path ++ "\n")->Array.join("")
 
   // Setup libraries file in memfsHome pointing to stdlib
   let presetupCallback = async ({memfsTempDir: _, memfsHome}) => {
@@ -93,14 +118,14 @@ let make = async (extension, raw: Uint8Array.t) => {
         createDirectory(memfsHome, ".config")
         createDirectory(memfsHome, ".config/agda")
         let _ = %raw(`
-          function(memfsHome, createFile) {
-            const content = new TextEncoder().encode('/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n');
+          function(memfsHome, createFile, libsContent) {
+            const content = new TextEncoder().encode('/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n' + libsContent);
             createFile(memfsHome, '.config/agda/libraries', {
               size: BigInt(content.length),
               reader: () => Promise.resolve(content)
             });
           }
-        `)(memfsHome, createFile)
+        `)(memfsHome, createFile, libsContent)
         Ok()
       } catch {
       | Exn.Error(err) => Error(("Error extract unzipped content to memfs.", err))

--- a/src/Connection/Binding/WASMLoader.res
+++ b/src/Connection/Binding/WASMLoader.res
@@ -36,7 +36,6 @@ type t = {
 @send external createMemoryFileSystem: wasmAPI => promise<memoryFileSystem> = "createMemoryFileSystem"
 @send external bytes: Fetch.Response.t => promise<Uint8Array.t> = "bytes"
 @send external createDirectory: (memoryFileSystem, string) => unit = "createDirectory"
-@send external listInstalledLibraries: unit => promise<installedLibrariesDesc> = "listInstalledLibraries"
 
 let isDesktop = %raw("Vscode.env.uiKind === Vscode.UIKind.Desktop")
 let memfsAgdaDataDirCache = ref(None)
@@ -71,12 +70,16 @@ let downloadStdlib = async () => {
   }
 }
 
+let libsDescToLines = (desc: installedLibrariesDesc) =>
+  desc.paths->Array.map(path => desc.base ++ "/" ++ path ++ "\n")->Array.join("")
+
 let make = async (extension, raw: Uint8Array.t) => {
   let exports = VSCode.Extension.exports(extension)
   let agdaLanguageServerFactory: agdaLanguageServerFactory = exports["AgdaLanguageServerFactory"]
   let wasmAPILoader: wasmAPILoader = exports["WasmAPILoader"]
   let createUriConverters = exports["createUriConverters"]
   let memfsUnzip: (memoryFileSystem, Uint8Array.t) => promise<memoryFileSystem> = exports["memfsUnzip"]
+  let listInstalledLibraries: option<unit => promise<installedLibrariesDesc>> = exports["listInstalledLibraries"]
 
   let wasm = wasmAPILoader->load
   let mod = await WebAssembly.compile(raw)
@@ -84,30 +87,38 @@ let make = async (extension, raw: Uint8Array.t) => {
 
   let (memfsAgdaDataDir, stdlibSetupResult) = {
     switch memfsAgdaDataDirCache.contents {
-    | Some(memfs) => (memfs, Ok())
+    | Some(cached) => (cached, Ok())
     | None => {
       let memfsAgdaDataDir = await wasm->createMemoryFileSystem
 
+      let stdlibSetupResult = switch listInstalledLibraries {
+      // skip if having library management support
+      | Some(_) => Ok()
+
       // Populate memfsAgdaDataDir with standard library using extension's memfsUnzip
-      let stdlibSetupResult = switch await downloadStdlib() {
-      | Error(err) => Error(err)
-      | Ok(zipData) =>
-        try {
-          let _ = await memfsUnzip(memfsAgdaDataDir, zipData)
-          Ok()
-        } catch {
-        | Exn.Error(err) => Error(("Error unzipping downloaded archive.", err))
+      | None => switch await downloadStdlib() {
+        | Error(err) => Error(err)
+        | Ok(zipData) =>
+          try {
+            let _ = await memfsUnzip(memfsAgdaDataDir, zipData)
+            memfsAgdaDataDirCache.contents = Some(memfsAgdaDataDir)
+            Ok()
+          } catch {
+          | Exn.Error(err) => Error(("Error unzipping downloaded archive.", err))
+          }
         }
       }
 
-      memfsAgdaDataDirCache.contents = Some(memfsAgdaDataDir)
       (memfsAgdaDataDir, stdlibSetupResult)
     }
     }
   }
 
-  let desc = await exports["listInstalledLibraries"]()
-  let libsContent = desc.paths->Array.map(path => desc.base ++ "/" ++ path ++ "\n")->Array.join("")
+  let libsContent: string = await listInstalledLibraries->Option.mapOr(
+    // for older ALS WASM loader that does not support library management,
+    // provide the only entry stdlib-2.3 from `downloadStdlib`
+    Promise.resolve("/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n"),
+    fn => fn()->Promise.thenResolve(libsDescToLines))
 
   // Setup libraries file in memfsHome pointing to stdlib
   let presetupCallback = async ({memfsTempDir: _, memfsHome}) => {
@@ -119,7 +130,7 @@ let make = async (extension, raw: Uint8Array.t) => {
         createDirectory(memfsHome, ".config/agda")
         let _ = %raw(`
           function(memfsHome, createFile, libsContent) {
-            const content = new TextEncoder().encode('/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n' + libsContent);
+            const content = new TextEncoder().encode(libsContent);
             createFile(memfsHome, '.config/agda/libraries', {
               size: BigInt(content.length),
               reader: () => Promise.resolve(content)

--- a/src/Connection/Binding/WASMLoader.res
+++ b/src/Connection/Binding/WASMLoader.res
@@ -93,7 +93,10 @@ let make = async (extension, raw: Uint8Array.t) => {
 
       let stdlibSetupResult = switch listInstalledLibraries {
       // skip if having library management support
-      | Some(_) => Ok()
+      | Some(_) => {
+        memfsAgdaDataDirCache.contents = Some(memfsAgdaDataDir)
+        Ok()
+      }
 
       // Populate memfsAgdaDataDir with standard library using extension's memfsUnzip
       | None => switch await downloadStdlib() {
@@ -101,7 +104,8 @@ let make = async (extension, raw: Uint8Array.t) => {
         | Ok(zipData) =>
           try {
             let _ = await memfsUnzip(memfsAgdaDataDir, zipData)
-            memfsAgdaDataDirCache.contents = Some(memfsAgdaDataDir)
+            // NOTE: Do not save cache in this path;
+            // older ALS WASM Loader will stuck on setup process with unknown reason
             Ok()
           } catch {
           | Exn.Error(err) => Error(("Error unzipping downloaded archive.", err))
@@ -115,28 +119,30 @@ let make = async (extension, raw: Uint8Array.t) => {
   }
 
   let libsContent: string = await listInstalledLibraries->Option.mapOr(
-    // for older ALS WASM loader that does not support library management,
+    // For older ALS WASM loader that does not support library management,
     // provide the only entry stdlib-2.3 from `downloadStdlib`
     Promise.resolve("/opt/agda/agda-stdlib-2.3/standard-library.agda-lib\n"),
     fn => fn()->Promise.thenResolve(libsDescToLines))
 
   // Setup libraries file in memfsHome pointing to stdlib
   let presetupCallback = async ({memfsTempDir: _, memfsHome}) => {
+    let doCreateFile: (string, string) => unit = %raw(`
+      (memfsHome, createFile) => (path, content) =>
+        createFile(memfsHome, path, new TextEncoder().encode(content))
+    `)(memfsHome, createFile)
+
     let memfsSetupResult = switch stdlibSetupResult {
     | Error(err) => Error(err)
     | Ok() =>
       try {
         createDirectory(memfsHome, ".config")
         createDirectory(memfsHome, ".config/agda")
-        let _ = %raw(`
-          function(memfsHome, createFile, libsContent) {
-            const content = new TextEncoder().encode(libsContent);
-            createFile(memfsHome, '.config/agda/libraries', {
-              size: BigInt(content.length),
-              reader: () => Promise.resolve(content)
-            });
-          }
-        `)(memfsHome, createFile, libsContent)
+
+        doCreateFile(".config/agda/libraries", libsContent)
+        switch listInstalledLibraries {
+        | None => doCreateFile(".config/agda/defaults", "standard-library")
+        | _ => ()
+        }
         Ok()
       } catch {
       | Exn.Error(err) => Error(("Error extract unzipped content to memfs.", err))


### PR DESCRIPTION
* Requires ALS WASM Loader v0.8.0. [The diff to the added API.](https://github.com/andy0130tw/vscode-als-wasm-loader/compare/v0.7.2...v0.8.0)
* Care has been taken to ensure compatibility with Loader v0.7.2.
