### PR TITLE
Add structured events for connection lifecycle flows

### DIFF
--- a/lib/js/src/Connection/Connection__Candidate.bs.js
+++ b/lib/js/src/Connection/Connection__Candidate.bs.js
@@ -208,31 +208,45 @@ function isUnderDirectory(candidate, directory) {
   }
 }
 
-async function resolve(findCommand, candidate) {
+async function resolve(findCommand, candidate, onCandidateResolveStartedOpt, onCandidateResolvedOpt, onCandidateResolveFailedOpt) {
+  var onCandidateResolveStarted = onCandidateResolveStartedOpt !== undefined ? onCandidateResolveStartedOpt : (function (param) {
+        
+      });
+  var onCandidateResolved = onCandidateResolvedOpt !== undefined ? onCandidateResolvedOpt : (function (param, param$1) {
+        
+      });
+  var onCandidateResolveFailed = onCandidateResolveFailedOpt !== undefined ? onCandidateResolveFailedOpt : (function (param, param$1) {
+        
+      });
+  onCandidateResolveStarted(candidate);
   if (candidate.TAG === "Command") {
     var path = await findCommand(candidate._0, undefined);
-    if (path.TAG !== "Ok") {
+    if (path.TAG === "Ok") {
+      var match = Connection__URI$AgdaModeVscode.parse(path._0);
+      var uri = match._1;
+      var resolved = {
+        original: candidate,
+        resource: uri
+      };
+      onCandidateResolved(candidate, uri);
       return {
-              TAG: "Error",
-              _0: path._0
+              TAG: "Ok",
+              _0: resolved
             };
     }
-    var match = Connection__URI$AgdaModeVscode.parse(path._0);
-    var resolved_resource = match._1;
-    var resolved = {
-      original: candidate,
-      resource: resolved_resource
-    };
+    var error = path._0;
+    onCandidateResolveFailed(candidate, error);
     return {
-            TAG: "Ok",
-            _0: resolved
+            TAG: "Error",
+            _0: error
           };
   }
-  var resolved_resource$1 = candidate._0;
+  var uri$1 = candidate._0;
   var resolved$1 = {
     original: candidate,
-    resource: resolved_resource$1
+    resource: uri$1
   };
+  onCandidateResolved(candidate, uri$1);
   return {
           TAG: "Ok",
           _0: resolved$1

--- a/lib/js/src/Connection/Connection__Core.bs.js
+++ b/lib/js/src/Connection/Connection__Core.bs.js
@@ -355,9 +355,12 @@ async function probeCandidate(platformDeps, candidate, onProbeFlowOpt) {
       };
 }
 
-async function makeResolved(resolved, source, pathForErrorsOpt) {
+async function makeResolved(resolved, source, pathForErrorsOpt, onProbeFlowOpt) {
   var pathForErrors = pathForErrorsOpt !== undefined ? pathForErrorsOpt : resolvedPathForErrors(resolved);
-  var error = await probeResolved(resolved, undefined);
+  var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
+  var error = await probeResolved(resolved, onProbeFlow);
   if (error.TAG !== "Ok") {
     return {
             TAG: "Error",
@@ -498,7 +501,7 @@ async function makeResolved(resolved, source, pathForErrorsOpt) {
 }
 
 async function make(rawpath, source) {
-  return await makeResolved(resolvedFromRawResource(rawpath), source, undefined);
+  return await makeResolved(resolvedFromRawResource(rawpath), source, undefined, undefined);
 }
 
 async function tryUntilSuccess(xs) {
@@ -524,8 +527,28 @@ async function tryUntilSuccess(xs) {
   return await loop(xs, []);
 }
 
-async function tryCandidate(platformDeps, candidate, source) {
-  var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, undefined, undefined, undefined);
+async function tryCandidate(platformDeps, candidate, source, onProbeFlowOpt) {
+  var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
+  var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, (function (c) {
+          onProbeFlow({
+                TAG: "CandidateResolveStarted",
+                _0: c
+              });
+        }), (function (original, resource) {
+          onProbeFlow({
+                TAG: "CandidateResolved",
+                _0: original,
+                _1: resource
+              });
+        }), (function (original, commandError) {
+          onProbeFlow({
+                TAG: "CandidateResolveFailed",
+                _0: original,
+                _1: commandError
+              });
+        }));
   if (resolved.TAG === "Ok") {
     var resolved$1 = resolved._0;
     var command = resolved$1.original;
@@ -534,7 +557,7 @@ async function tryCandidate(platformDeps, candidate, source) {
           TAG: "FromCommandLookup",
           _0: command._0
         }) : source;
-    return await makeResolved(resolved$1, resolvedSource, undefined);
+    return await makeResolved(resolved$1, resolvedSource, undefined, onProbeFlow);
   }
   if (candidate.TAG === "Command") {
     return {
@@ -549,12 +572,15 @@ async function tryCandidate(platformDeps, candidate, source) {
       };
 }
 
-async function fromPathsOrCommands(platformDeps, entries) {
+async function fromPathsOrCommands(platformDeps, entries, onProbeFlowOpt) {
+  var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
   var tasks = entries.map(function (param) {
         var source = param[1];
         var candidate = Connection__Candidate$AgdaModeVscode.make(param[0]);
         return function () {
-          return tryCandidate(platformDeps, candidate, source);
+          return tryCandidate(platformDeps, candidate, source, onProbeFlow);
         };
       });
   var connection = await tryUntilSuccess(tasks);
@@ -915,7 +941,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
                 "FromConfig"
               ];
       });
-  var connection = await fromPathsOrCommands(platformDeps, preferredEntries);
+  var connection = await fromPathsOrCommands(platformDeps, preferredEntries, undefined);
   if (connection.TAG === "Ok") {
     var connection$1 = connection._0;
     logConnection(connection$1);
@@ -924,7 +950,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
             _0: connection$1
           };
   }
-  var connection$2 = await fromPathsOrCommands(platformDeps, pathsWithSource);
+  var connection$2 = await fromPathsOrCommands(platformDeps, pathsWithSource, undefined);
   if (connection$2.TAG === "Ok") {
     var connection$3 = connection$2._0;
     logConnection(connection$3);

--- a/lib/js/src/Connection/Connection__Core.bs.js
+++ b/lib/js/src/Connection/Connection__Core.bs.js
@@ -151,11 +151,22 @@ function resolvedFromRawResource(raw) {
         };
 }
 
-async function probeResolved(resolved) {
+async function probeResolved(resolved, onProbeFlowOpt) {
+  var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
   var resource = resolved.resource;
+  onProbeFlow({
+        TAG: "ProbeStarted",
+        _0: resource
+      });
   var resourceString = resource.toString();
+  var pathKey = resolvedPathForErrors(resolved);
   if (resourceString.endsWith(".wasm")) {
-    var pathKey = resource.scheme === "file" ? resource.fsPath : resourceString;
+    onProbeFlow({
+          TAG: "ProbeClassifiedAsALSWASM",
+          _0: pathKey
+        });
     return {
             TAG: "Ok",
             _0: [
@@ -169,105 +180,144 @@ async function probeResolved(resolved) {
   }
   var fsPath = resource.fsPath;
   var result = await Connection__Process__Exec$AgdaModeVscode.run(fsPath, ["--version"], 3000, undefined);
-  if (result.TAG !== "Ok") {
-    return {
-            TAG: "Error",
-            _0: {
-              TAG: "CannotDetermineAgdaOrALS",
-              _0: result._0
+  if (result.TAG === "Ok") {
+    var output = result._0;
+    var match = output.match(/Agda version (.*)/);
+    var exit = 0;
+    if ((match == null) || match.length !== 2) {
+      exit = 1;
+    } else {
+      var version = match[1];
+      if (version !== undefined) {
+        onProbeFlow({
+              TAG: "ProbeClassifiedAsAgda",
+              _0: fsPath,
+              _1: version
+            });
+        return {
+                TAG: "Ok",
+                _0: [
+                  fsPath,
+                  {
+                    TAG: "IsAgda",
+                    _0: version
+                  }
+                ]
+              };
+      }
+      exit = 1;
+    }
+    if (exit === 1) {
+      var match$1 = output.match(/Agda v(.*) Language Server v(.*)/);
+      var exit$1 = 0;
+      if ((match$1 == null) || match$1.length !== 3) {
+        exit$1 = 2;
+      } else {
+        var agdaVersion = match$1[1];
+        if (agdaVersion !== undefined) {
+          var alsVersion = match$1[2];
+          if (alsVersion !== undefined) {
+            onProbeFlow({
+                  TAG: "ProbeClassifiedAsALS",
+                  _0: fsPath,
+                  _1: alsVersion,
+                  _2: agdaVersion
+                });
+            var assetPath = await checkForPrebuiltDataDirectory(fsPath);
+            var lspOptions;
+            if (assetPath !== undefined) {
+              var env = Object.fromEntries([[
+                      "Agda_datadir",
+                      assetPath
+                    ]]);
+              lspOptions = {
+                env: env
+              };
+            } else {
+              lspOptions = undefined;
             }
-          };
-  }
-  var output = result._0;
-  var match = output.match(/Agda version (.*)/);
-  if (!(match == null) && match.length === 2) {
-    var version = match[1];
-    if (version !== undefined) {
-      return {
-              TAG: "Ok",
-              _0: [
-                fsPath,
-                {
-                  TAG: "IsAgda",
-                  _0: version
-                }
-              ]
-            };
+            return {
+                    TAG: "Ok",
+                    _0: [
+                      fsPath,
+                      {
+                        TAG: "IsALS",
+                        _0: alsVersion,
+                        _1: agdaVersion,
+                        _2: lspOptions
+                      }
+                    ]
+                  };
+          }
+          exit$1 = 2;
+        } else {
+          exit$1 = 2;
+        }
+      }
+      if (exit$1 === 2) {
+        var error = {
+          TAG: "NotAgdaOrALS",
+          _0: output
+        };
+        onProbeFlow({
+              TAG: "ProbeFailed",
+              _0: pathKey,
+              _1: error
+            });
+        return {
+                TAG: "Error",
+                _0: error
+              };
+      }
+      
     }
     
-  }
-  var match$1 = output.match(/Agda v(.*) Language Server v(.*)/);
-  if (match$1 == null) {
-    return {
-            TAG: "Error",
-            _0: {
-              TAG: "NotAgdaOrALS",
-              _0: output
-            }
-          };
-  }
-  if (match$1.length !== 3) {
-    return {
-            TAG: "Error",
-            _0: {
-              TAG: "NotAgdaOrALS",
-              _0: output
-            }
-          };
-  }
-  var agdaVersion = match$1[1];
-  if (agdaVersion === undefined) {
-    return {
-            TAG: "Error",
-            _0: {
-              TAG: "NotAgdaOrALS",
-              _0: output
-            }
-          };
-  }
-  var alsVersion = match$1[2];
-  if (alsVersion === undefined) {
-    return {
-            TAG: "Error",
-            _0: {
-              TAG: "NotAgdaOrALS",
-              _0: output
-            }
-          };
-  }
-  var assetPath = await checkForPrebuiltDataDirectory(fsPath);
-  var lspOptions;
-  if (assetPath !== undefined) {
-    var env = Object.fromEntries([[
-            "Agda_datadir",
-            assetPath
-          ]]);
-    lspOptions = {
-      env: env
-    };
   } else {
-    lspOptions = undefined;
+    var probeError = {
+      TAG: "CannotDetermineAgdaOrALS",
+      _0: result._0
+    };
+    onProbeFlow({
+          TAG: "ProbeFailed",
+          _0: pathKey,
+          _1: probeError
+        });
+    return {
+            TAG: "Error",
+            _0: probeError
+          };
   }
-  return {
-          TAG: "Ok",
-          _0: [
-            fsPath,
-            {
-              TAG: "IsALS",
-              _0: alsVersion,
-              _1: agdaVersion,
-              _2: lspOptions
-            }
-          ]
-        };
 }
 
-async function probeFilepath(path) {
-  return await probeResolved(resolvedFromRawResource(path));
+async function probeFilepath(path, onProbeFlowOpt) {
+  var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
+  return await probeResolved(resolvedFromRawResource(path), onProbeFlow);
 }
 
-async function probeCandidate(platformDeps, candidate) {
-  var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate);
+async function probeCandidate(platformDeps, candidate, onProbeFlowOpt) {
+  var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
+  var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, (function (candidate) {
+          onProbeFlow({
+                TAG: "CandidateResolveStarted",
+                _0: candidate
+              });
+        }), (function (original, resource) {
+          onProbeFlow({
+                TAG: "CandidateResolved",
+                _0: original,
+                _1: resource
+              });
+        }), (function (original, commandError) {
+          onProbeFlow({
+                TAG: "CandidateResolveFailed",
+                _0: original,
+                _1: commandError
+              });
+        }));
   if (resolved.TAG === "Ok") {
     var resolved$1 = resolved._0;
     var command = resolved$1.original;
@@ -276,7 +326,7 @@ async function probeCandidate(platformDeps, candidate) {
           TAG: "FromCommandLookup",
           _0: command._0
         }) : "FromConfig";
-    var error = await probeResolved(resolved$1);
+    var error = await probeResolved(resolved$1, onProbeFlow);
     if (error.TAG === "Ok") {
       return {
               TAG: "Ok",
@@ -307,7 +357,7 @@ async function probeCandidate(platformDeps, candidate) {
 
 async function makeResolved(resolved, source, pathForErrorsOpt) {
   var pathForErrors = pathForErrorsOpt !== undefined ? pathForErrorsOpt : resolvedPathForErrors(resolved);
-  var error = await probeResolved(resolved);
+  var error = await probeResolved(resolved, undefined);
   if (error.TAG !== "Ok") {
     return {
             TAG: "Error",
@@ -475,7 +525,7 @@ async function tryUntilSuccess(xs) {
 }
 
 async function tryCandidate(platformDeps, candidate, source) {
-  var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate);
+  var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, undefined, undefined, undefined);
   if (resolved.TAG === "Ok") {
     var resolved$1 = resolved._0;
     var command = resolved$1.original;

--- a/lib/js/src/Connection/Connection__Core.bs.js
+++ b/lib/js/src/Connection/Connection__Core.bs.js
@@ -572,14 +572,23 @@ async function tryCandidate(platformDeps, candidate, source, onProbeFlowOpt) {
       };
 }
 
-async function fromPathsOrCommands(platformDeps, entries, onProbeFlowOpt) {
+async function fromPathsOrCommands(platformDeps, entries, onProbeFlowOpt, onEstablishFlowOpt) {
   var onProbeFlow = onProbeFlowOpt !== undefined ? onProbeFlowOpt : (function (param) {
+        
+      });
+  var onEstablishFlow = onEstablishFlowOpt !== undefined ? onEstablishFlowOpt : (function (param) {
         
       });
   var tasks = entries.map(function (param) {
         var source = param[1];
-        var candidate = Connection__Candidate$AgdaModeVscode.make(param[0]);
+        var raw = param[0];
+        var candidate = Connection__Candidate$AgdaModeVscode.make(raw);
         return function () {
+          onEstablishFlow({
+                TAG: "CandidateAttempted",
+                _0: raw,
+                _1: source
+              });
           return tryCandidate(platformDeps, candidate, source, onProbeFlow);
         };
       });
@@ -597,16 +606,26 @@ async function fromPathsOrCommands(platformDeps, entries, onProbeFlowOpt) {
   }
 }
 
-async function fromDownloads(platformDeps, memento, globalStorageUri) {
-  var platform = await platformDeps.determinePlatform();
-  if (platform.TAG !== "Ok") {
+async function fromDownloads(platformDeps, memento, globalStorageUri, onEstablishFlowOpt) {
+  var onEstablishFlow = onEstablishFlowOpt !== undefined ? onEstablishFlowOpt : (function (param) {
+        
+      });
+  var failDownloadFallback = function (error) {
+    onEstablishFlow({
+          TAG: "DownloadFallbackFailed",
+          _0: error
+        });
     return {
             TAG: "Error",
-            _0: Connection__Error$AgdaModeVscode.Establish.fromDownloadError({
-                  TAG: "PlatformNotSupported",
-                  _0: platform._0
-                })
+            _0: error
           };
+  };
+  var platform = await platformDeps.determinePlatform();
+  if (platform.TAG !== "Ok") {
+    return failDownloadFallback(Connection__Error$AgdaModeVscode.Establish.fromDownloadError({
+                    TAG: "PlatformNotSupported",
+                    _0: platform._0
+                  }));
   }
   var platform$1 = platform._0;
   var policy;
@@ -636,6 +655,11 @@ async function fromDownloads(platformDeps, memento, globalStorageUri) {
           var s = Memento$AgdaModeVscode.Module.SelectedChannel.get(memento);
           channel = s !== undefined ? Core__Option.getOr(Connection__Download__Channel$AgdaModeVscode.fromString(s), "DevALS") : "DevALS";
         }
+        onEstablishFlow({
+              TAG: "DownloadFallbackStarted",
+              _0: channel,
+              _1: Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.fromDownloadPlatform(platform$1)
+            });
         var wasmFallbackSource = {
           contents: undefined
         };
@@ -791,10 +815,7 @@ async function fromDownloads(platformDeps, memento, globalStorageUri) {
           }
         }
         if (downloadResult.TAG !== "Ok") {
-          return {
-                  TAG: "Error",
-                  _0: downloadResult._0
-                };
+          return failDownloadFallback(downloadResult._0);
         }
         var match = downloadResult._0;
         var source$1 = match[1];
@@ -808,25 +829,19 @@ async function fromDownloads(platformDeps, memento, globalStorageUri) {
         }
         var nativeError = connection._0;
         if (path$1.endsWith(".wasm")) {
-          return {
-                  TAG: "Error",
-                  _0: {
-                    probes: nativeError.probes,
-                    commands: nativeError.commands,
-                    download: "Succeeded"
-                  }
-                };
+          return failDownloadFallback({
+                      probes: nativeError.probes,
+                      commands: nativeError.commands,
+                      download: "Succeeded"
+                    });
         }
         var wasmPath = await tryWasmFallback(path$1, source$1);
         if (wasmPath.TAG !== "Ok") {
-          return {
-                  TAG: "Error",
-                  _0: {
-                    probes: nativeError.probes,
-                    commands: nativeError.commands,
-                    download: "Succeeded"
-                  }
-                };
+          return failDownloadFallback({
+                      probes: nativeError.probes,
+                      commands: nativeError.commands,
+                      download: "Succeeded"
+                    });
         }
         var connection$1 = await make(wasmPath._0, source$1);
         if (connection$1.TAG === "Ok") {
@@ -836,32 +851,50 @@ async function fromDownloads(platformDeps, memento, globalStorageUri) {
                 };
         }
         var wasmError = connection$1._0;
-        return {
-                TAG: "Error",
-                _0: Connection__Error$AgdaModeVscode.Establish.merge({
-                      probes: nativeError.probes,
-                      commands: nativeError.commands,
-                      download: "Succeeded"
-                    }, {
-                      probes: wasmError.probes,
-                      commands: wasmError.commands,
-                      download: "Succeeded"
-                    })
-              };
+        return failDownloadFallback(Connection__Error$AgdaModeVscode.Establish.merge({
+                        probes: nativeError.probes,
+                        commands: nativeError.commands,
+                        download: "Succeeded"
+                      }, {
+                        probes: wasmError.probes,
+                        commands: wasmError.commands,
+                        download: "Succeeded"
+                      }));
     case "No" :
     case "Undecided" :
         break;
     
   }
   await Config$AgdaModeVscode.Connection.DownloadPolicy.set("No");
-  return {
-          TAG: "Error",
-          _0: Connection__Error$AgdaModeVscode.Establish.fromDownloadError("OptedNotToDownload")
-        };
+  return failDownloadFallback(Connection__Error$AgdaModeVscode.Establish.fromDownloadError("OptedNotToDownload"));
 }
 
 async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, _commands, logChannel) {
   var logConnection = function (connection) {
+    var establishKind;
+    switch (connection.TAG) {
+      case "Agda" :
+          establishKind = "Agda";
+          break;
+      case "ALS" :
+          establishKind = "ALS";
+          break;
+      case "ALSWASM" :
+          establishKind = "ALSWASM";
+          break;
+      
+    }
+    Chan$AgdaModeVscode.emit(logChannel, {
+          TAG: "Connection",
+          _0: {
+            TAG: "EstablishFlow",
+            _0: {
+              TAG: "ConnectionEstablished",
+              _0: getPath(connection),
+              _1: establishKind
+            }
+          }
+        });
     switch (connection.TAG) {
       case "Agda" :
           return Chan$AgdaModeVscode.emit(logChannel, {
@@ -928,6 +961,15 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
     }
   };
   var preferredCandidate = Memento$AgdaModeVscode.Module.PreferredCandidate.get(memento);
+  var onEstablishFlow = function ($$event) {
+    Chan$AgdaModeVscode.emit(logChannel, {
+          TAG: "Connection",
+          _0: {
+            TAG: "EstablishFlow",
+            _0: $$event
+          }
+        });
+  };
   var preferredEntries = preferredCandidate !== undefined ? [[
         preferredCandidate,
         "FromConfig"
@@ -941,7 +983,12 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
                 "FromConfig"
               ];
       });
-  var connection = await fromPathsOrCommands(platformDeps, preferredEntries, undefined);
+  var configCandidateCount = preferredEntries.length + pathsWithSource.length | 0;
+  onEstablishFlow({
+        TAG: "ConfigCandidatesStarted",
+        _0: configCandidateCount
+      });
+  var connection = await fromPathsOrCommands(platformDeps, preferredEntries, undefined, onEstablishFlow);
   if (connection.TAG === "Ok") {
     var connection$1 = connection._0;
     logConnection(connection$1);
@@ -950,7 +997,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
             _0: connection$1
           };
   }
-  var connection$2 = await fromPathsOrCommands(platformDeps, pathsWithSource, undefined);
+  var connection$2 = await fromPathsOrCommands(platformDeps, pathsWithSource, undefined, onEstablishFlow);
   if (connection$2.TAG === "Ok") {
     var connection$3 = connection$2._0;
     logConnection(connection$3);
@@ -959,32 +1006,34 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
             _0: connection$3
           };
   }
+  onEstablishFlow("ConfigCandidatesFailed");
   var pathErrors = Connection__Error$AgdaModeVscode.Establish.mergeMany([
         connection._0,
         connection$2._0
       ]);
-  var connection$4 = await fromDownloads(platformDeps, memento, globalStorageUri);
-  if (connection$4.TAG !== "Ok") {
+  var connection$4 = await fromDownloads(platformDeps, memento, globalStorageUri, onEstablishFlow);
+  if (connection$4.TAG === "Ok") {
+    var connection$5 = connection$4._0;
+    logConnection(connection$5);
+    var downloadedPath = getPath(connection$5);
+    if (!paths.includes(downloadedPath)) {
+      await Config$AgdaModeVscode.Connection.setAgdaPaths(logChannel, [downloadedPath].concat(paths));
+    }
     return {
-            TAG: "Error",
-            _0: {
-              TAG: "Establish",
-              _0: Connection__Error$AgdaModeVscode.Establish.mergeMany([
-                    pathErrors,
-                    connection$4._0
-                  ])
-            }
+            TAG: "Ok",
+            _0: connection$5
           };
   }
-  var connection$5 = connection$4._0;
-  logConnection(connection$5);
-  var downloadedPath = getPath(connection$5);
-  if (!paths.includes(downloadedPath)) {
-    await Config$AgdaModeVscode.Connection.setAgdaPaths(logChannel, [downloadedPath].concat(paths));
-  }
+  onEstablishFlow("ConnectionEstablishFailed");
   return {
-          TAG: "Ok",
-          _0: connection$5
+          TAG: "Error",
+          _0: {
+            TAG: "Establish",
+            _0: Connection__Error$AgdaModeVscode.Establish.mergeMany([
+                  pathErrors,
+                  connection$4._0
+                ])
+          }
         };
 }
 

--- a/lib/js/src/Connection/Connection__Core.bs.js
+++ b/lib/js/src/Connection/Connection__Core.bs.js
@@ -889,7 +889,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
           _0: {
             TAG: "EstablishFlow",
             _0: {
-              TAG: "ConnectionEstablished",
+              TAG: "ConnectionCreated",
               _0: getPath(connection),
               _1: establishKind
             }
@@ -994,7 +994,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
       });
   var configCandidateCount = preferredEntries.length + pathsWithSource.length | 0;
   onEstablishFlow({
-        TAG: "ConfigCandidatesStarted",
+        TAG: "ConfigCandidatesPlanned",
         _0: configCandidateCount
       });
   var connection = await fromPathsOrCommands(platformDeps, preferredEntries, onProbeFlow, onEstablishFlow);

--- a/lib/js/src/Connection/Connection__Core.bs.js
+++ b/lib/js/src/Connection/Connection__Core.bs.js
@@ -970,6 +970,15 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
           }
         });
   };
+  var onProbeFlow = function ($$event) {
+    Chan$AgdaModeVscode.emit(logChannel, {
+          TAG: "Connection",
+          _0: {
+            TAG: "ProbeFlow",
+            _0: $$event
+          }
+        });
+  };
   var preferredEntries = preferredCandidate !== undefined ? [[
         preferredCandidate,
         "FromConfig"
@@ -988,7 +997,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
         TAG: "ConfigCandidatesStarted",
         _0: configCandidateCount
       });
-  var connection = await fromPathsOrCommands(platformDeps, preferredEntries, undefined, onEstablishFlow);
+  var connection = await fromPathsOrCommands(platformDeps, preferredEntries, onProbeFlow, onEstablishFlow);
   if (connection.TAG === "Ok") {
     var connection$1 = connection._0;
     logConnection(connection$1);
@@ -997,7 +1006,7 @@ async function makeWithFallback(platformDeps, memento, globalStorageUri, paths, 
             _0: connection$1
           };
   }
-  var connection$2 = await fromPathsOrCommands(platformDeps, pathsWithSource, undefined, onEstablishFlow);
+  var connection$2 = await fromPathsOrCommands(platformDeps, pathsWithSource, onProbeFlow, onEstablishFlow);
   if (connection$2.TAG === "Ok") {
     var connection$3 = connection$2._0;
     logConnection(connection$3);

--- a/lib/js/src/Connection/Connection__Switch.bs.js
+++ b/lib/js/src/Connection/Connection__Switch.bs.js
@@ -333,10 +333,19 @@ async function switchAgdaVersion(state, selectedPath) {
         TAG: "Plain",
         _0: "Switching connection..."
       }, []);
+  var onProbeFlow = function ($$event) {
+    Chan$AgdaModeVscode.emit(state.channels.log, {
+          TAG: "Connection",
+          _0: {
+            TAG: "ProbeFlow",
+            _0: $$event
+          }
+        });
+  };
   var conn = await Connection__Core$AgdaModeVscode.fromPathsOrCommands(state.platformDeps, [[
           selectedPath,
           "FromConfig"
-        ]]);
+        ]], onProbeFlow);
   if (conn.TAG === "Ok") {
     var conn$1 = conn._0;
     Util$AgdaModeVscode.log("[ debug ] switchAgdaVersion: connection succeeded", Connection__Core$AgdaModeVscode.toString(conn$1));

--- a/lib/js/src/Connection/Connection__Switch.bs.js
+++ b/lib/js/src/Connection/Connection__Switch.bs.js
@@ -4,6 +4,7 @@
 var Nodepath = require("node:path");
 var Caml_option = require("rescript/lib/js/caml_option.js");
 var Core__Array = require("@rescript/core/lib/js/src/Core__Array.bs.js");
+var Chan$AgdaModeVscode = require("../Util/Chan.bs.js");
 var Item$AgdaModeVscode = require("../View/Component/Item.bs.js");
 var Util$AgdaModeVscode = require("../Util/Util.bs.js");
 var Config$AgdaModeVscode = require("../Config.bs.js");
@@ -94,7 +95,8 @@ function inferCandidateKind(raw) {
 function make(state) {
   return {
           memento: state.memento,
-          globalStorageUri: state.globalStorageUri
+          globalStorageUri: state.globalStorageUri,
+          logChannel: state.channels.log
         };
 }
 
@@ -117,7 +119,7 @@ async function getItemData(self, downloadItems, downloadHeaderOpt, platformDepsO
     if (platformDeps === undefined) {
       return command;
     }
-    var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate);
+    var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, undefined, undefined, undefined);
     if (resolved.TAG !== "Ok") {
       return command;
     }
@@ -131,7 +133,7 @@ async function getItemData(self, downloadItems, downloadHeaderOpt, platformDepsO
             var resolvedMetadata;
             if (candidate.TAG === "Command") {
               if (platformDeps !== undefined) {
-                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate);
+                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, undefined, undefined, undefined);
                 resolvedMetadata = resolved.TAG === "Ok" ? Memento$AgdaModeVscode.Module.ResolvedMetadata.get(self.memento, resolved._0) : undefined;
               } else {
                 resolvedMetadata = undefined;
@@ -163,9 +165,18 @@ async function probeVersions(self, platformDeps) {
   if (pathsToProbe.length === 0) {
     return false;
   }
+  var onProbeFlow = function ($$event) {
+    Chan$AgdaModeVscode.emit(self.logChannel, {
+          TAG: "Connection",
+          _0: {
+            TAG: "ProbeFlow",
+            _0: $$event
+          }
+        });
+  };
   var probePromises = pathsToProbe.map(async function (path) {
         var candidate = Connection__Candidate$AgdaModeVscode.make(path);
-        var error = await Connection__Core$AgdaModeVscode.probeCandidate(platformDeps, candidate);
+        var error = await Connection__Core$AgdaModeVscode.probeCandidate(platformDeps, candidate, onProbeFlow);
         if (error.TAG === "Ok") {
           var match = error._0;
           var agdaVersion = match[1];
@@ -241,7 +252,7 @@ async function probeVersions(self, platformDeps) {
                 TAG: "Establish",
                 _0: error._0
               });
-          var resolved$1 = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate);
+          var resolved$1 = await Connection__Candidate$AgdaModeVscode.resolve(platformDeps.findCommand, candidate, undefined, undefined, undefined);
           if (resolved$1.TAG === "Ok") {
             await Memento$AgdaModeVscode.Module.ResolvedMetadata.setError(self.memento, resolved$1._0, match$4[1]);
           }

--- a/lib/js/src/Connection/Connection__Switch.bs.js
+++ b/lib/js/src/Connection/Connection__Switch.bs.js
@@ -351,6 +351,15 @@ async function switchAgdaVersion(state, selectedPath) {
           }
         });
   };
+  var onSwitchUIFlow = function ($$event) {
+    Chan$AgdaModeVscode.emit(state.channels.log, {
+          TAG: "Connection",
+          _0: {
+            TAG: "SwitchUIFlow",
+            _0: $$event
+          }
+        });
+  };
   var establishKind = function (connection) {
     switch (connection.TAG) {
       case "Agda" :
@@ -362,84 +371,108 @@ async function switchAgdaVersion(state, selectedPath) {
       
     }
   };
+  onSwitchUIFlow({
+        TAG: "SwitchRequested",
+        _0: selectedPath
+      });
   var conn = await Connection__Core$AgdaModeVscode.fromPathsOrCommands(state.platformDeps, [[
           selectedPath,
           "FromConfig"
         ]], onProbeFlow, onEstablishFlow);
   if (conn.TAG === "Ok") {
     var conn$1 = conn._0;
-    onEstablishFlow({
-          TAG: "ConnectionEstablished",
-          _0: Connection__Core$AgdaModeVscode.getPath(conn$1),
-          _1: establishKind(conn$1)
-        });
-    Util$AgdaModeVscode.log("[ debug ] switchAgdaVersion: connection succeeded", Connection__Core$AgdaModeVscode.toString(conn$1));
-    await Registry__Connection$AgdaModeVscode.shutdown();
-    await Memento$AgdaModeVscode.Module.PreferredCandidate.set(state.memento, selectedPath);
-    await State__View$AgdaModeVscode.Panel.displayConnectionStatus(state, conn$1);
-    await State__View$AgdaModeVscode.Panel.display(state, {
-          TAG: "Success",
-          _0: "Switched to " + Connection__Core$AgdaModeVscode.toString(conn$1)
-        }, []);
-    switch (conn$1.TAG) {
-      case "Agda" :
-          var resolved = resolvedFromConnectionPath(conn$1._1);
-          await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, resolved, {
-                TAG: "Agda",
-                _0: conn$1._2
-              });
-          break;
-      case "ALS" :
-          var match = conn$1._2;
-          var v = match.alsVersion;
-          if (v !== undefined) {
-            var resolved$1 = resolvedFromConnectionPath(conn$1._1);
-            await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, resolved$1, {
-                  TAG: "ALS",
-                  _0: "Native",
-                  _1: [
-                    v,
-                    match.agdaVersion,
-                    match.lspOptions
-                  ]
+    try {
+      Util$AgdaModeVscode.log("[ debug ] switchAgdaVersion: connection succeeded", Connection__Core$AgdaModeVscode.toString(conn$1));
+      await Registry__Connection$AgdaModeVscode.shutdown();
+      await Memento$AgdaModeVscode.Module.PreferredCandidate.set(state.memento, selectedPath);
+      await State__View$AgdaModeVscode.Panel.displayConnectionStatus(state, conn$1);
+      await State__View$AgdaModeVscode.Panel.display(state, {
+            TAG: "Success",
+            _0: "Switched to " + Connection__Core$AgdaModeVscode.toString(conn$1)
+          }, []);
+      switch (conn$1.TAG) {
+        case "Agda" :
+            var resolved = resolvedFromConnectionPath(conn$1._1);
+            await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, resolved, {
+                  TAG: "Agda",
+                  _0: conn$1._2
                 });
-          }
-          break;
-      case "ALSWASM" :
-          var match$1 = conn$1._3;
-          var v$1 = match$1.alsVersion;
-          if (v$1 !== undefined) {
-            var resolved$2 = resolvedFromConnectionPath(conn$1._2);
-            await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, resolved$2, {
-                  TAG: "ALS",
-                  _0: "WASM",
-                  _1: [
-                    v$1,
-                    match$1.agdaVersion,
-                    match$1.lspOptions
-                  ]
-                });
-          }
-          break;
-      
+            break;
+        case "ALS" :
+            var match = conn$1._2;
+            var v = match.alsVersion;
+            if (v !== undefined) {
+              var resolved$1 = resolvedFromConnectionPath(conn$1._1);
+              await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, resolved$1, {
+                    TAG: "ALS",
+                    _0: "Native",
+                    _1: [
+                      v,
+                      match.agdaVersion,
+                      match.lspOptions
+                    ]
+                  });
+            }
+            break;
+        case "ALSWASM" :
+            var match$1 = conn$1._3;
+            var v$1 = match$1.alsVersion;
+            if (v$1 !== undefined) {
+              var resolved$2 = resolvedFromConnectionPath(conn$1._2);
+              await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, resolved$2, {
+                    TAG: "ALS",
+                    _0: "WASM",
+                    _1: [
+                      v$1,
+                      match$1.agdaVersion,
+                      match$1.lspOptions
+                    ]
+                  });
+            }
+            break;
+        
+      }
+      onEstablishFlow({
+            TAG: "ConnectionEstablished",
+            _0: Connection__Core$AgdaModeVscode.getPath(conn$1),
+            _1: establishKind(conn$1)
+          });
+      onSwitchUIFlow({
+            TAG: "SwitchSucceeded",
+            _0: Connection__Core$AgdaModeVscode.getPath(conn$1)
+          });
+      await Connection__Core$AgdaModeVscode.destroy(conn$1, state.channels.log);
+      return ;
     }
-    await Connection__Core$AgdaModeVscode.destroy(conn$1, state.channels.log);
-    return ;
+    catch (exn){
+      onEstablishFlow("ConnectionEstablishFailed");
+      onSwitchUIFlow({
+            TAG: "SwitchFailed",
+            _0: selectedPath
+          });
+      await Connection__Core$AgdaModeVscode.destroy(conn$1, state.channels.log);
+      throw exn;
+    }
+  } else {
+    onSwitchUIFlow({
+          TAG: "SwitchFailed",
+          _0: selectedPath
+        });
+    onEstablishFlow("ConnectionEstablishFailed");
+    var match$2 = Connection__Error$AgdaModeVscode.toString({
+          TAG: "Establish",
+          _0: conn._0
+        });
+    var errorBody = match$2[1];
+    var errorHeader = match$2[0];
+    Util$AgdaModeVscode.log("[ debug ] switchAgdaVersion: connection failed", errorHeader + " | " + errorBody);
+    var header = {
+      TAG: "Error",
+      _0: "Failed to switch to a different installation: " + errorHeader
+    };
+    var body = [Item$AgdaModeVscode.plainText(errorBody)];
+    return await State__View$AgdaModeVscode.Panel.display(state, header, body);
   }
-  onEstablishFlow("ConnectionEstablishFailed");
-  var match$2 = Connection__Error$AgdaModeVscode.toString({
-        TAG: "Establish",
-        _0: conn._0
-      });
-  var errorBody = match$2[1];
-  var errorHeader = match$2[0];
-  Util$AgdaModeVscode.log("[ debug ] switchAgdaVersion: connection failed", errorHeader + " | " + errorBody);
-  var header = {
-    TAG: "Error",
-    _0: "Failed to switch to a different installation: " + errorHeader
-  };
-  var body = [Item$AgdaModeVscode.plainText(errorBody)];
-  return await State__View$AgdaModeVscode.Panel.display(state, header, body);
 }
 
 async function getPlaceholderDownloadItems(platformDeps) {

--- a/lib/js/src/Connection/Connection__Switch.bs.js
+++ b/lib/js/src/Connection/Connection__Switch.bs.js
@@ -342,12 +342,37 @@ async function switchAgdaVersion(state, selectedPath) {
           }
         });
   };
+  var onEstablishFlow = function ($$event) {
+    Chan$AgdaModeVscode.emit(state.channels.log, {
+          TAG: "Connection",
+          _0: {
+            TAG: "EstablishFlow",
+            _0: $$event
+          }
+        });
+  };
+  var establishKind = function (connection) {
+    switch (connection.TAG) {
+      case "Agda" :
+          return "Agda";
+      case "ALS" :
+          return "ALS";
+      case "ALSWASM" :
+          return "ALSWASM";
+      
+    }
+  };
   var conn = await Connection__Core$AgdaModeVscode.fromPathsOrCommands(state.platformDeps, [[
           selectedPath,
           "FromConfig"
-        ]], onProbeFlow);
+        ]], onProbeFlow, onEstablishFlow);
   if (conn.TAG === "Ok") {
     var conn$1 = conn._0;
+    onEstablishFlow({
+          TAG: "ConnectionEstablished",
+          _0: Connection__Core$AgdaModeVscode.getPath(conn$1),
+          _1: establishKind(conn$1)
+        });
     Util$AgdaModeVscode.log("[ debug ] switchAgdaVersion: connection succeeded", Connection__Core$AgdaModeVscode.toString(conn$1));
     await Registry__Connection$AgdaModeVscode.shutdown();
     await Memento$AgdaModeVscode.Module.PreferredCandidate.set(state.memento, selectedPath);
@@ -401,6 +426,7 @@ async function switchAgdaVersion(state, selectedPath) {
     await Connection__Core$AgdaModeVscode.destroy(conn$1, state.channels.log);
     return ;
   }
+  onEstablishFlow("ConnectionEstablishFailed");
   var match$2 = Connection__Error$AgdaModeVscode.toString({
         TAG: "Establish",
         _0: conn._0

--- a/lib/js/src/Connection/Connection__Switch.bs.js
+++ b/lib/js/src/Connection/Connection__Switch.bs.js
@@ -433,7 +433,7 @@ async function switchAgdaVersion(state, selectedPath) {
         
       }
       onEstablishFlow({
-            TAG: "ConnectionEstablished",
+            TAG: "ConnectionCreated",
             _0: Connection__Core$AgdaModeVscode.getPath(conn$1),
             _1: establishKind(conn$1)
           });
@@ -445,7 +445,11 @@ async function switchAgdaVersion(state, selectedPath) {
       return ;
     }
     catch (exn){
-      onEstablishFlow("ConnectionEstablishFailed");
+      onEstablishFlow({
+            TAG: "ConnectionFinalizeFailed",
+            _0: Connection__Core$AgdaModeVscode.getPath(conn$1),
+            _1: establishKind(conn$1)
+          });
       onSwitchUIFlow({
             TAG: "SwitchFailed",
             _0: selectedPath

--- a/lib/js/src/Connection/Download/Connection__Download__Flow.bs.js
+++ b/lib/js/src/Connection/Download/Connection__Download__Flow.bs.js
@@ -6,7 +6,10 @@ var Connection__Download__Assets$AgdaModeVscode = require("./Connection__Downloa
 var Connection__Download__Source$AgdaModeVscode = require("./Connection__Download__Source.bs.js");
 var Connection__Download__DownloadArtifact$AgdaModeVscode = require("./Connection__Download__DownloadArtifact.bs.js");
 
-async function sourceForSelection(memento, globalStorageUri, platformDeps, channel, platform, versionString) {
+async function sourceForSelection(memento, globalStorageUri, platformDeps, channel, platform, versionString, onEventOpt) {
+  var onEvent = onEventOpt !== undefined ? onEventOpt : (function (param) {
+        
+      });
   var downloadPlatform = await platformDeps.determinePlatform();
   if (downloadPlatform.TAG !== "Ok") {
     return {
@@ -32,46 +35,88 @@ async function sourceForSelection(memento, globalStorageUri, platformDeps, chann
           };
   }
   var source = error._0;
-  if (source.TAG !== "FromGitHub") {
+  if (source.TAG === "FromGitHub") {
+    var descriptor = source._1;
+    var release = descriptor.release;
+    var assets;
+    assets = platform === "Wasm" ? Connection__Download__Assets$AgdaModeVscode.wasm(release) : Connection__Download__Assets$AgdaModeVscode.nativeForPlatform(release, downloadPlatform$1);
+    var matchingSource = Core__Array.reduce(assets, undefined, (function (found, asset) {
+            if (found !== undefined) {
+              return found;
+            }
+            var source_1 = {
+              release: release,
+              asset: asset,
+              saveAsFileName: descriptor.saveAsFileName
+            };
+            var source = {
+              TAG: "FromGitHub",
+              _0: channel,
+              _1: source_1
+            };
+            if (Connection__Download__Source$AgdaModeVscode.toVersionString(source) === versionString) {
+              return source;
+            }
+            
+          }));
+    if (matchingSource !== undefined) {
+      onEvent({
+            TAG: "SourceResolved",
+            _0: "GitHub",
+            _1: Connection__Download__Source$AgdaModeVscode.toVersionString(matchingSource)
+          });
+      return {
+              TAG: "Ok",
+              _0: matchingSource
+            };
+    }
+    if (platform === "Wasm") {
+      return {
+              TAG: "Error",
+              _0: "CannotFindCompatibleALSRelease"
+            };
+    }
+    var wasmAsset = Connection__Download__Assets$AgdaModeVscode.wasm(release)[0];
+    if (wasmAsset === undefined) {
+      return {
+              TAG: "Error",
+              _0: "CannotFindCompatibleALSRelease"
+            };
+    }
+    var wasmSource_1 = {
+      release: release,
+      asset: wasmAsset,
+      saveAsFileName: descriptor.saveAsFileName
+    };
+    var wasmSource = {
+      TAG: "FromGitHub",
+      _0: channel,
+      _1: wasmSource_1
+    };
+    var wasmVersion = Connection__Download__Source$AgdaModeVscode.toVersionString(wasmSource);
+    onEvent({
+          TAG: "FallbackChosen",
+          _0: wasmVersion
+        });
+    onEvent({
+          TAG: "SourceResolved",
+          _0: "GitHub",
+          _1: wasmVersion
+        });
     return {
             TAG: "Ok",
-            _0: source
+            _0: wasmSource
           };
   }
-  var descriptor = source._1;
-  var release = descriptor.release;
-  var assets;
-  assets = platform === "Wasm" ? Connection__Download__Assets$AgdaModeVscode.wasm(release) : Connection__Download__Assets$AgdaModeVscode.nativeForPlatform(release, downloadPlatform$1);
-  var matchingSource = Core__Array.reduce(assets, undefined, (function (found, asset) {
-          if (found !== undefined) {
-            return found;
-          }
-          var source_1 = {
-            release: release,
-            asset: asset,
-            saveAsFileName: descriptor.saveAsFileName
-          };
-          var source = {
-            TAG: "FromGitHub",
-            _0: channel,
-            _1: source_1
-          };
-          if (Connection__Download__Source$AgdaModeVscode.toVersionString(source) === versionString) {
-            return source;
-          }
-          
-        }));
-  if (matchingSource !== undefined) {
-    return {
-            TAG: "Ok",
-            _0: matchingSource
-          };
-  } else {
-    return {
-            TAG: "Error",
-            _0: "CannotFindCompatibleALSRelease"
-          };
-  }
+  onEvent({
+        TAG: "SourceResolved",
+        _0: "URL",
+        _1: Connection__Download__Source$AgdaModeVscode.toVersionString(source)
+      });
+  return {
+          TAG: "Ok",
+          _0: source
+        };
 }
 
 exports.sourceForSelection = sourceForSelection;

--- a/lib/js/src/Connection/UI/Connection__UI__Handlers.bs.js
+++ b/lib/js/src/Connection/UI/Connection__UI__Handlers.bs.js
@@ -44,13 +44,57 @@ async function handleDownload(state, platformDeps, platform, downloaded, version
           _1: versionString
         }
       });
+  Chan$AgdaModeVscode.emit(state.channels.log, {
+        TAG: "Connection",
+        _0: {
+          TAG: "DownloadFlow",
+          _0: {
+            TAG: "SelectionRequested",
+            _0: channel,
+            _1: platform,
+            _2: versionString,
+            _3: downloaded
+          }
+        }
+      });
   if (downloaded) {
     var downloadedPath = await Connection__Download__ManagedStorage$AgdaModeVscode.findCandidateForSelection(state.globalStorageUri, channel, platform, versionString);
     if (downloadedPath !== undefined) {
+      Chan$AgdaModeVscode.emit(state.channels.log, {
+            TAG: "Connection",
+            _0: {
+              TAG: "DownloadFlow",
+              _0: {
+                TAG: "ManagedHit",
+                _0: versionString,
+                _1: downloadedPath
+              }
+            }
+          });
+      Chan$AgdaModeVscode.emit(state.channels.log, {
+            TAG: "Connection",
+            _0: {
+              TAG: "DownloadFlow",
+              _0: {
+                TAG: "ReusedExistingArtifact",
+                _0: downloadedPath
+              }
+            }
+          });
       await Config$AgdaModeVscode.Connection.addAgdaPath(state.channels.log, downloadedPath);
       Vscode.window.showInformationMessage(versionString + " is already downloaded");
+    } else {
+      Chan$AgdaModeVscode.emit(state.channels.log, {
+            TAG: "Connection",
+            _0: {
+              TAG: "DownloadFlow",
+              _0: {
+                TAG: "ManagedMiss",
+                _0: versionString
+              }
+            }
+          });
     }
-    
   } else {
     var onTrace = function ($$event) {
       Chan$AgdaModeVscode.emit(state.channels.log, {
@@ -58,20 +102,63 @@ async function handleDownload(state, platformDeps, platform, downloaded, version
             _0: $$event
           });
     };
-    var error = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(state.memento, state.globalStorageUri, platformDeps, channel, platform, versionString);
-    var downloadResult;
-    downloadResult = error.TAG === "Ok" ? await platformDeps.download(state.globalStorageUri, error._0, onTrace) : ({
-          TAG: "Error",
-          _0: error._0
-        });
-    if (downloadResult.TAG === "Ok") {
-      await Config$AgdaModeVscode.Connection.addAgdaPath(state.channels.log, downloadResult._0);
-      if (refreshUI !== undefined) {
-        await refreshUI();
+    var onFlowEvent = function ($$event) {
+      Chan$AgdaModeVscode.emit(state.channels.log, {
+            TAG: "Connection",
+            _0: {
+              TAG: "DownloadFlow",
+              _0: $$event
+            }
+          });
+    };
+    var sourceResult = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(state.memento, state.globalStorageUri, platformDeps, channel, platform, versionString, onFlowEvent);
+    if (sourceResult.TAG === "Ok") {
+      Chan$AgdaModeVscode.emit(state.channels.log, {
+            TAG: "Connection",
+            _0: {
+              TAG: "DownloadFlow",
+              _0: {
+                TAG: "DownloadStarted",
+                _0: channel,
+                _1: platform,
+                _2: versionString
+              }
+            }
+          });
+      var downloadResult = await platformDeps.download(state.globalStorageUri, sourceResult._0, onTrace);
+      if (downloadResult.TAG === "Ok") {
+        var downloadedPath$1 = downloadResult._0;
+        Chan$AgdaModeVscode.emit(state.channels.log, {
+              TAG: "Connection",
+              _0: {
+                TAG: "DownloadFlow",
+                _0: {
+                  TAG: "DownloadSucceeded",
+                  _0: downloadedPath$1
+                }
+              }
+            });
+        await Config$AgdaModeVscode.Connection.addAgdaPath(state.channels.log, downloadedPath$1);
+        if (refreshUI !== undefined) {
+          await refreshUI();
+        }
+        Vscode.window.showInformationMessage(versionString + " successfully downloaded");
+      } else {
+        var error = downloadResult._0;
+        Chan$AgdaModeVscode.emit(state.channels.log, {
+              TAG: "Connection",
+              _0: {
+                TAG: "DownloadFlow",
+                _0: {
+                  TAG: "DownloadFailed",
+                  _0: Connection__Download__Error$AgdaModeVscode.toString(error)
+                }
+              }
+            });
+        Vscode.window.showErrorMessage(Connection__Download__Error$AgdaModeVscode.toString(error));
       }
-      Vscode.window.showInformationMessage(versionString + " successfully downloaded");
     } else {
-      Vscode.window.showErrorMessage(Connection__Download__Error$AgdaModeVscode.toString(downloadResult._0));
+      Vscode.window.showErrorMessage(Connection__Download__Error$AgdaModeVscode.toString(sourceResult._0));
     }
   }
   return Chan$AgdaModeVscode.emit(state.channels.log, {
@@ -193,7 +280,6 @@ function onSelection(state, platformDeps, selectedChannel, updateUI, view, selec
                     if (versionString === Connection__UI__Labels$AgdaModeVscode.checkingAvailability) {
                       return ;
                     } else {
-                      Util$AgdaModeVscode.log("[ debug ] user clicked: download button = " + selectedItem.label, "");
                       Connection__UI__Picker$AgdaModeVscode.destroy(view);
                       return await handleDownload(state, platformDeps, match._2, match._0, versionString, selectedChannel.contents, undefined);
                     }

--- a/lib/js/src/State/Log.bs.js
+++ b/lib/js/src/State/Log.bs.js
@@ -9,6 +9,8 @@ var Memento$AgdaModeVscode = require("../Memento.bs.js");
 var Request$AgdaModeVscode = require("../Request.bs.js");
 var Response$AgdaModeVscode = require("../Response.bs.js");
 var Connection__Download__Trace$AgdaModeVscode = require("../Connection/Download/Connection__Download__Trace.bs.js");
+var Connection__Download__Channel$AgdaModeVscode = require("../Connection/Download/Connection__Download__Channel.bs.js");
+var Connection__Download__DownloadArtifact$AgdaModeVscode = require("../Connection/Download/Connection__Download__DownloadArtifact.bs.js");
 
 function toString($$event) {
   if (typeof $$event !== "object") {
@@ -73,6 +75,44 @@ var SwitchVersion = {
 
 function toString$1($$event) {
   switch ($$event.TAG) {
+    case "SelectionRequested" :
+        return "SelectionRequested: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1) + " version=" + $$event._2 + " downloaded=" + PervasivesU.string_of_bool($$event._3);
+    case "ManagedHit" :
+        return "ManagedHit: " + $$event._0 + " at " + $$event._1;
+    case "ManagedMiss" :
+        return "ManagedMiss: " + $$event._0;
+    case "SourceResolved" :
+        switch ($$event._0) {
+          case "Managed" :
+              return "SourceResolved(Managed): " + $$event._1;
+          case "GitHub" :
+              return "SourceResolved(GitHub): " + $$event._1;
+          case "URL" :
+              return "SourceResolved(URL): " + $$event._1;
+          
+        }
+    case "ReusedExistingArtifact" :
+        return "ReusedExistingArtifact: " + $$event._0;
+    case "DownloadStarted" :
+        return "DownloadStarted: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1) + " version=" + $$event._2;
+    case "DownloadSucceeded" :
+        return "DownloadSucceeded: " + $$event._0;
+    case "DownloadFailed" :
+        return "DownloadFailed: " + $$event._0;
+    case "FallbackChosen" :
+        return "FallbackChosen: " + $$event._0;
+    
+  }
+}
+
+var DownloadFlow = {
+  toString: toString$1
+};
+
+function toString$2($$event) {
+  switch ($$event.TAG) {
+    case "DownloadFlow" :
+        return "[ DownloadFlow     ] " + toString$1($$event._0);
     case "ConnectedToAgda" :
         return "ConnectedToAgda: " + $$event._0 + " - Agda v" + $$event._1;
     case "ConnectedToALS" :
@@ -90,10 +130,11 @@ function toString$1($$event) {
 }
 
 var Connection = {
-  toString: toString$1
+  DownloadFlow: DownloadFlow,
+  toString: toString$2
 };
 
-function toString$2($$event) {
+function toString$3($$event) {
   switch ($$event.TAG) {
     case "Lookup" :
         return "lookup: " + $$event._0 + " " + (
@@ -108,18 +149,18 @@ function toString$2($$event) {
 }
 
 var Registry = {
-  toString: toString$2
+  toString: toString$3
 };
 
-function toString$3($$event) {
+function toString$4($$event) {
   return "Config changed:\nBefore: " + $$event._0.join(", ") + "\nAfter: " + $$event._1.join(", ");
 }
 
 var Config = {
-  toString: toString$3
+  toString: toString$4
 };
 
-function toString$4(log) {
+function toString$5(log) {
   switch (log.TAG) {
     case "CommandDispatched" :
         return " <=== " + Command$AgdaModeVscode.toString(log._0);
@@ -130,15 +171,15 @@ function toString$4(log) {
     case "ResponseHandled" :
         return "    > " + Response$AgdaModeVscode.toString(log._0);
     case "Registry" :
-        return "[ Registry         ] " + toString$2(log._0);
+        return "[ Registry         ] " + toString$3(log._0);
     case "TokensReset" :
         return "Tokens reset: " + log._0;
     case "SwitchVersionUI" :
         return "[ SwitchVersion    ] " + toString(log._0);
     case "Connection" :
-        return "[ Connection       ] " + toString$1(log._0);
+        return "[ Connection       ] " + toString$2(log._0);
     case "Config" :
-        return "[ Config           ] " + toString$3(log._0);
+        return "[ Config           ] " + toString$4(log._0);
     case "DownloadTrace" :
         return "[ DownloadTrace    ] " + Connection__Download__Trace$AgdaModeVscode.toString(log._0);
     case "Others" :
@@ -195,7 +236,7 @@ exports.SwitchVersion = SwitchVersion;
 exports.Connection = Connection;
 exports.Registry = Registry;
 exports.Config = Config;
-exports.toString = toString$4;
+exports.toString = toString$5;
 exports.isConfig = isConfig;
 exports.isConnection = isConnection;
 exports.collect = collect;

--- a/lib/js/src/State/Log.bs.js
+++ b/lib/js/src/State/Log.bs.js
@@ -77,6 +77,42 @@ var SwitchVersion = {
 };
 
 function toString$1($$event) {
+  switch ($$event) {
+    case "ActivationStarted" :
+        return "ActivationStarted";
+    case "ExistingConnectionReused" :
+        return "ExistingConnectionReused";
+    case "FreshEstablishStarted" :
+        return "FreshEstablishStarted";
+    case "ActivationSucceeded" :
+        return "ActivationSucceeded";
+    case "ActivationFailed" :
+        return "ActivationFailed";
+    
+  }
+}
+
+var ActivationFlow = {
+  toString: toString$1
+};
+
+function toString$2($$event) {
+  switch ($$event.TAG) {
+    case "SwitchRequested" :
+        return "SwitchRequested: " + $$event._0;
+    case "SwitchSucceeded" :
+        return "SwitchSucceeded: " + $$event._0;
+    case "SwitchFailed" :
+        return "SwitchFailed: " + $$event._0;
+    
+  }
+}
+
+var SwitchUIFlow = {
+  toString: toString$2
+};
+
+function toString$3($$event) {
   if (typeof $$event !== "object") {
     if ($$event === "ConfigCandidatesFailed") {
       return "ConfigCandidatesFailed";
@@ -109,10 +145,10 @@ function toString$1($$event) {
 }
 
 var EstablishFlow = {
-  toString: toString$1
+  toString: toString$3
 };
 
-function toString$2($$event) {
+function toString$4($$event) {
   switch ($$event.TAG) {
     case "CandidateResolveStarted" :
         return "CandidateResolveStarted: " + Connection__Candidate$AgdaModeVscode.toString($$event._0);
@@ -135,10 +171,10 @@ function toString$2($$event) {
 }
 
 var ProbeFlow = {
-  toString: toString$2
+  toString: toString$4
 };
 
-function toString$3($$event) {
+function toString$5($$event) {
   switch ($$event.TAG) {
     case "SelectionRequested" :
         return "SelectionRequested: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1) + " version=" + $$event._2 + " downloaded=" + PervasivesU.string_of_bool($$event._3);
@@ -171,17 +207,21 @@ function toString$3($$event) {
 }
 
 var DownloadFlow = {
-  toString: toString$3
+  toString: toString$5
 };
 
-function toString$4($$event) {
+function toString$6($$event) {
   switch ($$event.TAG) {
+    case "ActivationFlow" :
+        return "[ ActivationFlow   ] " + toString$1($$event._0);
+    case "SwitchUIFlow" :
+        return "[ SwitchUIFlow    ] " + toString$2($$event._0);
     case "EstablishFlow" :
-        return "[ EstablishFlow    ] " + toString$1($$event._0);
+        return "[ EstablishFlow    ] " + toString$3($$event._0);
     case "ProbeFlow" :
-        return "[ ProbeFlow        ] " + toString$2($$event._0);
+        return "[ ProbeFlow        ] " + toString$4($$event._0);
     case "DownloadFlow" :
-        return "[ DownloadFlow     ] " + toString$3($$event._0);
+        return "[ DownloadFlow     ] " + toString$5($$event._0);
     case "ConnectedToAgda" :
         return "ConnectedToAgda: " + $$event._0 + " - Agda v" + $$event._1;
     case "ConnectedToALS" :
@@ -199,13 +239,15 @@ function toString$4($$event) {
 }
 
 var Connection = {
+  ActivationFlow: ActivationFlow,
+  SwitchUIFlow: SwitchUIFlow,
   EstablishFlow: EstablishFlow,
   ProbeFlow: ProbeFlow,
   DownloadFlow: DownloadFlow,
-  toString: toString$4
+  toString: toString$6
 };
 
-function toString$5($$event) {
+function toString$7($$event) {
   switch ($$event.TAG) {
     case "Lookup" :
         return "lookup: " + $$event._0 + " " + (
@@ -220,18 +262,18 @@ function toString$5($$event) {
 }
 
 var Registry = {
-  toString: toString$5
+  toString: toString$7
 };
 
-function toString$6($$event) {
+function toString$8($$event) {
   return "Config changed:\nBefore: " + $$event._0.join(", ") + "\nAfter: " + $$event._1.join(", ");
 }
 
 var Config = {
-  toString: toString$6
+  toString: toString$8
 };
 
-function toString$7(log) {
+function toString$9(log) {
   switch (log.TAG) {
     case "CommandDispatched" :
         return " <=== " + Command$AgdaModeVscode.toString(log._0);
@@ -242,15 +284,15 @@ function toString$7(log) {
     case "ResponseHandled" :
         return "    > " + Response$AgdaModeVscode.toString(log._0);
     case "Registry" :
-        return "[ Registry         ] " + toString$5(log._0);
+        return "[ Registry         ] " + toString$7(log._0);
     case "TokensReset" :
         return "Tokens reset: " + log._0;
     case "SwitchVersionUI" :
         return "[ SwitchVersion    ] " + toString(log._0);
     case "Connection" :
-        return "[ Connection       ] " + toString$4(log._0);
+        return "[ Connection       ] " + toString$6(log._0);
     case "Config" :
-        return "[ Config           ] " + toString$6(log._0);
+        return "[ Config           ] " + toString$8(log._0);
     case "DownloadTrace" :
         return "[ DownloadTrace    ] " + Connection__Download__Trace$AgdaModeVscode.toString(log._0);
     case "Others" :
@@ -272,12 +314,12 @@ function isConnection(log) {
     return false;
   }
   switch (log._0.TAG) {
-    case "EstablishFlow" :
-    case "ProbeFlow" :
-    case "DownloadFlow" :
-        return false;
+    case "ConnectedToAgda" :
+    case "ConnectedToALS" :
+    case "Disconnected" :
+        return true;
     default:
-      return true;
+      return false;
   }
 }
 
@@ -313,7 +355,7 @@ exports.SwitchVersion = SwitchVersion;
 exports.Connection = Connection;
 exports.Registry = Registry;
 exports.Config = Config;
-exports.toString = toString$7;
+exports.toString = toString$9;
 exports.isConfig = isConfig;
 exports.isConnection = isConnection;
 exports.collect = collect;

--- a/lib/js/src/State/Log.bs.js
+++ b/lib/js/src/State/Log.bs.js
@@ -121,23 +121,34 @@ function toString$3($$event) {
     }
   }
   switch ($$event.TAG) {
-    case "ConfigCandidatesStarted" :
-        return "ConfigCandidatesStarted: " + String($$event._0);
+    case "ConfigCandidatesPlanned" :
+        return "ConfigCandidatesPlanned: " + String($$event._0);
     case "CandidateAttempted" :
         return "CandidateAttempted: " + $$event._0 + " (" + Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1) + ")";
     case "DownloadFallbackStarted" :
         return "DownloadFallbackStarted: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1);
     case "DownloadFallbackFailed" :
         return "DownloadFallbackFailed: " + Connection__Error$AgdaModeVscode.Establish.toString($$event._0);
-    case "ConnectionEstablished" :
+    case "ConnectionCreated" :
         var path = $$event._0;
         switch ($$event._1) {
           case "Agda" :
-              return "ConnectionEstablished: " + path + " (Agda)";
+              return "ConnectionCreated: " + path + " (Agda)";
           case "ALS" :
-              return "ConnectionEstablished: " + path + " (ALS)";
+              return "ConnectionCreated: " + path + " (ALS)";
           case "ALSWASM" :
-              return "ConnectionEstablished: " + path + " (ALSWASM)";
+              return "ConnectionCreated: " + path + " (ALSWASM)";
+          
+        }
+    case "ConnectionFinalizeFailed" :
+        var path$1 = $$event._0;
+        switch ($$event._1) {
+          case "Agda" :
+              return "ConnectionFinalizeFailed: " + path$1 + " (Agda)";
+          case "ALS" :
+              return "ConnectionFinalizeFailed: " + path$1 + " (ALS)";
+          case "ALSWASM" :
+              return "ConnectionFinalizeFailed: " + path$1 + " (ALSWASM)";
           
         }
     

--- a/lib/js/src/State/Log.bs.js
+++ b/lib/js/src/State/Log.bs.js
@@ -77,6 +77,42 @@ var SwitchVersion = {
 };
 
 function toString$1($$event) {
+  if (typeof $$event !== "object") {
+    if ($$event === "ConfigCandidatesFailed") {
+      return "ConfigCandidatesFailed";
+    } else {
+      return "ConnectionEstablishFailed";
+    }
+  }
+  switch ($$event.TAG) {
+    case "ConfigCandidatesStarted" :
+        return "ConfigCandidatesStarted: " + String($$event._0);
+    case "CandidateAttempted" :
+        return "CandidateAttempted: " + $$event._0 + " (" + Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1) + ")";
+    case "DownloadFallbackStarted" :
+        return "DownloadFallbackStarted: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1);
+    case "DownloadFallbackFailed" :
+        return "DownloadFallbackFailed: " + Connection__Error$AgdaModeVscode.Establish.toString($$event._0);
+    case "ConnectionEstablished" :
+        var path = $$event._0;
+        switch ($$event._1) {
+          case "Agda" :
+              return "ConnectionEstablished: " + path + " (Agda)";
+          case "ALS" :
+              return "ConnectionEstablished: " + path + " (ALS)";
+          case "ALSWASM" :
+              return "ConnectionEstablished: " + path + " (ALSWASM)";
+          
+        }
+    
+  }
+}
+
+var EstablishFlow = {
+  toString: toString$1
+};
+
+function toString$2($$event) {
   switch ($$event.TAG) {
     case "CandidateResolveStarted" :
         return "CandidateResolveStarted: " + Connection__Candidate$AgdaModeVscode.toString($$event._0);
@@ -99,10 +135,10 @@ function toString$1($$event) {
 }
 
 var ProbeFlow = {
-  toString: toString$1
+  toString: toString$2
 };
 
-function toString$2($$event) {
+function toString$3($$event) {
   switch ($$event.TAG) {
     case "SelectionRequested" :
         return "SelectionRequested: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1) + " version=" + $$event._2 + " downloaded=" + PervasivesU.string_of_bool($$event._3);
@@ -135,15 +171,17 @@ function toString$2($$event) {
 }
 
 var DownloadFlow = {
-  toString: toString$2
+  toString: toString$3
 };
 
-function toString$3($$event) {
+function toString$4($$event) {
   switch ($$event.TAG) {
+    case "EstablishFlow" :
+        return "[ EstablishFlow    ] " + toString$1($$event._0);
     case "ProbeFlow" :
-        return "[ ProbeFlow        ] " + toString$1($$event._0);
+        return "[ ProbeFlow        ] " + toString$2($$event._0);
     case "DownloadFlow" :
-        return "[ DownloadFlow     ] " + toString$2($$event._0);
+        return "[ DownloadFlow     ] " + toString$3($$event._0);
     case "ConnectedToAgda" :
         return "ConnectedToAgda: " + $$event._0 + " - Agda v" + $$event._1;
     case "ConnectedToALS" :
@@ -161,12 +199,13 @@ function toString$3($$event) {
 }
 
 var Connection = {
+  EstablishFlow: EstablishFlow,
   ProbeFlow: ProbeFlow,
   DownloadFlow: DownloadFlow,
-  toString: toString$3
+  toString: toString$4
 };
 
-function toString$4($$event) {
+function toString$5($$event) {
   switch ($$event.TAG) {
     case "Lookup" :
         return "lookup: " + $$event._0 + " " + (
@@ -181,18 +220,18 @@ function toString$4($$event) {
 }
 
 var Registry = {
-  toString: toString$4
+  toString: toString$5
 };
 
-function toString$5($$event) {
+function toString$6($$event) {
   return "Config changed:\nBefore: " + $$event._0.join(", ") + "\nAfter: " + $$event._1.join(", ");
 }
 
 var Config = {
-  toString: toString$5
+  toString: toString$6
 };
 
-function toString$6(log) {
+function toString$7(log) {
   switch (log.TAG) {
     case "CommandDispatched" :
         return " <=== " + Command$AgdaModeVscode.toString(log._0);
@@ -203,15 +242,15 @@ function toString$6(log) {
     case "ResponseHandled" :
         return "    > " + Response$AgdaModeVscode.toString(log._0);
     case "Registry" :
-        return "[ Registry         ] " + toString$4(log._0);
+        return "[ Registry         ] " + toString$5(log._0);
     case "TokensReset" :
         return "Tokens reset: " + log._0;
     case "SwitchVersionUI" :
         return "[ SwitchVersion    ] " + toString(log._0);
     case "Connection" :
-        return "[ Connection       ] " + toString$3(log._0);
+        return "[ Connection       ] " + toString$4(log._0);
     case "Config" :
-        return "[ Config           ] " + toString$5(log._0);
+        return "[ Config           ] " + toString$6(log._0);
     case "DownloadTrace" :
         return "[ DownloadTrace    ] " + Connection__Download__Trace$AgdaModeVscode.toString(log._0);
     case "Others" :
@@ -229,10 +268,16 @@ function isConfig(log) {
 }
 
 function isConnection(log) {
-  if (log.TAG === "Connection") {
-    return true;
-  } else {
+  if (log.TAG !== "Connection") {
     return false;
+  }
+  switch (log._0.TAG) {
+    case "EstablishFlow" :
+    case "ProbeFlow" :
+    case "DownloadFlow" :
+        return false;
+    default:
+      return true;
   }
 }
 
@@ -268,7 +313,7 @@ exports.SwitchVersion = SwitchVersion;
 exports.Connection = Connection;
 exports.Registry = Registry;
 exports.Config = Config;
-exports.toString = toString$6;
+exports.toString = toString$7;
 exports.isConfig = isConfig;
 exports.isConnection = isConnection;
 exports.collect = collect;

--- a/lib/js/src/State/Log.bs.js
+++ b/lib/js/src/State/Log.bs.js
@@ -8,6 +8,9 @@ var Command$AgdaModeVscode = require("../Command.bs.js");
 var Memento$AgdaModeVscode = require("../Memento.bs.js");
 var Request$AgdaModeVscode = require("../Request.bs.js");
 var Response$AgdaModeVscode = require("../Response.bs.js");
+var Connection__Error$AgdaModeVscode = require("../Connection/Shared/Connection__Error.bs.js");
+var Connection__Command$AgdaModeVscode = require("../Connection/Resolver/Connection__Command.bs.js");
+var Connection__Candidate$AgdaModeVscode = require("../Connection/Connection__Candidate.bs.js");
 var Connection__Download__Trace$AgdaModeVscode = require("../Connection/Download/Connection__Download__Trace.bs.js");
 var Connection__Download__Channel$AgdaModeVscode = require("../Connection/Download/Connection__Download__Channel.bs.js");
 var Connection__Download__DownloadArtifact$AgdaModeVscode = require("../Connection/Download/Connection__Download__DownloadArtifact.bs.js");
@@ -75,6 +78,32 @@ var SwitchVersion = {
 
 function toString$1($$event) {
   switch ($$event.TAG) {
+    case "CandidateResolveStarted" :
+        return "CandidateResolveStarted: " + Connection__Candidate$AgdaModeVscode.toString($$event._0);
+    case "CandidateResolved" :
+        return "CandidateResolved: " + Connection__Candidate$AgdaModeVscode.toString($$event._0) + " -> " + $$event._1.toString();
+    case "CandidateResolveFailed" :
+        return "CandidateResolveFailed: " + Connection__Candidate$AgdaModeVscode.toString($$event._0) + " -> " + Connection__Command$AgdaModeVscode.$$Error.toString($$event._1);
+    case "ProbeStarted" :
+        return "ProbeStarted: " + $$event._0.toString();
+    case "ProbeClassifiedAsAgda" :
+        return "ProbeClassifiedAsAgda: " + $$event._0 + " (Agda v" + $$event._1 + ")";
+    case "ProbeClassifiedAsALS" :
+        return "ProbeClassifiedAsALS: " + $$event._0 + " (ALS v" + $$event._1 + ", Agda v" + $$event._2 + ")";
+    case "ProbeClassifiedAsALSWASM" :
+        return "ProbeClassifiedAsALSWASM: " + $$event._0;
+    case "ProbeFailed" :
+        return "ProbeFailed: " + $$event._0 + " -> " + Connection__Error$AgdaModeVscode.Probe.toString($$event._1);
+    
+  }
+}
+
+var ProbeFlow = {
+  toString: toString$1
+};
+
+function toString$2($$event) {
+  switch ($$event.TAG) {
     case "SelectionRequested" :
         return "SelectionRequested: channel=" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + " platform=" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1) + " version=" + $$event._2 + " downloaded=" + PervasivesU.string_of_bool($$event._3);
     case "ManagedHit" :
@@ -106,13 +135,15 @@ function toString$1($$event) {
 }
 
 var DownloadFlow = {
-  toString: toString$1
+  toString: toString$2
 };
 
-function toString$2($$event) {
+function toString$3($$event) {
   switch ($$event.TAG) {
+    case "ProbeFlow" :
+        return "[ ProbeFlow        ] " + toString$1($$event._0);
     case "DownloadFlow" :
-        return "[ DownloadFlow     ] " + toString$1($$event._0);
+        return "[ DownloadFlow     ] " + toString$2($$event._0);
     case "ConnectedToAgda" :
         return "ConnectedToAgda: " + $$event._0 + " - Agda v" + $$event._1;
     case "ConnectedToALS" :
@@ -130,11 +161,12 @@ function toString$2($$event) {
 }
 
 var Connection = {
+  ProbeFlow: ProbeFlow,
   DownloadFlow: DownloadFlow,
-  toString: toString$2
+  toString: toString$3
 };
 
-function toString$3($$event) {
+function toString$4($$event) {
   switch ($$event.TAG) {
     case "Lookup" :
         return "lookup: " + $$event._0 + " " + (
@@ -149,18 +181,18 @@ function toString$3($$event) {
 }
 
 var Registry = {
-  toString: toString$3
+  toString: toString$4
 };
 
-function toString$4($$event) {
+function toString$5($$event) {
   return "Config changed:\nBefore: " + $$event._0.join(", ") + "\nAfter: " + $$event._1.join(", ");
 }
 
 var Config = {
-  toString: toString$4
+  toString: toString$5
 };
 
-function toString$5(log) {
+function toString$6(log) {
   switch (log.TAG) {
     case "CommandDispatched" :
         return " <=== " + Command$AgdaModeVscode.toString(log._0);
@@ -171,15 +203,15 @@ function toString$5(log) {
     case "ResponseHandled" :
         return "    > " + Response$AgdaModeVscode.toString(log._0);
     case "Registry" :
-        return "[ Registry         ] " + toString$3(log._0);
+        return "[ Registry         ] " + toString$4(log._0);
     case "TokensReset" :
         return "Tokens reset: " + log._0;
     case "SwitchVersionUI" :
         return "[ SwitchVersion    ] " + toString(log._0);
     case "Connection" :
-        return "[ Connection       ] " + toString$2(log._0);
+        return "[ Connection       ] " + toString$3(log._0);
     case "Config" :
-        return "[ Config           ] " + toString$4(log._0);
+        return "[ Config           ] " + toString$5(log._0);
     case "DownloadTrace" :
         return "[ DownloadTrace    ] " + Connection__Download__Trace$AgdaModeVscode.toString(log._0);
     case "Others" :
@@ -236,7 +268,7 @@ exports.SwitchVersion = SwitchVersion;
 exports.Connection = Connection;
 exports.Registry = Registry;
 exports.Config = Config;
-exports.toString = toString$5;
+exports.toString = toString$6;
 exports.isConfig = isConfig;
 exports.isConnection = isConnection;
 exports.collect = collect;

--- a/lib/js/src/State/State__Connection.bs.js
+++ b/lib/js/src/State/State__Connection.bs.js
@@ -42,7 +42,25 @@ async function sendRequest(state, handleResponse, request) {
       
     }
   };
+  Chan$AgdaModeVscode.emit(state.channels.log, {
+        TAG: "Connection",
+        _0: {
+          TAG: "ActivationFlow",
+          _0: "ActivationStarted"
+        }
+      });
+  var freshEstablishStarted = {
+    contents: false
+  };
   var make = function () {
+    freshEstablishStarted.contents = true;
+    Chan$AgdaModeVscode.emit(state.channels.log, {
+          TAG: "Connection",
+          _0: {
+            TAG: "ActivationFlow",
+            _0: "FreshEstablishStarted"
+          }
+        });
     return Connection$AgdaModeVscode.makeWithFallback(state.platformDeps, state.memento, state.globalStorageUri, Config$AgdaModeVscode.Connection.getAgdaPaths(), [
                 "als",
                 "agda"
@@ -50,10 +68,32 @@ async function sendRequest(state, handleResponse, request) {
   };
   var error = await Registry__Connection$AgdaModeVscode.acquire(state.id, make);
   if (error.TAG === "Ok") {
+    if (!freshEstablishStarted.contents) {
+      Chan$AgdaModeVscode.emit(state.channels.log, {
+            TAG: "Connection",
+            _0: {
+              TAG: "ActivationFlow",
+              _0: "ExistingConnectionReused"
+            }
+          });
+    }
+    Chan$AgdaModeVscode.emit(state.channels.log, {
+          TAG: "Connection",
+          _0: {
+            TAG: "ActivationFlow",
+            _0: "ActivationSucceeded"
+          }
+        });
     return await sendRequestAndHandleResponses(error._0, state, request, handleResponse);
-  } else {
-    return await State__View$AgdaModeVscode.Panel.displayConnectionError(state, error._0);
   }
+  Chan$AgdaModeVscode.emit(state.channels.log, {
+        TAG: "Connection",
+        _0: {
+          TAG: "ActivationFlow",
+          _0: "ActivationFailed"
+        }
+      });
+  return await State__View$AgdaModeVscode.Panel.displayConnectionError(state, error._0);
 }
 
 async function sendRequestAndCollectResponses(state, request) {

--- a/lib/js/test/tests/Connection/Test__Connection__Config.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Config.bs.js
@@ -154,7 +154,7 @@ describe("Config.Connection paths", (function () {
                         var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformWithDiscovery, [[
                                 "agda",
                                 "FromConfig"
-                              ]]);
+                              ]], undefined);
                         if (result.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), systemAgda.contents, undefined);
                         }
@@ -164,7 +164,7 @@ describe("Config.Connection paths", (function () {
                         var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformNoDiscovery, [[
                                 "agda",
                                 "FromConfig"
-                              ]]);
+                              ]], undefined);
                         if (result.TAG !== "Ok") {
                           return ;
                         }
@@ -174,7 +174,7 @@ describe("Config.Connection paths", (function () {
                         var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformNoDiscovery, [[
                                 userAgda.contents,
                                 "FromConfig"
-                              ]]);
+                              ]], undefined);
                         if (result.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), userAgda.contents, undefined);
                         }

--- a/lib/js/test/tests/Connection/Test__Connection__Config.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Config.bs.js
@@ -154,7 +154,7 @@ describe("Config.Connection paths", (function () {
                         var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformWithDiscovery, [[
                                 "agda",
                                 "FromConfig"
-                              ]], undefined);
+                              ]], undefined, undefined);
                         if (result.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), systemAgda.contents, undefined);
                         }
@@ -164,7 +164,7 @@ describe("Config.Connection paths", (function () {
                         var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformNoDiscovery, [[
                                 "agda",
                                 "FromConfig"
-                              ]], undefined);
+                              ]], undefined, undefined);
                         if (result.TAG !== "Ok") {
                           return ;
                         }
@@ -174,7 +174,7 @@ describe("Config.Connection paths", (function () {
                         var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformNoDiscovery, [[
                                 userAgda.contents,
                                 "FromConfig"
-                              ]], undefined);
+                              ]], undefined, undefined);
                         if (result.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), userAgda.contents, undefined);
                         }

--- a/lib/js/test/tests/Connection/Test__Connection__Download.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Download.bs.js
@@ -1043,7 +1043,7 @@ describe("Download", (function () {
                               makeAsset("als-dev-Agda-2.8.0-wasm.wasm")
                             ]);
                         var platform = makePlatform("MacOS_Arm", makeGitHubSource("DevALS", release, nativeAsset, "dev-als"));
-                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-dev-native"), platform, "DevALS", "MacOSArm64", "Agda v2.8.0 Language Server (dev build)");
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-dev-native"), platform, "DevALS", "MacOSArm64", "Agda v2.8.0 Language Server (dev build)", undefined);
                         return expectGitHubAsset(result, "DevALS", "als-dev-Agda-2.8.0-macos-arm64.zip");
                       }));
                 it("should return the matching DevALS WASM source for the selected version string", (async function () {
@@ -1055,14 +1055,14 @@ describe("Download", (function () {
                               makeAsset("als-dev-Agda-2.7.0.1-wasm.wasm")
                             ]);
                         var platform = makePlatform("MacOS_Arm", makeGitHubSource("DevALS", release, nativeAsset, "dev-als"));
-                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-dev-wasm"), platform, "DevALS", "Wasm", "Agda v2.8.0 Language Server (dev build)");
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-dev-wasm"), platform, "DevALS", "Wasm", "Agda v2.8.0 Language Server (dev build)", undefined);
                         return expectGitHubAsset(result, "DevALS", "als-dev-Agda-2.8.0-wasm.wasm");
                       }));
                 it("should return CannotFindCompatibleALSRelease when no source matches", (async function () {
                         var nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip");
                         var release = makeRelease("dev", [nativeAsset]);
                         var platform = makePlatform("MacOS_Arm", makeGitHubSource("DevALS", release, nativeAsset, "dev-als"));
-                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-no-match"), platform, "DevALS", "MacOSArm64", "Agda v9.9.9 Language Server (dev build)");
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-no-match"), platform, "DevALS", "MacOSArm64", "Agda v9.9.9 Language Server (dev build)", undefined);
                         return Curry._3(Assert.deepStrictEqual, result, {
                                     TAG: "Error",
                                     _0: "CannotFindCompatibleALSRelease"
@@ -1076,7 +1076,7 @@ describe("Download", (function () {
                           _2: "dev-als"
                         };
                         var platform = makePlatform("Web", source);
-                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-url"), platform, "DevALS", "Wasm", "irrelevant for URL sources");
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-url"), platform, "DevALS", "Wasm", "irrelevant for URL sources", undefined);
                         return Curry._3(Assert.deepStrictEqual, result, {
                                     TAG: "Ok",
                                     _0: source
@@ -1090,8 +1090,50 @@ describe("Download", (function () {
                               makeAsset("als-v5-Agda-2.7.0.1-macos-arm64.zip")
                             ]);
                         var platform = makePlatform("MacOS_Arm", makeGitHubSource("LatestALS", release, latestAsset, "latest-als"));
-                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-latest"), platform, "LatestALS", "MacOSArm64", "Agda v2.8.0 Language Server v6");
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-latest"), platform, "LatestALS", "MacOSArm64", "Agda v2.8.0 Language Server v6", undefined);
                         return expectGitHubAsset(result, "LatestALS", "als-v6-Agda-2.8.0-macos-arm64.zip");
+                      }));
+                it("sourceForSelection should emit SourceResolved(GitHub) via onEvent callback for matching asset", (async function () {
+                        var nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip");
+                        var wasmAsset = makeAsset("als-dev-Agda-2.8.0-wasm.wasm");
+                        var release = makeRelease("dev", [
+                              nativeAsset,
+                              wasmAsset
+                            ]);
+                        var platform = makePlatform("MacOS_Arm", makeGitHubSource("DevALS", release, nativeAsset, "dev-als"));
+                        var events = [];
+                        await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-onEvent"), platform, "DevALS", "Wasm", "Agda v2.8.0 Language Server (dev build)", (function ($$event) {
+                                events.push($$event);
+                              }));
+                        return Curry._3(Assert.deepStrictEqual, events, [{
+                                      TAG: "SourceResolved",
+                                      _0: "GitHub",
+                                      _1: "Agda v2.8.0 Language Server (dev build)"
+                                    }], undefined);
+                      }));
+                it("sourceForSelection should emit FallbackChosen when native not found but WASM exists", (async function () {
+                        var wasmAsset = makeAsset("als-dev-Agda-2.8.0-wasm.wasm");
+                        var nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip");
+                        var release = makeRelease("dev", [
+                              nativeAsset,
+                              wasmAsset
+                            ]);
+                        var platform = makePlatform("MacOS_Arm", makeGitHubSource("DevALS", release, nativeAsset, "dev-als"));
+                        var events = [];
+                        await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-fallback"), platform, "DevALS", "MacOSArm64", "Agda v9.9.9 Language Server (dev build)", (function ($$event) {
+                                events.push($$event);
+                              }));
+                        return Curry._3(Assert.deepStrictEqual, events, [
+                                    {
+                                      TAG: "FallbackChosen",
+                                      _0: "Agda v2.8.0 Language Server (dev build)"
+                                    },
+                                    {
+                                      TAG: "SourceResolved",
+                                      _0: "GitHub",
+                                      _1: "Agda v2.8.0 Language Server (dev build)"
+                                    }
+                                  ], undefined);
                       }));
               }));
         describe("ManagedStorage.findAnyWasmDownloaded", (function () {

--- a/lib/js/test/tests/Connection/Test__Connection__Download.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Download.bs.js
@@ -10,6 +10,7 @@ var Nodeos = require("node:os");
 var Process = require("process");
 var Nodepath = require("node:path");
 var Caml_option = require("rescript/lib/js/caml_option.js");
+var Core__Array = require("@rescript/core/lib/js/src/Core__Array.bs.js");
 var Nodestream = require("node:stream");
 var Core__Option = require("@rescript/core/lib/js/src/Core__Option.bs.js");
 var Core__Result = require("@rescript/core/lib/js/src/Core__Result.bs.js");
@@ -1082,6 +1083,43 @@ describe("Download", (function () {
                                     _0: source
                                   }, undefined);
                       }));
+                it("sourceForSelection should emit SourceResolved(URL) and no fallback for FromURL sources", (async function () {
+                        var source = {
+                          TAG: "FromURL",
+                          _0: "DevALS",
+                          _1: "https://example.invalid/als.wasm",
+                          _2: "dev-als"
+                        };
+                        var sourceVersion = Connection__Download__Source$AgdaModeVscode.toVersionString(source);
+                        var platform = makePlatform("Web", source);
+                        var events = [];
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-url-events"), platform, "DevALS", "Wasm", "ignored for URL source", (function ($$event) {
+                                events.push($$event);
+                              }));
+                        Curry._3(Assert.deepStrictEqual, result, {
+                              TAG: "Ok",
+                              _0: source
+                            }, undefined);
+                        return Curry._3(Assert.deepStrictEqual, events, [{
+                                      TAG: "SourceResolved",
+                                      _0: "URL",
+                                      _1: sourceVersion
+                                    }], undefined);
+                      }));
+                it("sourceForSelection should not emit download lifecycle events when GitHub resolution fails before download", (async function () {
+                        var nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip");
+                        var release = makeRelease("dev", [nativeAsset]);
+                        var platform = makePlatform("MacOS_Arm", makeGitHubSource("DevALS", release, nativeAsset, "dev-als"));
+                        var events = [];
+                        var result = await Connection__Download__Flow$AgdaModeVscode.sourceForSelection(Memento$AgdaModeVscode.make(undefined), Vscode.Uri.file("/tmp/agda-flow-prefail"), platform, "DevALS", "MacOSArm64", "Agda v9.9.9 Language Server (dev build)", (function ($$event) {
+                                events.push($$event);
+                              }));
+                        Curry._3(Assert.deepStrictEqual, result, {
+                              TAG: "Error",
+                              _0: "CannotFindCompatibleALSRelease"
+                            }, undefined);
+                        return Curry._3(Assert.deepStrictEqual, events, [], undefined);
+                      }));
                 it("should use canonical LatestALS release assets", (async function () {
                         var latestAsset = makeAsset("als-v6-Agda-2.8.0-macos-arm64.zip");
                         var release = makeRelease("v6", [
@@ -1911,6 +1949,18 @@ describe("Download", (function () {
                     throw exn;
                   }
                 };
+                var collectDownloadFlowEvents = function (events) {
+                  return Core__Array.filterMap(events, (function ($$event) {
+                                if ($$event.TAG !== "Connection") {
+                                  return ;
+                                }
+                                var flowEvent = $$event._0;
+                                if (flowEvent.TAG === "DownloadFlow") {
+                                  return flowEvent._0;
+                                }
+                                
+                              }));
+                };
                 it("GitHub.download should forward trace to asFile", (async function () {
                         return await withTempDir("agda-trace-wire-", (async function (globalStorageUri) {
                                       var traces = {
@@ -2078,6 +2128,105 @@ describe("Download", (function () {
                                             }
                                           });
                                       return Curry._3(Assert.deepStrictEqual, hasDownloadTrace, true, undefined);
+                                    }));
+                      }));
+                it("handleDownload should emit SelectionRequested, SourceResolved(URL), DownloadStarted, DownloadSucceeded for URL-backed source", (async function () {
+                        return await withTempDir("agda-flow-log-url-", (async function (storageUri) {
+                                      var channels_inputMethod = Chan$AgdaModeVscode.make();
+                                      var channels_responseHandled = Chan$AgdaModeVscode.make();
+                                      var channels_commandHandled = Chan$AgdaModeVscode.make();
+                                      var channels_log = Chan$AgdaModeVscode.make();
+                                      var channels = {
+                                        inputMethod: channels_inputMethod,
+                                        responseHandled: channels_responseHandled,
+                                        commandHandled: channels_commandHandled,
+                                        log: channels_log
+                                      };
+                                      var mockEditor = { document: { fileName: "test.agda" } };
+                                      var mockExtensionUri = Vscode.Uri.file(Process.cwd());
+                                      var state = State$AgdaModeVscode.make("test-id-flow-url", Mock$AgdaModeVscode.Platform.makeBasic(), channels, storageUri, mockExtensionUri, Memento$AgdaModeVscode.make(undefined), mockEditor, undefined);
+                                      var logEvents = {
+                                        contents: []
+                                      };
+                                      Chan$AgdaModeVscode.on(state.channels.log, (function ($$event) {
+                                              logEvents.contents = logEvents.contents.concat([$$event]);
+                                            }));
+                                      var urlSource = {
+                                        TAG: "FromURL",
+                                        _0: "DevALS",
+                                        _1: "https://example.invalid/dev-als.wasm",
+                                        _2: "dev-als"
+                                      };
+                                      var sourceVersion = Connection__Download__Source$AgdaModeVscode.toVersionString(urlSource);
+                                      var determinePlatform = async function () {
+                                        return {
+                                                TAG: "Ok",
+                                                _0: "MacOS_Arm"
+                                              };
+                                      };
+                                      var askUserAboutDownloadPolicy = async function () {
+                                        return "Yes";
+                                      };
+                                      var alreadyDownloaded = function (_globalStorageUri) {
+                                        return Promise.resolve(undefined);
+                                      };
+                                      var resolveDownloadChannel = Mock$AgdaModeVscode.DownloadDescriptor.mockWith(function (param) {
+                                            return {
+                                                    TAG: "Ok",
+                                                    _0: urlSource
+                                                  };
+                                          });
+                                      var download = function (_globalStorageUri, _source, traceOpt) {
+                                        var trace = traceOpt !== undefined ? traceOpt : Connection__Download__Trace$AgdaModeVscode.noop;
+                                        trace({
+                                              TAG: "FetchStarted",
+                                              _0: "https://example.invalid/dev-als.wasm"
+                                            });
+                                        return Promise.resolve({
+                                                    TAG: "Ok",
+                                                    _0: "/mock/url-backed/path"
+                                                  });
+                                      };
+                                      var findCommand = function (_command, _timeoutOpt) {
+                                        return Promise.resolve({
+                                                    TAG: "Error",
+                                                    _0: "NotFound"
+                                                  });
+                                      };
+                                      var platform = {
+                                        determinePlatform: determinePlatform,
+                                        findCommand: findCommand,
+                                        alreadyDownloaded: alreadyDownloaded,
+                                        resolveDownloadChannel: resolveDownloadChannel,
+                                        download: download,
+                                        askUserAboutDownloadPolicy: askUserAboutDownloadPolicy
+                                      };
+                                      var selectedVersionString = "manual URL selection";
+                                      await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "MacOSArm64", false, selectedVersionString, "DevALS", undefined);
+                                      return Curry._3(Assert.deepStrictEqual, collectDownloadFlowEvents(logEvents.contents), [
+                                                  {
+                                                    TAG: "SelectionRequested",
+                                                    _0: "DevALS",
+                                                    _1: "MacOSArm64",
+                                                    _2: selectedVersionString,
+                                                    _3: false
+                                                  },
+                                                  {
+                                                    TAG: "SourceResolved",
+                                                    _0: "URL",
+                                                    _1: sourceVersion
+                                                  },
+                                                  {
+                                                    TAG: "DownloadStarted",
+                                                    _0: "DevALS",
+                                                    _1: "MacOSArm64",
+                                                    _2: selectedVersionString
+                                                  },
+                                                  {
+                                                    TAG: "DownloadSucceeded",
+                                                    _0: "/mock/url-backed/path"
+                                                  }
+                                                ], undefined);
                                     }));
                       }));
                 it("Log.toString renders DownloadTrace with stage and URL", (function () {

--- a/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
@@ -1621,7 +1621,7 @@ describe("Connection__Switch", (function () {
                                                       Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1),
                                                       ""
                                                     ];
-                                          case "ConnectionEstablished" :
+                                          case "ConnectionCreated" :
                                               var tmp;
                                               switch ($$event._1) {
                                                 case "Agda" :
@@ -1636,7 +1636,7 @@ describe("Connection__Switch", (function () {
                                                 
                                               }
                                               return [
-                                                      "ConnectionEstablished",
+                                                      "ConnectionCreated",
                                                       $$event._0,
                                                       tmp,
                                                       ""
@@ -1706,7 +1706,7 @@ describe("Connection__Switch", (function () {
                                         ""
                                       ],
                                       [
-                                        "ConnectionEstablished",
+                                        "ConnectionCreated",
                                         mockAgdaFsPath,
                                         "Agda",
                                         ""
@@ -1736,10 +1736,10 @@ describe("Connection__Switch", (function () {
                                               }
                                           case "EstablishFlow" :
                                               var match = $$event._0;
-                                              if (typeof match !== "object" || match.TAG !== "ConnectionEstablished") {
+                                              if (typeof match !== "object" || match.TAG !== "ConnectionCreated") {
                                                 return ;
                                               } else {
-                                                return "ConnectionEstablished:" + match._0;
+                                                return "ConnectionCreated:" + match._0;
                                               }
                                           case "Disconnected" :
                                               return "Disconnected:" + $$event._0;
@@ -1748,7 +1748,7 @@ describe("Connection__Switch", (function () {
                                         }
                                       }));
                                 Curry._3(Assert.deepStrictEqual, orderedKeys, [
-                                      "ConnectionEstablished:" + mockAgdaFsPath,
+                                      "ConnectionCreated:" + mockAgdaFsPath,
                                       "SwitchSucceeded:" + mockAgdaFsPath,
                                       "Disconnected:" + mockAgdaFsPath
                                     ], undefined);
@@ -1770,6 +1770,132 @@ describe("Connection__Switch", (function () {
                                             TAG: "Agda",
                                             _0: "2.7.0.1"
                                           }, undefined);
+                              }));
+                        it("should emit ConnectionFinalizeFailed when post-establish finalization throws", (async function () {
+                                var platform = makeMockPlatformWithBareCommands();
+                                var state = createTestStateWithPlatform(platform);
+                                var mockAgdaUri = Vscode.Uri.file(mockAgda.contents);
+                                var mockAgdaFsPath = mockAgdaUri.fsPath;
+                                var observedConnections = observeConnectionEvents(state);
+                                var restoreSetKind = ((() => {
+              const original = Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind;
+              Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind = () => Promise.reject(new Error("finalize injection"));
+              return () => { Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind = original; };
+            })());
+                                var completion = Core__Promise.$$catch(Connection$AgdaModeVscode.switchCandidate(state, "agda"), (function (param) {
+                                          return Promise.resolve();
+                                        })).then(function () {
+                                      return "done";
+                                    });
+                                var timeout = Util$AgdaModeVscode.Promise_.$$setTimeout(1000).then(function () {
+                                      return "timeout";
+                                    });
+                                var winner = await Promise.race([
+                                      completion,
+                                      timeout
+                                    ]);
+                                try {
+                                  var observedEstablishFlow = establishFlowEvents(observedConnections).map(function ($$event) {
+                                        if (typeof $$event === "object") {
+                                          switch ($$event.TAG) {
+                                            case "CandidateAttempted" :
+                                                return [
+                                                        "CandidateAttempted",
+                                                        $$event._0,
+                                                        Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1),
+                                                        ""
+                                                      ];
+                                            case "ConnectionFinalizeFailed" :
+                                                var tmp;
+                                                switch ($$event._1) {
+                                                  case "Agda" :
+                                                      tmp = "Agda";
+                                                      break;
+                                                  case "ALS" :
+                                                      tmp = "ALS";
+                                                      break;
+                                                  case "ALSWASM" :
+                                                      tmp = "ALSWASM";
+                                                      break;
+                                                  
+                                                }
+                                                return [
+                                                        "ConnectionFinalizeFailed",
+                                                        $$event._0,
+                                                        tmp,
+                                                        ""
+                                                      ];
+                                            default:
+                                              
+                                          }
+                                        }
+                                        return [
+                                                "Unexpected",
+                                                Log$AgdaModeVscode.Connection.EstablishFlow.toString($$event),
+                                                "",
+                                                ""
+                                              ];
+                                      });
+                                  var observedSwitchUIFlow = switchUIFlowEvents(observedConnections).map(function ($$event) {
+                                        switch ($$event.TAG) {
+                                          case "SwitchRequested" :
+                                              return [
+                                                      "SwitchRequested",
+                                                      $$event._0
+                                                    ];
+                                          case "SwitchSucceeded" :
+                                              return [
+                                                      "SwitchSucceeded",
+                                                      $$event._0
+                                                    ];
+                                          case "SwitchFailed" :
+                                              return [
+                                                      "SwitchFailed",
+                                                      $$event._0
+                                                    ];
+                                          
+                                        }
+                                      });
+                                  switch (winner) {
+                                    case "done" :
+                                        Curry._3(Assert.deepStrictEqual, observedEstablishFlow, [
+                                              [
+                                                "CandidateAttempted",
+                                                "agda",
+                                                "from config",
+                                                ""
+                                              ],
+                                              [
+                                                "ConnectionFinalizeFailed",
+                                                mockAgdaFsPath,
+                                                "Agda",
+                                                ""
+                                              ]
+                                            ], undefined);
+                                        Curry._3(Assert.deepStrictEqual, observedSwitchUIFlow, [
+                                              [
+                                                "SwitchRequested",
+                                                "agda"
+                                              ],
+                                              [
+                                                "SwitchFailed",
+                                                "agda"
+                                              ]
+                                            ], undefined);
+                                        break;
+                                    case "timeout" :
+                                        Registry__Connection$AgdaModeVscode.status.contents = "Empty";
+                                        Assert.fail("switchAgdaVersion hung during post-establish failure");
+                                        break;
+                                    default:
+                                      Assert.fail("Unexpected race result");
+                                  }
+                                  return restoreSetKind();
+                                }
+                                catch (exn){
+                                  restoreSetKind();
+                                  throw exn;
+                                }
                               }));
                         it("should mark the active connection candidate selected when no preferred candidate is stored", (async function () {
                                 var state = createTestState();

--- a/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
@@ -27,6 +27,7 @@ var Desktop$AgdaModeVscode = require("../../../src/Main/Desktop.bs.js");
 var Memento$AgdaModeVscode = require("../../../src/Memento.bs.js");
 var Connection$AgdaModeVscode = require("../../../src/Connection/Connection.bs.js");
 var Test__Util$AgdaModeVscode = require("../Test__Util.bs.js");
+var Connection__Error$AgdaModeVscode = require("../../../src/Connection/Shared/Connection__Error.bs.js");
 var Connection__Switch$AgdaModeVscode = require("../../../src/Connection/Connection__Switch.bs.js");
 var Connection__Command$AgdaModeVscode = require("../../../src/Connection/Resolver/Connection__Command.bs.js");
 var Registry__Connection$AgdaModeVscode = require("../../../src/Registry__Connection.bs.js");
@@ -1367,6 +1368,23 @@ describe("Connection__Switch", (function () {
                                 }));
                           return events;
                         };
+                        var observeEstablishFlow = function (state) {
+                          var events = {
+                            contents: []
+                          };
+                          Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
+                                  if (logEvent.TAG !== "Connection") {
+                                    return ;
+                                  }
+                                  var $$event = logEvent._0;
+                                  if ($$event.TAG === "EstablishFlow") {
+                                    events.contents = events.contents.concat([$$event._0]);
+                                    return ;
+                                  }
+                                  
+                                }));
+                          return events;
+                        };
                         it("should keep existing shared connection when switch target cannot be established", (async function () {
                                 var state = createTestState();
                                 var existingPath = "/usr/bin/agda";
@@ -1385,6 +1403,7 @@ describe("Connection__Switch", (function () {
                                 var missingPathKey = missingUri.fsPath;
                                 var missingUriString = missingUri.toString();
                                 var probeFlowEvents = observeProbeFlow(state);
+                                var establishFlowEvents = observeEstablishFlow(state);
                                 var completion = Connection$AgdaModeVscode.switchCandidate(state, missingPath).then(function () {
                                       return "done";
                                     });
@@ -1434,6 +1453,29 @@ describe("Connection__Switch", (function () {
                                                 ];
                                       }
                                     });
+                                var observedEstablishFlow = establishFlowEvents.contents.map(function ($$event) {
+                                      if (typeof $$event !== "object") {
+                                        if ($$event === "ConnectionEstablishFailed") {
+                                          return [
+                                                  "ConnectionEstablishFailed",
+                                                  "",
+                                                  ""
+                                                ];
+                                        }
+                                        
+                                      } else if ($$event.TAG === "CandidateAttempted") {
+                                        return [
+                                                "CandidateAttempted",
+                                                $$event._0,
+                                                Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1)
+                                              ];
+                                      }
+                                      return [
+                                              "Unexpected",
+                                              Log$AgdaModeVscode.Connection.EstablishFlow.toString($$event),
+                                              ""
+                                            ];
+                                    });
                                 switch (winner) {
                                   case "done" :
                                       Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
@@ -1462,6 +1504,18 @@ describe("Connection__Switch", (function () {
                                               ""
                                             ]
                                           ], undefined);
+                                      Curry._3(Assert.deepStrictEqual, observedEstablishFlow, [
+                                            [
+                                              "CandidateAttempted",
+                                              missingPath,
+                                              "from config"
+                                            ],
+                                            [
+                                              "ConnectionEstablishFailed",
+                                              "",
+                                              ""
+                                            ]
+                                          ], undefined);
                                       var resource = Registry__Connection$AgdaModeVscode.status.contents;
                                       if (typeof resource !== "object" || resource.TAG !== "Active") {
                                         Assert.fail("Expected existing shared connection to remain active when switch target fails to establish");
@@ -1485,6 +1539,7 @@ describe("Connection__Switch", (function () {
                                 var mockAgdaUriString = mockAgdaUri.toString();
                                 var mockAgdaFsPath = mockAgdaUri.fsPath;
                                 var probeFlowEvents = observeProbeFlow(state);
+                                var establishFlowEvents = observeEstablishFlow(state);
                                 await Connection$AgdaModeVscode.switchCandidate(state, "agda");
                                 var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
                                       switch ($$event.TAG) {
@@ -1525,6 +1580,47 @@ describe("Connection__Switch", (function () {
                                                 ];
                                       }
                                     });
+                                var observedEstablishFlow = establishFlowEvents.contents.map(function ($$event) {
+                                      if (typeof $$event === "object") {
+                                        switch ($$event.TAG) {
+                                          case "CandidateAttempted" :
+                                              return [
+                                                      "CandidateAttempted",
+                                                      $$event._0,
+                                                      Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1),
+                                                      ""
+                                                    ];
+                                          case "ConnectionEstablished" :
+                                              var tmp;
+                                              switch ($$event._1) {
+                                                case "Agda" :
+                                                    tmp = "Agda";
+                                                    break;
+                                                case "ALS" :
+                                                    tmp = "ALS";
+                                                    break;
+                                                case "ALSWASM" :
+                                                    tmp = "ALSWASM";
+                                                    break;
+                                                
+                                              }
+                                              return [
+                                                      "ConnectionEstablished",
+                                                      $$event._0,
+                                                      tmp,
+                                                      ""
+                                                    ];
+                                          default:
+                                            
+                                        }
+                                      }
+                                      return [
+                                              "Unexpected",
+                                              Log$AgdaModeVscode.Connection.EstablishFlow.toString($$event),
+                                              "",
+                                              ""
+                                            ];
+                                    });
                                 Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
                                       [
                                         "CandidateResolveStarted",
@@ -1548,6 +1644,20 @@ describe("Connection__Switch", (function () {
                                         "ProbeClassifiedAsAgda",
                                         mockAgdaFsPath,
                                         "2.7.0.1",
+                                        ""
+                                      ]
+                                    ], undefined);
+                                Curry._3(Assert.deepStrictEqual, observedEstablishFlow, [
+                                      [
+                                        "CandidateAttempted",
+                                        "agda",
+                                        "from config",
+                                        ""
+                                      ],
+                                      [
+                                        "ConnectionEstablished",
+                                        mockAgdaFsPath,
+                                        "Agda",
                                         ""
                                       ]
                                     ], undefined);

--- a/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
@@ -1351,39 +1351,42 @@ describe("Connection__Switch", (function () {
                         var createTestState = function () {
                           return createTestStateWithPlatform(Mock$AgdaModeVscode.Platform.makeWithAgda());
                         };
-                        var observeProbeFlow = function (state) {
+                        var observeConnectionEvents = function (state) {
                           var events = {
                             contents: []
                           };
                           Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
-                                  if (logEvent.TAG !== "Connection") {
-                                    return ;
-                                  }
-                                  var $$event = logEvent._0;
-                                  if ($$event.TAG === "ProbeFlow") {
-                                    events.contents = events.contents.concat([$$event._0]);
+                                  if (logEvent.TAG === "Connection") {
+                                    events.contents = events.contents.concat([logEvent._0]);
                                     return ;
                                   }
                                   
                                 }));
                           return events;
                         };
-                        var observeEstablishFlow = function (state) {
-                          var events = {
-                            contents: []
-                          };
-                          Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
-                                  if (logEvent.TAG !== "Connection") {
-                                    return ;
-                                  }
-                                  var $$event = logEvent._0;
-                                  if ($$event.TAG === "EstablishFlow") {
-                                    events.contents = events.contents.concat([$$event._0]);
-                                    return ;
-                                  }
-                                  
-                                }));
-                          return events;
+                        var probeFlowEvents = function (observedConnections) {
+                          return Core__Array.filterMap(observedConnections.contents, (function (connectionEvent) {
+                                        if (connectionEvent.TAG === "ProbeFlow") {
+                                          return connectionEvent._0;
+                                        }
+                                        
+                                      }));
+                        };
+                        var establishFlowEvents = function (observedConnections) {
+                          return Core__Array.filterMap(observedConnections.contents, (function (connectionEvent) {
+                                        if (connectionEvent.TAG === "EstablishFlow") {
+                                          return connectionEvent._0;
+                                        }
+                                        
+                                      }));
+                        };
+                        var switchUIFlowEvents = function (observedConnections) {
+                          return Core__Array.filterMap(observedConnections.contents, (function (connectionEvent) {
+                                        if (connectionEvent.TAG === "SwitchUIFlow") {
+                                          return connectionEvent._0;
+                                        }
+                                        
+                                      }));
                         };
                         it("should keep existing shared connection when switch target cannot be established", (async function () {
                                 var state = createTestState();
@@ -1402,8 +1405,7 @@ describe("Connection__Switch", (function () {
                                 var missingUri = Vscode.Uri.file(missingPath);
                                 var missingPathKey = missingUri.fsPath;
                                 var missingUriString = missingUri.toString();
-                                var probeFlowEvents = observeProbeFlow(state);
-                                var establishFlowEvents = observeEstablishFlow(state);
+                                var observedConnections = observeConnectionEvents(state);
                                 var completion = Connection$AgdaModeVscode.switchCandidate(state, missingPath).then(function () {
                                       return "done";
                                     });
@@ -1414,7 +1416,7 @@ describe("Connection__Switch", (function () {
                                       completion,
                                       timeout
                                     ]);
-                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                var observedProbeFlow = probeFlowEvents(observedConnections).map(function ($$event) {
                                       switch ($$event.TAG) {
                                         case "CandidateResolveStarted" :
                                             return [
@@ -1453,7 +1455,7 @@ describe("Connection__Switch", (function () {
                                                 ];
                                       }
                                     });
-                                var observedEstablishFlow = establishFlowEvents.contents.map(function ($$event) {
+                                var observedEstablishFlow = establishFlowEvents(observedConnections).map(function ($$event) {
                                       if (typeof $$event !== "object") {
                                         if ($$event === "ConnectionEstablishFailed") {
                                           return [
@@ -1475,6 +1477,26 @@ describe("Connection__Switch", (function () {
                                               Log$AgdaModeVscode.Connection.EstablishFlow.toString($$event),
                                               ""
                                             ];
+                                    });
+                                var observedSwitchUIFlow = switchUIFlowEvents(observedConnections).map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "SwitchRequested" :
+                                            return [
+                                                    "SwitchRequested",
+                                                    $$event._0
+                                                  ];
+                                        case "SwitchSucceeded" :
+                                            return [
+                                                    "SwitchSucceeded",
+                                                    $$event._0
+                                                  ];
+                                        case "SwitchFailed" :
+                                            return [
+                                                    "SwitchFailed",
+                                                    $$event._0
+                                                  ];
+                                        
+                                      }
                                     });
                                 switch (winner) {
                                   case "done" :
@@ -1516,6 +1538,16 @@ describe("Connection__Switch", (function () {
                                               ""
                                             ]
                                           ], undefined);
+                                      Curry._3(Assert.deepStrictEqual, observedSwitchUIFlow, [
+                                            [
+                                              "SwitchRequested",
+                                              missingPath
+                                            ],
+                                            [
+                                              "SwitchFailed",
+                                              missingPath
+                                            ]
+                                          ], undefined);
                                       var resource = Registry__Connection$AgdaModeVscode.status.contents;
                                       if (typeof resource !== "object" || resource.TAG !== "Active") {
                                         Assert.fail("Expected existing shared connection to remain active when switch target fails to establish");
@@ -1538,10 +1570,9 @@ describe("Connection__Switch", (function () {
                                 var mockAgdaUri = Vscode.Uri.file(mockAgda.contents);
                                 var mockAgdaUriString = mockAgdaUri.toString();
                                 var mockAgdaFsPath = mockAgdaUri.fsPath;
-                                var probeFlowEvents = observeProbeFlow(state);
-                                var establishFlowEvents = observeEstablishFlow(state);
+                                var observedConnections = observeConnectionEvents(state);
                                 await Connection$AgdaModeVscode.switchCandidate(state, "agda");
-                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                var observedProbeFlow = probeFlowEvents(observedConnections).map(function ($$event) {
                                       switch ($$event.TAG) {
                                         case "CandidateResolveStarted" :
                                             return [
@@ -1580,7 +1611,7 @@ describe("Connection__Switch", (function () {
                                                 ];
                                       }
                                     });
-                                var observedEstablishFlow = establishFlowEvents.contents.map(function ($$event) {
+                                var observedEstablishFlow = establishFlowEvents(observedConnections).map(function ($$event) {
                                       if (typeof $$event === "object") {
                                         switch ($$event.TAG) {
                                           case "CandidateAttempted" :
@@ -1621,6 +1652,26 @@ describe("Connection__Switch", (function () {
                                               ""
                                             ];
                                     });
+                                var observedSwitchUIFlow = switchUIFlowEvents(observedConnections).map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "SwitchRequested" :
+                                            return [
+                                                    "SwitchRequested",
+                                                    $$event._0
+                                                  ];
+                                        case "SwitchSucceeded" :
+                                            return [
+                                                    "SwitchSucceeded",
+                                                    $$event._0
+                                                  ];
+                                        case "SwitchFailed" :
+                                            return [
+                                                    "SwitchFailed",
+                                                    $$event._0
+                                                  ];
+                                        
+                                      }
+                                    });
                                 Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
                                       [
                                         "CandidateResolveStarted",
@@ -1660,6 +1711,46 @@ describe("Connection__Switch", (function () {
                                         "Agda",
                                         ""
                                       ]
+                                    ], undefined);
+                                Curry._3(Assert.deepStrictEqual, observedSwitchUIFlow, [
+                                      [
+                                        "SwitchRequested",
+                                        "agda"
+                                      ],
+                                      [
+                                        "SwitchSucceeded",
+                                        mockAgdaFsPath
+                                      ]
+                                    ], undefined);
+                                var orderedKeys = Core__Array.filterMap(observedConnections.contents, (function ($$event) {
+                                        switch ($$event.TAG) {
+                                          case "SwitchUIFlow" :
+                                              var path = $$event._0;
+                                              switch (path.TAG) {
+                                                case "SwitchSucceeded" :
+                                                    return "SwitchSucceeded:" + path._0;
+                                                case "SwitchRequested" :
+                                                case "SwitchFailed" :
+                                                    return ;
+                                                
+                                              }
+                                          case "EstablishFlow" :
+                                              var match = $$event._0;
+                                              if (typeof match !== "object" || match.TAG !== "ConnectionEstablished") {
+                                                return ;
+                                              } else {
+                                                return "ConnectionEstablished:" + match._0;
+                                              }
+                                          case "Disconnected" :
+                                              return "Disconnected:" + $$event._0;
+                                          default:
+                                            return ;
+                                        }
+                                      }));
+                                Curry._3(Assert.deepStrictEqual, orderedKeys, [
+                                      "ConnectionEstablished:" + mockAgdaFsPath,
+                                      "SwitchSucceeded:" + mockAgdaFsPath,
+                                      "Disconnected:" + mockAgdaFsPath
                                     ], undefined);
                                 var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"), undefined, undefined, undefined);
                                 var resolved$1;

--- a/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
@@ -28,6 +28,7 @@ var Memento$AgdaModeVscode = require("../../../src/Memento.bs.js");
 var Connection$AgdaModeVscode = require("../../../src/Connection/Connection.bs.js");
 var Test__Util$AgdaModeVscode = require("../Test__Util.bs.js");
 var Connection__Switch$AgdaModeVscode = require("../../../src/Connection/Connection__Switch.bs.js");
+var Connection__Command$AgdaModeVscode = require("../../../src/Connection/Resolver/Connection__Command.bs.js");
 var Registry__Connection$AgdaModeVscode = require("../../../src/Registry__Connection.bs.js");
 var Connection__Candidate$AgdaModeVscode = require("../../../src/Connection/Connection__Candidate.bs.js");
 var Connection__UI__Labels$AgdaModeVscode = require("../../../src/Connection/UI/Connection__UI__Labels.bs.js");
@@ -860,6 +861,23 @@ describe("Connection__Switch", (function () {
                         var createTestStateWithPlatform = function (platform) {
                           return createTestStateWithPlatformAndStorage(platform, Vscode.Uri.file(Nodeos.tmpdir()));
                         };
+                        var observeProbeFlow = function (state) {
+                          var events = {
+                            contents: []
+                          };
+                          Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
+                                  if (logEvent.TAG !== "Connection") {
+                                    return ;
+                                  }
+                                  var $$event = logEvent._0;
+                                  if ($$event.TAG === "ProbeFlow") {
+                                    events.contents = events.contents.concat([$$event._0]);
+                                    return ;
+                                  }
+                                  
+                                }));
+                          return events;
+                        };
                         it("should write probe metadata under resolved identity for bare command candidates", (async function () {
                                 var platform = makeMockPlatformWithBareCommands();
                                 var state = createTestStateWithPlatform(platform);
@@ -912,6 +930,7 @@ describe("Connection__Switch", (function () {
                                           return item._2.kind;
                                         }
                                       }));
+                                var probeFlowEvents = observeProbeFlow(state);
                                 var changed = await Connection__Switch$AgdaModeVscode.SwitchVersionManager.probeVersions(manager, platform);
                                 var resolved_original = Connection__Candidate$AgdaModeVscode.make(devALSPath);
                                 var resolved_resource = Vscode.Uri.file(devALSPath);
@@ -919,6 +938,55 @@ describe("Connection__Switch", (function () {
                                   original: resolved_original,
                                   resource: resolved_resource
                                 };
+                                var expectedCandidate = Connection__Candidate$AgdaModeVscode.make(devALSPath);
+                                var expectedResolvedResource;
+                                if (expectedCandidate.TAG === "Command") {
+                                  throw {
+                                        RE_EXN_ID: "Failure",
+                                        _1: "Expected DevALS path candidate to parse as resource",
+                                        Error: new Error()
+                                      };
+                                }
+                                expectedResolvedResource = expectedCandidate._0;
+                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "CandidateResolveStarted" :
+                                            return [
+                                                    "CandidateResolveStarted",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "CandidateResolved" :
+                                            return [
+                                                    "CandidateResolved",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    $$event._1.toString(),
+                                                    ""
+                                                  ];
+                                        case "ProbeStarted" :
+                                            return [
+                                                    "ProbeStarted",
+                                                    $$event._0.toString(),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "ProbeClassifiedAsALS" :
+                                            return [
+                                                    "ProbeClassifiedAsALS",
+                                                    $$event._0,
+                                                    $$event._1,
+                                                    $$event._2
+                                                  ];
+                                        default:
+                                          return [
+                                                  "Unexpected",
+                                                  Log$AgdaModeVscode.Connection.ProbeFlow.toString($$event),
+                                                  "",
+                                                  ""
+                                                ];
+                                      }
+                                    });
                                 Curry._3(Assert.deepStrictEqual, preProbeKind, {
                                       TAG: "ALS",
                                       _0: "Native",
@@ -928,6 +996,32 @@ describe("Connection__Switch", (function () {
                                         undefined
                                       ]
                                     }, undefined);
+                                Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
+                                      [
+                                        "CandidateResolveStarted",
+                                        Connection__Candidate$AgdaModeVscode.toString(expectedCandidate),
+                                        "",
+                                        ""
+                                      ],
+                                      [
+                                        "CandidateResolved",
+                                        Connection__Candidate$AgdaModeVscode.toString(expectedCandidate),
+                                        expectedResolvedResource.toString(),
+                                        ""
+                                      ],
+                                      [
+                                        "ProbeStarted",
+                                        expectedResolvedResource.toString(),
+                                        "",
+                                        ""
+                                      ],
+                                      [
+                                        "ProbeClassifiedAsALS",
+                                        expectedResolvedResource.fsPath,
+                                        "1.2.3",
+                                        "2.8.0"
+                                      ]
+                                    ], undefined);
                                 Curry._3(Assert.deepStrictEqual, changed, true, undefined);
                                 Curry._3(Assert.deepStrictEqual, Core__Option.map(Memento$AgdaModeVscode.Module.ResolvedMetadata.get(state.memento, resolved), (function (entry) {
                                             return entry.kind;
@@ -976,6 +1070,209 @@ describe("Connection__Switch", (function () {
                                     }, undefined);
                                 await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, previousPaths);
                                 await FS$AgdaModeVscode.deleteRecursive(Vscode.Uri.file(storagePath));
+                              }));
+                        it("should emit ProbeFlow events including ProbeFailed when probing a non-executable file", (async function () {
+                                var nonExecPath = Nodepath.join(Nodeos.tmpdir(), "agda-probe-fail-test-" + String(Date.now() | 0) + ".txt");
+                                Nodefs.writeFileSync(nonExecPath, Buffer.from("not an executable"));
+                                var platform = Mock$AgdaModeVscode.Platform.makeWithAgda();
+                                var state = createTestStateWithPlatform(platform);
+                                var manager = Connection__Switch$AgdaModeVscode.SwitchVersionManager.make(state);
+                                var previousPaths = Config$AgdaModeVscode.Connection.getAgdaPaths();
+                                var probeFlowEvents = observeProbeFlow(state);
+                                await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, [nonExecPath]);
+                                var changed = await Connection__Switch$AgdaModeVscode.SwitchVersionManager.probeVersions(manager, platform);
+                                var pathKey = Vscode.Uri.file(nonExecPath).fsPath;
+                                var resourceUri = Vscode.Uri.file(nonExecPath).toString();
+                                var resolved_original = Connection__Candidate$AgdaModeVscode.make(nonExecPath);
+                                var resolved_resource = Vscode.Uri.file(nonExecPath);
+                                var resolved = {
+                                  original: resolved_original,
+                                  resource: resolved_resource
+                                };
+                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "CandidateResolveStarted" :
+                                            return [
+                                                    "CandidateResolveStarted",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "CandidateResolved" :
+                                            return [
+                                                    "CandidateResolved",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    $$event._1.toString(),
+                                                    ""
+                                                  ];
+                                        case "ProbeStarted" :
+                                            return [
+                                                    "ProbeStarted",
+                                                    $$event._0.toString(),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "ProbeFailed" :
+                                            return [
+                                                    "ProbeFailed",
+                                                    $$event._0,
+                                                    "",
+                                                    ""
+                                                  ];
+                                        default:
+                                          return [
+                                                  "Unexpected",
+                                                  Log$AgdaModeVscode.Connection.ProbeFlow.toString($$event),
+                                                  "",
+                                                  ""
+                                                ];
+                                      }
+                                    });
+                                var mementoEntry = Memento$AgdaModeVscode.Module.ResolvedMetadata.get(state.memento, resolved);
+                                var testResult;
+                                try {
+                                  Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
+                                        [
+                                          "CandidateResolveStarted",
+                                          resourceUri,
+                                          "",
+                                          ""
+                                        ],
+                                        [
+                                          "CandidateResolved",
+                                          resourceUri,
+                                          resourceUri,
+                                          ""
+                                        ],
+                                        [
+                                          "ProbeStarted",
+                                          resourceUri,
+                                          "",
+                                          ""
+                                        ],
+                                        [
+                                          "ProbeFailed",
+                                          pathKey,
+                                          "",
+                                          ""
+                                        ]
+                                      ], undefined);
+                                  Curry._3(Assert.deepStrictEqual, changed, true, undefined);
+                                  Curry._3(Assert.deepStrictEqual, Core__Option.map(mementoEntry, (function (e) {
+                                              return e.kind;
+                                            })), "Unknown", undefined);
+                                  Curry._3(Assert.deepStrictEqual, Core__Option.map(mementoEntry, (function (e) {
+                                              return Core__Option.isSome(e.error);
+                                            })), true, undefined);
+                                  testResult = {
+                                    TAG: "Ok",
+                                    _0: undefined
+                                  };
+                                }
+                                catch (raw_e){
+                                  var e = Caml_js_exceptions.internalToOCamlException(raw_e);
+                                  testResult = {
+                                    TAG: "Error",
+                                    _0: e
+                                  };
+                                }
+                                await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, previousPaths);
+                                try {
+                                  Nodefs.unlinkSync(nonExecPath);
+                                }
+                                catch (exn){
+                                  
+                                }
+                                if (testResult.TAG === "Ok") {
+                                  return ;
+                                }
+                                throw testResult._0;
+                              }));
+                        it("should emit CandidateResolveFailed ProbeFlow event when a bare command cannot be resolved", (async function () {
+                                var bareCommand = "agda-probe-command-fail-test";
+                                var platform = Mock$AgdaModeVscode.Platform.makeWithAgda();
+                                var state = createTestStateWithPlatform(platform);
+                                var manager = Connection__Switch$AgdaModeVscode.SwitchVersionManager.make(state);
+                                var previousPaths = Config$AgdaModeVscode.Connection.getAgdaPaths();
+                                var unrelatedResolved_original = Connection__Candidate$AgdaModeVscode.make("/usr/bin/agda-unrelated");
+                                var unrelatedResolved_resource = Vscode.Uri.file("/usr/bin/agda-unrelated");
+                                var unrelatedResolved = {
+                                  original: unrelatedResolved_original,
+                                  resource: unrelatedResolved_resource
+                                };
+                                await Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind(state.memento, unrelatedResolved, {
+                                      TAG: "Agda",
+                                      _0: "2.6.0"
+                                    });
+                                var probeFlowEvents = observeProbeFlow(state);
+                                await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, [bareCommand]);
+                                var changed = await Connection__Switch$AgdaModeVscode.SwitchVersionManager.probeVersions(manager, platform);
+                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "CandidateResolveStarted" :
+                                            return [
+                                                    "CandidateResolveStarted",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "CandidateResolveFailed" :
+                                            return [
+                                                    "CandidateResolveFailed",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    Connection__Command$AgdaModeVscode.$$Error.toString($$event._1),
+                                                    ""
+                                                  ];
+                                        default:
+                                          return [
+                                                  "Unexpected",
+                                                  Log$AgdaModeVscode.Connection.ProbeFlow.toString($$event),
+                                                  "",
+                                                  ""
+                                                ];
+                                      }
+                                    });
+                                var testResult;
+                                try {
+                                  Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
+                                        [
+                                          "CandidateResolveStarted",
+                                          bareCommand,
+                                          "",
+                                          ""
+                                        ],
+                                        [
+                                          "CandidateResolveFailed",
+                                          bareCommand,
+                                          "Command not found",
+                                          ""
+                                        ]
+                                      ], undefined);
+                                  Curry._3(Assert.deepStrictEqual, changed, true, undefined);
+                                  Curry._3(Assert.deepStrictEqual, Core__Option.map(Memento$AgdaModeVscode.Module.ResolvedMetadata.get(state.memento, unrelatedResolved), (function (e) {
+                                              return e.kind;
+                                            })), {
+                                        TAG: "Agda",
+                                        _0: "2.6.0"
+                                      }, undefined);
+                                  Curry._3(Assert.deepStrictEqual, Object.entries(Memento$AgdaModeVscode.Module.ResolvedMetadata.entries(state.memento)).length, 1, undefined);
+                                  testResult = {
+                                    TAG: "Ok",
+                                    _0: undefined
+                                  };
+                                }
+                                catch (raw_e){
+                                  var e = Caml_js_exceptions.internalToOCamlException(raw_e);
+                                  testResult = {
+                                    TAG: "Error",
+                                    _0: e
+                                  };
+                                }
+                                await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, previousPaths);
+                                if (testResult.TAG === "Ok") {
+                                  return ;
+                                }
+                                throw testResult._0;
                               }));
                       }));
                 describe("activate and switching", (function () {
@@ -1053,6 +1350,23 @@ describe("Connection__Switch", (function () {
                         var createTestState = function () {
                           return createTestStateWithPlatform(Mock$AgdaModeVscode.Platform.makeWithAgda());
                         };
+                        var observeProbeFlow = function (state) {
+                          var events = {
+                            contents: []
+                          };
+                          Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
+                                  if (logEvent.TAG !== "Connection") {
+                                    return ;
+                                  }
+                                  var $$event = logEvent._0;
+                                  if ($$event.TAG === "ProbeFlow") {
+                                    events.contents = events.contents.concat([$$event._0]);
+                                    return ;
+                                  }
+                                  
+                                }));
+                          return events;
+                        };
                         it("should keep existing shared connection when switch target cannot be established", (async function () {
                                 var state = createTestState();
                                 var existingPath = "/usr/bin/agda";
@@ -1066,7 +1380,12 @@ describe("Connection__Switch", (function () {
                                     queue: Promise.resolve()
                                   }
                                 };
-                                var completion = Connection$AgdaModeVscode.switchCandidate(state, "/__agda_mode_vscode_nonexistent__/binary_should_not_exist_280").then(function () {
+                                var missingPath = "/__agda_mode_vscode_nonexistent__/binary_should_not_exist_280";
+                                var missingUri = Vscode.Uri.file(missingPath);
+                                var missingPathKey = missingUri.fsPath;
+                                var missingUriString = missingUri.toString();
+                                var probeFlowEvents = observeProbeFlow(state);
+                                var completion = Connection$AgdaModeVscode.switchCandidate(state, missingPath).then(function () {
                                       return "done";
                                     });
                                 var timeout = Util$AgdaModeVscode.Promise_.$$setTimeout(1000).then(function () {
@@ -1076,8 +1395,73 @@ describe("Connection__Switch", (function () {
                                       completion,
                                       timeout
                                     ]);
+                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "CandidateResolveStarted" :
+                                            return [
+                                                    "CandidateResolveStarted",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "CandidateResolved" :
+                                            return [
+                                                    "CandidateResolved",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    $$event._1.toString(),
+                                                    ""
+                                                  ];
+                                        case "ProbeStarted" :
+                                            return [
+                                                    "ProbeStarted",
+                                                    $$event._0.toString(),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "ProbeFailed" :
+                                            return [
+                                                    "ProbeFailed",
+                                                    $$event._0,
+                                                    "",
+                                                    ""
+                                                  ];
+                                        default:
+                                          return [
+                                                  "Unexpected",
+                                                  Log$AgdaModeVscode.Connection.ProbeFlow.toString($$event),
+                                                  "",
+                                                  ""
+                                                ];
+                                      }
+                                    });
                                 switch (winner) {
                                   case "done" :
+                                      Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
+                                            [
+                                              "CandidateResolveStarted",
+                                              missingUriString,
+                                              "",
+                                              ""
+                                            ],
+                                            [
+                                              "CandidateResolved",
+                                              missingUriString,
+                                              missingUriString,
+                                              ""
+                                            ],
+                                            [
+                                              "ProbeStarted",
+                                              missingUriString,
+                                              "",
+                                              ""
+                                            ],
+                                            [
+                                              "ProbeFailed",
+                                              missingPathKey,
+                                              "",
+                                              ""
+                                            ]
+                                          ], undefined);
                                       var resource = Registry__Connection$AgdaModeVscode.status.contents;
                                       if (typeof resource !== "object" || resource.TAG !== "Active") {
                                         Assert.fail("Expected existing shared connection to remain active when switch target fails to establish");
@@ -1097,7 +1481,76 @@ describe("Connection__Switch", (function () {
                         it("should write switch metadata under resolved identity for bare command selection", (async function () {
                                 var platform = makeMockPlatformWithBareCommands();
                                 var state = createTestStateWithPlatform(platform);
+                                var mockAgdaUri = Vscode.Uri.file(mockAgda.contents);
+                                var mockAgdaUriString = mockAgdaUri.toString();
+                                var mockAgdaFsPath = mockAgdaUri.fsPath;
+                                var probeFlowEvents = observeProbeFlow(state);
                                 await Connection$AgdaModeVscode.switchCandidate(state, "agda");
+                                var observedProbeFlow = probeFlowEvents.contents.map(function ($$event) {
+                                      switch ($$event.TAG) {
+                                        case "CandidateResolveStarted" :
+                                            return [
+                                                    "CandidateResolveStarted",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "CandidateResolved" :
+                                            return [
+                                                    "CandidateResolved",
+                                                    Connection__Candidate$AgdaModeVscode.toString($$event._0),
+                                                    $$event._1.toString(),
+                                                    ""
+                                                  ];
+                                        case "ProbeStarted" :
+                                            return [
+                                                    "ProbeStarted",
+                                                    $$event._0.toString(),
+                                                    "",
+                                                    ""
+                                                  ];
+                                        case "ProbeClassifiedAsAgda" :
+                                            return [
+                                                    "ProbeClassifiedAsAgda",
+                                                    $$event._0,
+                                                    $$event._1,
+                                                    ""
+                                                  ];
+                                        default:
+                                          return [
+                                                  "Unexpected",
+                                                  Log$AgdaModeVscode.Connection.ProbeFlow.toString($$event),
+                                                  "",
+                                                  ""
+                                                ];
+                                      }
+                                    });
+                                Curry._3(Assert.deepStrictEqual, observedProbeFlow, [
+                                      [
+                                        "CandidateResolveStarted",
+                                        "agda",
+                                        "",
+                                        ""
+                                      ],
+                                      [
+                                        "CandidateResolved",
+                                        "agda",
+                                        mockAgdaUriString,
+                                        ""
+                                      ],
+                                      [
+                                        "ProbeStarted",
+                                        mockAgdaUriString,
+                                        "",
+                                        ""
+                                      ],
+                                      [
+                                        "ProbeClassifiedAsAgda",
+                                        mockAgdaFsPath,
+                                        "2.7.0.1",
+                                        ""
+                                      ]
+                                    ], undefined);
                                 var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"), undefined, undefined, undefined);
                                 var resolved$1;
                                 if (resolved.TAG === "Ok") {

--- a/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
@@ -27,6 +27,7 @@ var Desktop$AgdaModeVscode = require("../../../src/Main/Desktop.bs.js");
 var Memento$AgdaModeVscode = require("../../../src/Memento.bs.js");
 var Connection$AgdaModeVscode = require("../../../src/Connection/Connection.bs.js");
 var Test__Util$AgdaModeVscode = require("../Test__Util.bs.js");
+var Connection__URI$AgdaModeVscode = require("../../../src/Connection/Shared/Connection__URI.bs.js");
 var Connection__Error$AgdaModeVscode = require("../../../src/Connection/Shared/Connection__Error.bs.js");
 var Connection__Switch$AgdaModeVscode = require("../../../src/Connection/Connection__Switch.bs.js");
 var Connection__Command$AgdaModeVscode = require("../../../src/Connection/Resolver/Connection__Command.bs.js");
@@ -1402,7 +1403,8 @@ describe("Connection__Switch", (function () {
                                   }
                                 };
                                 var missingPath = "/__agda_mode_vscode_nonexistent__/binary_should_not_exist_280";
-                                var missingUri = Vscode.Uri.file(missingPath);
+                                var match = Connection__URI$AgdaModeVscode.parse(missingPath);
+                                var missingUri = match._1;
                                 var missingPathKey = missingUri.fsPath;
                                 var missingUriString = missingUri.toString();
                                 var observedConnections = observeConnectionEvents(state);

--- a/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__Switch.bs.js
@@ -319,7 +319,7 @@ describe("Connection__Switch", (function () {
                                 var manager = Connection__Switch$AgdaModeVscode.SwitchVersionManager.make(state);
                                 var previousPaths = Config$AgdaModeVscode.Connection.getAgdaPaths();
                                 await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, ["agda"]);
-                                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"));
+                                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"), undefined, undefined, undefined);
                                 var resolved$1;
                                 if (resolved.TAG === "Ok") {
                                   resolved$1 = resolved._0;
@@ -867,7 +867,7 @@ describe("Connection__Switch", (function () {
                                 var previousPaths = Config$AgdaModeVscode.Connection.getAgdaPaths();
                                 await Config$AgdaModeVscode.Connection.setAgdaPaths(state.channels.log, ["agda"]);
                                 var changed = await Connection__Switch$AgdaModeVscode.SwitchVersionManager.probeVersions(manager, platform);
-                                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"));
+                                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"), undefined, undefined, undefined);
                                 var resolved$1;
                                 if (resolved.TAG === "Ok") {
                                   resolved$1 = resolved._0;
@@ -1098,7 +1098,7 @@ describe("Connection__Switch", (function () {
                                 var platform = makeMockPlatformWithBareCommands();
                                 var state = createTestStateWithPlatform(platform);
                                 await Connection$AgdaModeVscode.switchCandidate(state, "agda");
-                                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"));
+                                var resolved = await Connection__Candidate$AgdaModeVscode.resolve(platform.findCommand, Connection__Candidate$AgdaModeVscode.make("agda"), undefined, undefined, undefined);
                                 var resolved$1;
                                 if (resolved.TAG === "Ok") {
                                   resolved$1 = resolved._0;

--- a/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
@@ -1237,7 +1237,7 @@ describe("Connection UI", (function () {
                         it("handleDownload downloaded=true should emit SelectionRequested, ManagedHit, ReusedExistingArtifact when artifact found", (async function () {
                                 return await withTempStorage("flow-managed-hit-", (async function (tempDir, storageUri) {
                                               var artifactDir = Nodepath.join(tempDir, "releases", "dev", "als-dev-Agda-2.8.0-wasm");
-                                              var wasmFile = Nodepath.join(artifactDir, "als.wasm");
+                                              var wasmFile = Vscode.Uri.file(Nodepath.join(artifactDir, "als.wasm")).fsPath;
                                               await Nodefs.promises.mkdir(artifactDir, {
                                                     recursive: true,
                                                     mode: 511

--- a/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
@@ -19,6 +19,7 @@ var State$AgdaModeVscode = require("../../../src/State/State.bs.js");
 var Config$AgdaModeVscode = require("../../../src/Config.bs.js");
 var Desktop$AgdaModeVscode = require("../../../src/Main/Desktop.bs.js");
 var Memento$AgdaModeVscode = require("../../../src/Memento.bs.js");
+var Connection$AgdaModeVscode = require("../../../src/Connection/Connection.bs.js");
 var Test__Util$AgdaModeVscode = require("../Test__Util.bs.js");
 var Connection__Switch$AgdaModeVscode = require("../../../src/Connection/Connection__Switch.bs.js");
 var Connection__Download$AgdaModeVscode = require("../../../src/Connection/Download/Connection__Download.bs.js");
@@ -109,70 +110,105 @@ describe("Connection UI", (function () {
                   }
                 };
                 it("candidate rows should route selection through the candidate seam", (async function () {
-                        var state = createTestState();
-                        var view = Connection__UI__Picker$AgdaModeVscode.make(state.channels.log);
-                        var selectedChannel = {
-                          contents: "DevALS"
-                        };
-                        var switchCalled = {
-                          contents: undefined
-                        };
-                        var sawDestroyed = {
-                          contents: false
-                        };
-                        var sawSelectionCompleted = {
-                          contents: false
-                        };
-                        var entry_kind = {
-                          TAG: "Agda",
-                          _0: "2.7.0.1"
-                        };
-                        var entry_timestamp = new Date();
-                        var entry = {
-                          kind: entry_kind,
-                          timestamp: entry_timestamp,
-                          error: undefined
-                        };
-                        Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
-                                if (logEvent.TAG !== "SwitchVersionUI") {
-                                  return ;
-                                }
-                                var tmp = logEvent._0;
-                                if (typeof tmp === "object") {
-                                  return ;
-                                }
-                                switch (tmp) {
-                                  case "Destroyed" :
-                                      sawDestroyed.contents = true;
+                        var mockAgda = await Test__Util$AgdaModeVscode.Candidate.Agda.mock("2.7.0.1", "agda-ui-switch-flow");
+                        try {
+                          var state = createTestState();
+                          var view = Connection__UI__Picker$AgdaModeVscode.make(state.channels.log);
+                          var selectedChannel = {
+                            contents: "DevALS"
+                          };
+                          var sawDestroyed = {
+                            contents: false
+                          };
+                          var sawSelectionCompleted = {
+                            contents: false
+                          };
+                          var switchUIFlowEvents = [];
+                          var entry_kind = {
+                            TAG: "Agda",
+                            _0: "2.7.0.1"
+                          };
+                          var entry_timestamp = new Date();
+                          var entry = {
+                            kind: entry_kind,
+                            timestamp: entry_timestamp,
+                            error: undefined
+                          };
+                          Chan$AgdaModeVscode.on(state.channels.log, (function (logEvent) {
+                                  switch (logEvent.TAG) {
+                                    case "SwitchVersionUI" :
+                                        var tmp = logEvent._0;
+                                        if (typeof tmp === "object") {
+                                          return ;
+                                        }
+                                        switch (tmp) {
+                                          case "Destroyed" :
+                                              sawDestroyed.contents = true;
+                                              return ;
+                                          case "SelectionCompleted" :
+                                              sawSelectionCompleted.contents = true;
+                                              return ;
+                                          default:
+                                            return ;
+                                        }
+                                    case "Connection" :
+                                        var $$event = logEvent._0;
+                                        if ($$event.TAG !== "SwitchUIFlow") {
+                                          return ;
+                                        }
+                                        switchUIFlowEvents.push($$event._0);
+                                        return ;
+                                    default:
                                       return ;
-                                  case "SelectionCompleted" :
-                                      sawSelectionCompleted.contents = true;
-                                      return ;
-                                  default:
-                                    return ;
+                                  }
+                                }));
+                          var onSelectionCompleted = Log$AgdaModeVscode.on(state.channels.log, (function (log) {
+                                  if (log.TAG !== "SwitchVersionUI") {
+                                    return false;
+                                  }
+                                  var tmp = log._0;
+                                  if (typeof tmp !== "object" && tmp === "SelectionCompleted") {
+                                    return true;
+                                  } else {
+                                    return false;
+                                  }
+                                }));
+                          var selectedItem = makePickerItem(state, {
+                                TAG: "Candidate",
+                                _0: mockAgda,
+                                _1: mockAgda,
+                                _2: entry,
+                                _3: false
+                              });
+                          Connection__UI__Handlers$AgdaModeVscode.onSelection(state, Mock$AgdaModeVscode.Platform.makeWithAgda(), selectedChannel, (function (_downloadItems) {
+                                  return Promise.resolve();
+                                }), view, [selectedItem], (function (param) {
+                                  return true;
+                                }), (function (path) {
+                                  return Connection$AgdaModeVscode.switchCandidate(state, path);
+                                }), (function (_channel) {
+                                  return Promise.resolve([]);
+                                }), undefined, undefined);
+                          await onSelectionCompleted;
+                          Curry._3(Assert.deepStrictEqual, switchUIFlowEvents, [
+                                {
+                                  TAG: "SwitchRequested",
+                                  _0: mockAgda
+                                },
+                                {
+                                  TAG: "SwitchSucceeded",
+                                  _0: mockAgda
                                 }
-                              }));
-                        var selectedItem = makePickerItem(state, {
-                              TAG: "Candidate",
-                              _0: "/tmp/agda",
-                              _1: "/tmp/agda",
-                              _2: entry,
-                              _3: false
-                            });
-                        Connection__UI__Handlers$AgdaModeVscode.onSelection(state, Mock$AgdaModeVscode.Platform.makeWithAgda(), selectedChannel, (function (_downloadItems) {
-                                return Promise.resolve();
-                              }), view, [selectedItem], (function (param) {
-                                return true;
-                              }), (function (path) {
-                                switchCalled.contents = path;
-                                return Promise.resolve();
-                              }), (function (_channel) {
-                                return Promise.resolve([]);
-                              }), undefined, undefined);
-                        await Test__Util$AgdaModeVscode.wait(200);
-                        Curry._3(Assert.deepStrictEqual, switchCalled.contents, "/tmp/agda", undefined);
-                        Curry._3(Assert.deepStrictEqual, sawDestroyed.contents, true, undefined);
-                        return Curry._3(Assert.deepStrictEqual, sawSelectionCompleted.contents, true, undefined);
+                              ], undefined);
+                          Curry._3(Assert.deepStrictEqual, Memento$AgdaModeVscode.Module.PreferredCandidate.get(state.memento), mockAgda, undefined);
+                          Curry._3(Assert.deepStrictEqual, sawDestroyed.contents, true, undefined);
+                          Curry._3(Assert.deepStrictEqual, sawSelectionCompleted.contents, true, undefined);
+                        }
+                        catch (exn){
+                          await Test__Util$AgdaModeVscode.Candidate.Agda.destroy(mockAgda);
+                          throw exn;
+                        }
+                        return await Test__Util$AgdaModeVscode.Candidate.Agda.destroy(mockAgda);
                       }));
                 it("non-candidate picker items should not trigger candidate selection", (async function () {
                         var state = createTestState();

--- a/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
@@ -30,6 +30,7 @@ var Connection__UI__Picker$AgdaModeVscode = require("../../../src/Connection/UI/
 var Connection__UI__Handlers$AgdaModeVscode = require("../../../src/Connection/UI/Connection__UI__Handlers.bs.js");
 var Connection__UI__ItemData$AgdaModeVscode = require("../../../src/Connection/UI/Connection__UI__ItemData.bs.js");
 var Connection__Download__Error$AgdaModeVscode = require("../../../src/Connection/Download/Connection__Download__Error.bs.js");
+var Connection__Download__Source$AgdaModeVscode = require("../../../src/Connection/Download/Connection__Download__Source.bs.js");
 
 function makeMockConnection(_path, _version) {
   return ({
@@ -936,6 +937,20 @@ describe("Connection UI", (function () {
                           await runCase(match[0], match[1], match[2]);
                         }
                       }));
+                var observeDownloadFlow = function (state) {
+                  var events = [];
+                  Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
+                          if (log.TAG !== "Connection") {
+                            return ;
+                          }
+                          var $$event = log._0;
+                          if ($$event.TAG !== "DownloadFlow") {
+                            return ;
+                          }
+                          events.push($$event._0);
+                        }));
+                  return events;
+                };
                 it("handleDownload downloaded=true WASM on desktop should add managed WASM path to config", (async function () {
                         return await withTempStorage("sv-wasm-handoff-", (async function (tempDir, globalStorageUri) {
                                       var logChannel = Chan$AgdaModeVscode.make();
@@ -1072,7 +1087,39 @@ describe("Connection UI", (function () {
                               }), (function (_channel) {
                                 return Promise.resolve([]);
                               }));
-                        await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", false, "ALS vTest", "DevALS", undefined);
+                        var events = observeDownloadFlow(state);
+                        var requestedVersionString = "ALS vTest";
+                        var resolvedSourceVersion = Connection__Download__Source$AgdaModeVscode.toVersionString({
+                              TAG: "FromURL",
+                              _0: "DevALS",
+                              _1: "https://example.invalid/dev-als.wasm",
+                              _2: "dev-als"
+                            });
+                        await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", false, requestedVersionString, "DevALS", undefined);
+                        Curry._3(Assert.deepStrictEqual, events, [
+                              {
+                                TAG: "SelectionRequested",
+                                _0: "DevALS",
+                                _1: "Wasm",
+                                _2: requestedVersionString,
+                                _3: false
+                              },
+                              {
+                                TAG: "SourceResolved",
+                                _0: "URL",
+                                _1: resolvedSourceVersion
+                              },
+                              {
+                                TAG: "DownloadStarted",
+                                _0: "DevALS",
+                                _1: "Wasm",
+                                _2: requestedVersionString
+                              },
+                              {
+                                TAG: "DownloadSucceeded",
+                                _0: downloadedPath
+                              }
+                            ], undefined);
                         return Curry._3(Assert.deepStrictEqual, downloadedChannel.contents, "DevALS", undefined);
                       }));
                 it("should show DevALS WASM downloaded candidate as dev build before probing", (function () {
@@ -1124,17 +1171,7 @@ describe("Connection UI", (function () {
                                 var downloadedPath = "/tmp/flow-obs-wasm/als.wasm";
                                 var platform = Mock$AgdaModeVscode.Platform.makeWithSuccessfulDownload(downloadedPath);
                                 var state = createTestStateWithPlatform(platform);
-                                var events = [];
-                                Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
-                                        if (log.TAG !== "Connection") {
-                                          return ;
-                                        }
-                                        var e = log._0;
-                                        if (e.TAG !== "DownloadFlow") {
-                                          return ;
-                                        }
-                                        events.push(e._0);
-                                      }));
+                                var events = observeDownloadFlow(state);
                                 await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", false, versionString, "DevALS", Caml_option.some(undefined));
                                 return Curry._3(Assert.deepStrictEqual, events, [
                                             {
@@ -1172,17 +1209,7 @@ describe("Connection UI", (function () {
                                               Nodefs.writeFileSync(wasmFile, Buffer.from("mock wasm"));
                                               var platform = Mock$AgdaModeVscode.Platform.makeBasic();
                                               var state = createTestStateWithPlatformAndStorage(platform, storageUri);
-                                              var events = [];
-                                              Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
-                                                      if (log.TAG !== "Connection") {
-                                                        return ;
-                                                      }
-                                                      var e = log._0;
-                                                      if (e.TAG !== "DownloadFlow") {
-                                                        return ;
-                                                      }
-                                                      events.push(e._0);
-                                                    }));
+                                              var events = observeDownloadFlow(state);
                                               await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", true, versionString, "DevALS", Caml_option.some(undefined));
                                               return Curry._3(Assert.deepStrictEqual, events, [
                                                           {
@@ -1208,17 +1235,7 @@ describe("Connection UI", (function () {
                                 return await withTempStorage("flow-managed-miss-", (async function (_tempDir, storageUri) {
                                               var platform = Mock$AgdaModeVscode.Platform.makeBasic();
                                               var state = createTestStateWithPlatformAndStorage(platform, storageUri);
-                                              var events = [];
-                                              Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
-                                                      if (log.TAG !== "Connection") {
-                                                        return ;
-                                                      }
-                                                      var e = log._0;
-                                                      if (e.TAG !== "DownloadFlow") {
-                                                        return ;
-                                                      }
-                                                      events.push(e._0);
-                                                    }));
+                                              var events = observeDownloadFlow(state);
                                               await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", true, versionString, "DevALS", Caml_option.some(undefined));
                                               return Curry._3(Assert.deepStrictEqual, events, [
                                                           {
@@ -1235,7 +1252,7 @@ describe("Connection UI", (function () {
                                                         ], undefined);
                                             }));
                               }));
-                        it("handleDownload downloaded=false should emit SelectionRequested, SourceResolved, DownloadStarted, DownloadFailed on download error", (async function () {
+                        it("handleDownload downloaded=false should emit download-requested -> source-resolved -> download-started -> download-failed on download error", (async function () {
                                 var cannotFindMsg = Connection__Download__Error$AgdaModeVscode.toString("CannotFindCompatibleALSRelease");
                                 var determinePlatform = async function () {
                                   return {
@@ -1288,42 +1305,33 @@ describe("Connection UI", (function () {
                                   askUserAboutDownloadPolicy: askUserAboutDownloadPolicy
                                 };
                                 var state = createTestStateWithPlatform(platform);
-                                var events = [];
-                                Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
-                                        if (log.TAG !== "Connection") {
-                                          return ;
-                                        }
-                                        var e = log._0;
-                                        if (e.TAG !== "DownloadFlow") {
-                                          return ;
-                                        }
-                                        events.push(e._0);
-                                      }));
+                                var events = observeDownloadFlow(state);
                                 await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", false, versionString, "DevALS", Caml_option.some(undefined));
-                                return Curry._3(Assert.deepStrictEqual, events, [
-                                            {
-                                              TAG: "SelectionRequested",
-                                              _0: "DevALS",
-                                              _1: "Wasm",
-                                              _2: versionString,
-                                              _3: false
-                                            },
-                                            {
-                                              TAG: "SourceResolved",
-                                              _0: "GitHub",
-                                              _1: versionString
-                                            },
-                                            {
-                                              TAG: "DownloadStarted",
-                                              _0: "DevALS",
-                                              _1: "Wasm",
-                                              _2: versionString
-                                            },
-                                            {
-                                              TAG: "DownloadFailed",
-                                              _0: cannotFindMsg
-                                            }
-                                          ], undefined);
+                                var expectedFlowEvents = [
+                                  {
+                                    TAG: "SelectionRequested",
+                                    _0: "DevALS",
+                                    _1: "Wasm",
+                                    _2: versionString,
+                                    _3: false
+                                  },
+                                  {
+                                    TAG: "SourceResolved",
+                                    _0: "GitHub",
+                                    _1: versionString
+                                  },
+                                  {
+                                    TAG: "DownloadStarted",
+                                    _0: "DevALS",
+                                    _1: "Wasm",
+                                    _2: versionString
+                                  },
+                                  {
+                                    TAG: "DownloadFailed",
+                                    _0: cannotFindMsg
+                                  }
+                                ];
+                                return Curry._3(Assert.deepStrictEqual, events, expectedFlowEvents, undefined);
                               }));
                       }));
               }));

--- a/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
+++ b/lib/js/test/tests/Connection/Test__Connection__UI.bs.js
@@ -29,6 +29,7 @@ var Connection__UI__Labels$AgdaModeVscode = require("../../../src/Connection/UI/
 var Connection__UI__Picker$AgdaModeVscode = require("../../../src/Connection/UI/Connection__UI__Picker.bs.js");
 var Connection__UI__Handlers$AgdaModeVscode = require("../../../src/Connection/UI/Connection__UI__Handlers.bs.js");
 var Connection__UI__ItemData$AgdaModeVscode = require("../../../src/Connection/UI/Connection__UI__ItemData.bs.js");
+var Connection__Download__Error$AgdaModeVscode = require("../../../src/Connection/Download/Connection__Download__Error.bs.js");
 
 function makeMockConnection(_path, _version) {
   return ({
@@ -1116,6 +1117,214 @@ describe("Connection UI", (function () {
                               }
                             });
                         return Curry._3(Assert.deepStrictEqual, hasSelectOtherChannels, true, undefined);
+                      }));
+                describe("DownloadFlow observability", (function () {
+                        var versionString = "Agda v2.8.0 Language Server (dev build)";
+                        it("handleDownload downloaded=false should emit SelectionRequested, SourceResolved, DownloadStarted, DownloadSucceeded", (async function () {
+                                var downloadedPath = "/tmp/flow-obs-wasm/als.wasm";
+                                var platform = Mock$AgdaModeVscode.Platform.makeWithSuccessfulDownload(downloadedPath);
+                                var state = createTestStateWithPlatform(platform);
+                                var events = [];
+                                Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
+                                        if (log.TAG !== "Connection") {
+                                          return ;
+                                        }
+                                        var e = log._0;
+                                        if (e.TAG !== "DownloadFlow") {
+                                          return ;
+                                        }
+                                        events.push(e._0);
+                                      }));
+                                await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", false, versionString, "DevALS", Caml_option.some(undefined));
+                                return Curry._3(Assert.deepStrictEqual, events, [
+                                            {
+                                              TAG: "SelectionRequested",
+                                              _0: "DevALS",
+                                              _1: "Wasm",
+                                              _2: versionString,
+                                              _3: false
+                                            },
+                                            {
+                                              TAG: "SourceResolved",
+                                              _0: "GitHub",
+                                              _1: versionString
+                                            },
+                                            {
+                                              TAG: "DownloadStarted",
+                                              _0: "DevALS",
+                                              _1: "Wasm",
+                                              _2: versionString
+                                            },
+                                            {
+                                              TAG: "DownloadSucceeded",
+                                              _0: downloadedPath
+                                            }
+                                          ], undefined);
+                              }));
+                        it("handleDownload downloaded=true should emit SelectionRequested, ManagedHit, ReusedExistingArtifact when artifact found", (async function () {
+                                return await withTempStorage("flow-managed-hit-", (async function (tempDir, storageUri) {
+                                              var artifactDir = Nodepath.join(tempDir, "releases", "dev", "als-dev-Agda-2.8.0-wasm");
+                                              var wasmFile = Nodepath.join(artifactDir, "als.wasm");
+                                              await Nodefs.promises.mkdir(artifactDir, {
+                                                    recursive: true,
+                                                    mode: 511
+                                                  });
+                                              Nodefs.writeFileSync(wasmFile, Buffer.from("mock wasm"));
+                                              var platform = Mock$AgdaModeVscode.Platform.makeBasic();
+                                              var state = createTestStateWithPlatformAndStorage(platform, storageUri);
+                                              var events = [];
+                                              Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
+                                                      if (log.TAG !== "Connection") {
+                                                        return ;
+                                                      }
+                                                      var e = log._0;
+                                                      if (e.TAG !== "DownloadFlow") {
+                                                        return ;
+                                                      }
+                                                      events.push(e._0);
+                                                    }));
+                                              await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", true, versionString, "DevALS", Caml_option.some(undefined));
+                                              return Curry._3(Assert.deepStrictEqual, events, [
+                                                          {
+                                                            TAG: "SelectionRequested",
+                                                            _0: "DevALS",
+                                                            _1: "Wasm",
+                                                            _2: versionString,
+                                                            _3: true
+                                                          },
+                                                          {
+                                                            TAG: "ManagedHit",
+                                                            _0: versionString,
+                                                            _1: wasmFile
+                                                          },
+                                                          {
+                                                            TAG: "ReusedExistingArtifact",
+                                                            _0: wasmFile
+                                                          }
+                                                        ], undefined);
+                                            }));
+                              }));
+                        it("handleDownload downloaded=true should emit SelectionRequested, ManagedMiss when artifact not found", (async function () {
+                                return await withTempStorage("flow-managed-miss-", (async function (_tempDir, storageUri) {
+                                              var platform = Mock$AgdaModeVscode.Platform.makeBasic();
+                                              var state = createTestStateWithPlatformAndStorage(platform, storageUri);
+                                              var events = [];
+                                              Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
+                                                      if (log.TAG !== "Connection") {
+                                                        return ;
+                                                      }
+                                                      var e = log._0;
+                                                      if (e.TAG !== "DownloadFlow") {
+                                                        return ;
+                                                      }
+                                                      events.push(e._0);
+                                                    }));
+                                              await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", true, versionString, "DevALS", Caml_option.some(undefined));
+                                              return Curry._3(Assert.deepStrictEqual, events, [
+                                                          {
+                                                            TAG: "SelectionRequested",
+                                                            _0: "DevALS",
+                                                            _1: "Wasm",
+                                                            _2: versionString,
+                                                            _3: true
+                                                          },
+                                                          {
+                                                            TAG: "ManagedMiss",
+                                                            _0: versionString
+                                                          }
+                                                        ], undefined);
+                                            }));
+                              }));
+                        it("handleDownload downloaded=false should emit SelectionRequested, SourceResolved, DownloadStarted, DownloadFailed on download error", (async function () {
+                                var cannotFindMsg = Connection__Download__Error$AgdaModeVscode.toString("CannotFindCompatibleALSRelease");
+                                var determinePlatform = async function () {
+                                  return {
+                                          TAG: "Ok",
+                                          _0: "MacOS_Arm"
+                                        };
+                                };
+                                var askUserAboutDownloadPolicy = async function () {
+                                  return "Yes";
+                                };
+                                var alreadyDownloaded = function (_globalStorageUri) {
+                                  return Promise.resolve(undefined);
+                                };
+                                var resolveDownloadChannel = Mock$AgdaModeVscode.DownloadDescriptor.mockWith(function (channel) {
+                                      if (channel === "LatestALS") {
+                                        return {
+                                                TAG: "Error",
+                                                _0: "CannotFindCompatibleALSRelease"
+                                              };
+                                      } else {
+                                        return {
+                                                TAG: "Ok",
+                                                _0: {
+                                                  TAG: "FromGitHub",
+                                                  _0: channel,
+                                                  _1: Mock$AgdaModeVscode.DownloadDescriptor.mockDevALSDescriptor
+                                                }
+                                              };
+                                      }
+                                    });
+                                var download = function (_globalStorageUri, _source, $staropt$star) {
+                                  $staropt$star !== undefined;
+                                  return Promise.resolve({
+                                              TAG: "Error",
+                                              _0: "CannotFindCompatibleALSRelease"
+                                            });
+                                };
+                                var findCommand = function (_command, _timeoutOpt) {
+                                  return Promise.resolve({
+                                              TAG: "Error",
+                                              _0: "NotFound"
+                                            });
+                                };
+                                var platform = {
+                                  determinePlatform: determinePlatform,
+                                  findCommand: findCommand,
+                                  alreadyDownloaded: alreadyDownloaded,
+                                  resolveDownloadChannel: resolveDownloadChannel,
+                                  download: download,
+                                  askUserAboutDownloadPolicy: askUserAboutDownloadPolicy
+                                };
+                                var state = createTestStateWithPlatform(platform);
+                                var events = [];
+                                Chan$AgdaModeVscode.on(state.channels.log, (function (log) {
+                                        if (log.TAG !== "Connection") {
+                                          return ;
+                                        }
+                                        var e = log._0;
+                                        if (e.TAG !== "DownloadFlow") {
+                                          return ;
+                                        }
+                                        events.push(e._0);
+                                      }));
+                                await Connection__UI__Handlers$AgdaModeVscode.handleDownload(state, platform, "Wasm", false, versionString, "DevALS", Caml_option.some(undefined));
+                                return Curry._3(Assert.deepStrictEqual, events, [
+                                            {
+                                              TAG: "SelectionRequested",
+                                              _0: "DevALS",
+                                              _1: "Wasm",
+                                              _2: versionString,
+                                              _3: false
+                                            },
+                                            {
+                                              TAG: "SourceResolved",
+                                              _0: "GitHub",
+                                              _1: versionString
+                                            },
+                                            {
+                                              TAG: "DownloadStarted",
+                                              _0: "DevALS",
+                                              _1: "Wasm",
+                                              _2: versionString
+                                            },
+                                            {
+                                              TAG: "DownloadFailed",
+                                              _0: cannotFindMsg
+                                            }
+                                          ], undefined);
+                              }));
                       }));
               }));
         describe("Background update", (function () {

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -19,6 +19,7 @@ var Caml_js_exceptions = require("rescript/lib/js/caml_js_exceptions.js");
 var Log$AgdaModeVscode = require("../../src/State/Log.bs.js");
 var Chan$AgdaModeVscode = require("../../src/Util/Chan.bs.js");
 var Mock$AgdaModeVscode = require("../../src/Main/Mock.bs.js");
+var State$AgdaModeVscode = require("../../src/State/State.bs.js");
 var Config$AgdaModeVscode = require("../../src/Config.bs.js");
 var Desktop$AgdaModeVscode = require("../../src/Main/Desktop.bs.js");
 var Memento$AgdaModeVscode = require("../../src/Memento.bs.js");
@@ -26,6 +27,7 @@ var Connection$AgdaModeVscode = require("../../src/Connection/Connection.bs.js")
 var Test__Util$AgdaModeVscode = require("./Test__Util.bs.js");
 var Connection__URI$AgdaModeVscode = require("../../src/Connection/Shared/Connection__URI.bs.js");
 var Connection__Error$AgdaModeVscode = require("../../src/Connection/Shared/Connection__Error.bs.js");
+var State__Connection$AgdaModeVscode = require("../../src/State/State__Connection.bs.js");
 var Connection__Command$AgdaModeVscode = require("../../src/Connection/Resolver/Connection__Command.bs.js");
 var Connection__Download$AgdaModeVscode = require("../../src/Connection/Download/Connection__Download.bs.js");
 var Connection__Candidate$AgdaModeVscode = require("../../src/Connection/Connection__Candidate.bs.js");
@@ -167,23 +169,47 @@ function establishFlowSnapshot($$event) {
   }
 }
 
-function collectEstablishFlow(listener) {
-  return Core__Array.filterMap(listener((function (log) {
-                      if (log.TAG === "Connection" && log._0.TAG === "EstablishFlow") {
-                        return true;
-                      } else {
-                        return false;
-                      }
-                    })), (function (log) {
-                  if (log.TAG !== "Connection") {
-                    return ;
-                  }
-                  var $$event = log._0;
-                  if ($$event.TAG === "EstablishFlow") {
-                    return $$event._0;
+function collectConnectionFlowSnapshots(listener, pickEvent, toSnapshot) {
+  return Core__Array.filterMap(listener(undefined), (function (log) {
+                  if (log.TAG === "Connection") {
+                    return pickEvent(log._0);
                   }
                   
-                })).map(establishFlowSnapshot);
+                })).map(toSnapshot);
+}
+
+function collectEstablishFlow(listener) {
+  return collectConnectionFlowSnapshots(listener, (function (connectionEvent) {
+                if (connectionEvent.TAG === "EstablishFlow") {
+                  return connectionEvent._0;
+                }
+                
+              }), establishFlowSnapshot);
+}
+
+function activationFlowSnapshot($$event) {
+  switch ($$event) {
+    case "ActivationStarted" :
+        return "ActivationStarted";
+    case "ExistingConnectionReused" :
+        return "ExistingConnectionReused";
+    case "FreshEstablishStarted" :
+        return "FreshEstablishStarted";
+    case "ActivationSucceeded" :
+        return "ActivationSucceeded";
+    case "ActivationFailed" :
+        return "ActivationFailed";
+    
+  }
+}
+
+function collectActivationFlow(listener) {
+  return collectConnectionFlowSnapshots(listener, (function (connectionEvent) {
+                if (connectionEvent.TAG === "ActivationFlow") {
+                  return connectionEvent._0;
+                }
+                
+              }), activationFlowSnapshot);
 }
 
 async function getAgdaTarget() {
@@ -1018,6 +1044,97 @@ describe("Connection", (function () {
                       }));
               }));
         describe("make with logging", (function () {
+                it("State__Connection.sendRequest should log ActivationFlow for reused existing connection", (async function () {
+                        var ctx = await Test__Util$AgdaModeVscode.AgdaMode.makeAndLoad("GoalTypeAndContext.agda");
+                        var listener = Log$AgdaModeVscode.collect(ctx.channels.log);
+                        await State__Connection$AgdaModeVscode.sendRequestAndCollectResponses(ctx.state, "Load");
+                        var activationEvents = collectActivationFlow(listener);
+                        Curry._3(Assert.deepStrictEqual, activationEvents, [
+                              "ActivationStarted",
+                              "ExistingConnectionReused",
+                              "ActivationSucceeded"
+                            ], undefined);
+                        return await Test__Util$AgdaModeVscode.AgdaMode.quit(ctx);
+                      }));
+                it("State__Connection.sendRequest should log ActivationFlow for fresh establish failure", (async function () {
+                        var configLogChannel = Chan$AgdaModeVscode.make();
+                        var previousPaths = Config$AgdaModeVscode.Connection.getAgdaPaths();
+                        var restorePaths = async function () {
+                          return await Config$AgdaModeVscode.Connection.setAgdaPaths(configLogChannel, previousPaths);
+                        };
+                        await Config$AgdaModeVscode.Connection.setAgdaPaths(configLogChannel, ["/__activation_flow_test_nonexistent__/agda"]);
+                        var determinePlatform = async function () {
+                          return {
+                                  TAG: "Ok",
+                                  _0: "MacOS_Arm"
+                                };
+                        };
+                        var askUserAboutDownloadPolicy = async function () {
+                          return "No";
+                        };
+                        var alreadyDownloaded = function (param) {
+                          return Promise.resolve(undefined);
+                        };
+                        var resolveDownloadChannel = function (_channel, _allowFallback) {
+                          return async function (_memento, _globalStorageUri, _platform) {
+                            return {
+                                    TAG: "Error",
+                                    _0: "CannotFindCompatibleALSRelease"
+                                  };
+                          };
+                        };
+                        var download = function (_globalStorageUri, _source, $staropt$star) {
+                          $staropt$star !== undefined;
+                          return Promise.resolve({
+                                      TAG: "Error",
+                                      _0: "CannotFindCompatibleALSRelease"
+                                    });
+                        };
+                        var findCommand = function (_command, _timeoutOpt) {
+                          return Promise.resolve({
+                                      TAG: "Error",
+                                      _0: "NotFound"
+                                    });
+                        };
+                        var channels_inputMethod = Chan$AgdaModeVscode.make();
+                        var channels_responseHandled = Chan$AgdaModeVscode.make();
+                        var channels_commandHandled = Chan$AgdaModeVscode.make();
+                        var channels_log = Chan$AgdaModeVscode.make();
+                        var channels = {
+                          inputMethod: channels_inputMethod,
+                          responseHandled: channels_responseHandled,
+                          commandHandled: channels_commandHandled,
+                          log: channels_log
+                        };
+                        var listener = Log$AgdaModeVscode.collect(channels_log);
+                        var editor = await Test__Util$AgdaModeVscode.$$File.open_(Test__Util$AgdaModeVscode.Path.asset("GoalTypeAndContext.agda"));
+                        var state = State$AgdaModeVscode.make("activation-failure-" + String(Date.now() | 0), {
+                              determinePlatform: determinePlatform,
+                              findCommand: findCommand,
+                              alreadyDownloaded: alreadyDownloaded,
+                              resolveDownloadChannel: resolveDownloadChannel,
+                              download: download,
+                              askUserAboutDownloadPolicy: askUserAboutDownloadPolicy
+                            }, channels, Vscode.Uri.file("/tmp/test-storage"), Test__Util$AgdaModeVscode.Path.extensionUri, Memento$AgdaModeVscode.make(undefined), editor, undefined);
+                        try {
+                          await State__Connection$AgdaModeVscode.sendRequest(state, (function (_response) {
+                                  return Promise.resolve();
+                                }), "Load");
+                          var activationEvents = collectActivationFlow(listener);
+                          Curry._3(Assert.deepStrictEqual, activationEvents, [
+                                "ActivationStarted",
+                                "FreshEstablishStarted",
+                                "ActivationFailed"
+                              ], undefined);
+                          await State$AgdaModeVscode.destroy(state, false);
+                          return await restorePaths();
+                        }
+                        catch (exn){
+                          await State$AgdaModeVscode.destroy(state, false);
+                          await restorePaths();
+                          throw exn;
+                        }
+                      }));
                 it("should log ConnectedToAgda when Agda connection succeeds", (async function () {
                         var logChannel = Chan$AgdaModeVscode.make();
                         var listener = Log$AgdaModeVscode.collect(logChannel);
@@ -1195,6 +1312,24 @@ describe("Connection", (function () {
                               "DownloadFallbackStarted:dev:macos-arm64",
                               "DownloadFallbackFailed",
                               "ConnectionEstablishFailed"
+                            ], undefined);
+                        var probeFlowEvents = collectConnectionFlowSnapshots(listener, (function (connectionEvent) {
+                                if (connectionEvent.TAG === "ProbeFlow") {
+                                  return connectionEvent._0;
+                                }
+                                
+                              }), (function ($$event) {
+                                if ($$event.TAG === "ProbeFailed") {
+                                  return "ProbeFailed:" + $$event._0;
+                                } else {
+                                  return probeFlowSnapshot($$event);
+                                }
+                              }));
+                        Curry._3(Assert.deepStrictEqual, probeFlowEvents, [
+                              "CandidateResolveStarted:file:///nonexistent/path",
+                              "CandidateResolved:file:///nonexistent/path->file:///nonexistent/path",
+                              "ProbeStarted:file:///nonexistent/path",
+                              "ProbeFailed:/nonexistent/path"
                             ], undefined);
                         var loggedEvents = listener(Log$AgdaModeVscode.isConnection);
                         return Curry._3(Assert.deepStrictEqual, loggedEvents, [], undefined);
@@ -2083,6 +2218,9 @@ exports.resourceFromRawPath = resourceFromRawPath;
 exports.observeProbeFlow = observeProbeFlow;
 exports.probeFlowSnapshot = probeFlowSnapshot;
 exports.establishFlowSnapshot = establishFlowSnapshot;
+exports.collectConnectionFlowSnapshots = collectConnectionFlowSnapshots;
 exports.collectEstablishFlow = collectEstablishFlow;
+exports.activationFlowSnapshot = activationFlowSnapshot;
+exports.collectActivationFlow = collectActivationFlow;
 exports.getAgdaTarget = getAgdaTarget;
 /*  Not a pure module */

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -135,7 +135,7 @@ async function getAgdaTarget() {
   var connection = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
           "agda",
           "FromConfig"
-        ]]);
+        ]], undefined);
   if (connection.TAG === "Ok") {
     return connection._0;
   } else {
@@ -675,7 +675,7 @@ describe("Connection", (function () {
                                     mockPath,
                                     "FromConfig"
                                   ]];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
                                 if (result.TAG === "Ok") {
                                   var connection = result._0;
                                   switch (connection.TAG) {
@@ -715,7 +715,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
                                 if (result.TAG === "Ok") {
                                   var connection = result._0;
                                   switch (connection.TAG) {
@@ -749,7 +749,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with invalid paths");
                                   return ;
@@ -767,7 +767,7 @@ describe("Connection", (function () {
                                 var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
                                         path,
                                         "FromConfig"
-                                      ]]);
+                                      ]], undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with invalid resource candidate");
                                   return ;
@@ -784,7 +784,7 @@ describe("Connection", (function () {
                         it("should return empty error when no paths provided", (async function () {
                                 var platformDeps = Mock$AgdaModeVscode.Platform.makeBasic();
                                 var paths = [];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with empty paths");
                                   return ;
@@ -810,7 +810,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
                                 if (result.TAG === "Ok") {
                                   return ;
                                 }
@@ -832,7 +832,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
                                 if (result.TAG === "Ok") {
                                   return ;
                                 }
@@ -854,7 +854,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with invalid commands");
                                   return ;
@@ -926,7 +926,7 @@ describe("Connection", (function () {
                                 var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
                                         "agda",
                                         "FromConfig"
-                                      ]]);
+                                      ]], undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error when resolved agda path cannot be probed");
                                   return ;
@@ -947,7 +947,7 @@ describe("Connection", (function () {
                         it("should return empty error when no commands provided", (async function () {
                                 var platformDeps = Desktop$AgdaModeVscode.make();
                                 var commands = [];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with empty commands");
                                   return ;

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -1350,11 +1350,15 @@ describe("Connection", (function () {
                                   return probeFlowSnapshot($$event);
                                 }
                               }));
+                        var match$1 = Connection__URI$AgdaModeVscode.parse("/nonexistent/path");
+                        var nonexistentUri = match$1._1;
+                        var nonexistentUriString = nonexistentUri.toString();
+                        var nonexistentFsPath = nonexistentUri.fsPath;
                         Curry._3(Assert.deepStrictEqual, probeFlowEvents, [
-                              "CandidateResolveStarted:file:///nonexistent/path",
-                              "CandidateResolved:file:///nonexistent/path->file:///nonexistent/path",
-                              "ProbeStarted:file:///nonexistent/path",
-                              "ProbeFailed:/nonexistent/path"
+                              "CandidateResolveStarted:" + nonexistentUriString,
+                              "CandidateResolved:" + nonexistentUriString + "->" + nonexistentUriString,
+                              "ProbeStarted:" + nonexistentUriString,
+                              "ProbeFailed:" + nonexistentFsPath
                             ], undefined);
                         var loggedEvents = listener(Log$AgdaModeVscode.isConnection);
                         return Curry._3(Assert.deepStrictEqual, loggedEvents, [], undefined);

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -167,6 +167,25 @@ function establishFlowSnapshot($$event) {
   }
 }
 
+function collectEstablishFlow(listener) {
+  return Core__Array.filterMap(listener((function (log) {
+                      if (log.TAG === "Connection" && log._0.TAG === "EstablishFlow") {
+                        return true;
+                      } else {
+                        return false;
+                      }
+                    })), (function (log) {
+                  if (log.TAG !== "Connection") {
+                    return ;
+                  }
+                  var $$event = log._0;
+                  if ($$event.TAG === "EstablishFlow") {
+                    return $$event._0;
+                  }
+                  
+                })).map(establishFlowSnapshot);
+}
+
 async function getAgdaTarget() {
   var platformDeps = Desktop$AgdaModeVscode.make();
   var connection = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
@@ -1121,13 +1140,62 @@ describe("Connection", (function () {
                         var logChannel = Chan$AgdaModeVscode.make();
                         var listener = Log$AgdaModeVscode.collect(logChannel);
                         var memento = Memento$AgdaModeVscode.make(undefined);
-                        var platformDeps = Mock$AgdaModeVscode.Platform.makeBasic();
+                        var determinePlatform = async function () {
+                          return {
+                                  TAG: "Ok",
+                                  _0: "MacOS_Arm"
+                                };
+                        };
+                        var askUserAboutDownloadPolicy = async function () {
+                          return "Yes";
+                        };
+                        var alreadyDownloaded = function (param) {
+                          return Promise.resolve(undefined);
+                        };
+                        var resolveDownloadChannel = function (_channel, _allowFallback) {
+                          return async function (_memento, _globalStorageUri, _platform) {
+                            return {
+                                    TAG: "Error",
+                                    _0: "CannotFindCompatibleALSRelease"
+                                  };
+                          };
+                        };
+                        var download = function (_globalStorageUri, _source, $staropt$star) {
+                          $staropt$star !== undefined;
+                          return Promise.resolve({
+                                      TAG: "Error",
+                                      _0: "CannotFindCompatibleALSRelease"
+                                    });
+                        };
+                        var findCommand = function (_command, _timeoutOpt) {
+                          return Promise.resolve({
+                                      TAG: "Error",
+                                      _0: "NotFound"
+                                    });
+                        };
+                        var platformDeps = {
+                          determinePlatform: determinePlatform,
+                          findCommand: findCommand,
+                          alreadyDownloaded: alreadyDownloaded,
+                          resolveDownloadChannel: resolveDownloadChannel,
+                          download: download,
+                          askUserAboutDownloadPolicy: askUserAboutDownloadPolicy
+                        };
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
                         var match = await Connection$AgdaModeVscode.makeWithFallback(platformDeps, memento, globalStorageUri, ["/nonexistent/path"], ["nonexistent-command"], logChannel);
                         if (match.TAG === "Ok") {
                           Assert.fail("Expected connection to fail");
                           return ;
                         }
+                        var establishFlowEvents = collectEstablishFlow(listener);
+                        Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
+                              "ConfigCandidatesStarted:1",
+                              "CandidateAttempted:/nonexistent/path:from config",
+                              "ConfigCandidatesFailed",
+                              "DownloadFallbackStarted:dev:macos-arm64",
+                              "DownloadFallbackFailed",
+                              "ConnectionEstablishFailed"
+                            ], undefined);
                         var loggedEvents = listener(Log$AgdaModeVscode.isConnection);
                         return Curry._3(Assert.deepStrictEqual, loggedEvents, [], undefined);
                       }));
@@ -1178,9 +1246,15 @@ describe("Connection", (function () {
                         var platformDeps = Desktop$AgdaModeVscode.make();
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
                         var result = await Connection$AgdaModeVscode.makeWithFallback(platformDeps, memento, globalStorageUri, [agdaMockPath], ["invalid-command"], logChannel);
+                        var establishFlowEvents = collectEstablishFlow(listener);
                         var loggedEvents = listener(Log$AgdaModeVscode.isConnection);
                         if (result.TAG === "Ok") {
                           var connection = result._0;
+                          Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
+                                "ConfigCandidatesStarted:1",
+                                "CandidateAttempted:" + agdaMockPath + ":from config",
+                                "ConnectionEstablished:" + agdaMockPath + ":Agda"
+                              ], undefined);
                           Curry._3(Assert.deepStrictEqual, loggedEvents, [{
                                   TAG: "Connection",
                                   _0: {
@@ -1436,22 +1510,7 @@ describe("Connection", (function () {
                         var platform = Mock$AgdaModeVscode.Platform.makeWithSuccessfulDownload(downloadedAgda.contents);
                         var result = await Connection$AgdaModeVscode.makeWithFallback(platform, memento, Vscode.Uri.file("/tmp/test-storage"), ["/invalid/path"], ["invalid-command"], logChannel);
                         if (result.TAG === "Ok") {
-                          var establishFlowEvents = Core__Array.filterMap(listener((function (log) {
-                                        if (log.TAG === "Connection" && log._0.TAG === "EstablishFlow") {
-                                          return true;
-                                        } else {
-                                          return false;
-                                        }
-                                      })), (function (log) {
-                                    if (log.TAG !== "Connection") {
-                                      return ;
-                                    }
-                                    var $$event = log._0;
-                                    if ($$event.TAG === "EstablishFlow") {
-                                      return $$event._0;
-                                    }
-                                    
-                                  })).map(establishFlowSnapshot);
+                          var establishFlowEvents = collectEstablishFlow(listener);
                           Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
                                 "ConfigCandidatesStarted:1",
                                 "CandidateAttempted:/invalid/path:from config",
@@ -2024,5 +2083,6 @@ exports.resourceFromRawPath = resourceFromRawPath;
 exports.observeProbeFlow = observeProbeFlow;
 exports.probeFlowSnapshot = probeFlowSnapshot;
 exports.establishFlowSnapshot = establishFlowSnapshot;
+exports.collectEstablishFlow = collectEstablishFlow;
 exports.getAgdaTarget = getAgdaTarget;
 /*  Not a pure module */

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -142,15 +142,15 @@ function establishFlowSnapshot($$event) {
     }
   }
   switch ($$event.TAG) {
-    case "ConfigCandidatesStarted" :
-        return "ConfigCandidatesStarted:" + String($$event._0);
+    case "ConfigCandidatesPlanned" :
+        return "ConfigCandidatesPlanned:" + String($$event._0);
     case "CandidateAttempted" :
         return "CandidateAttempted:" + $$event._0 + ":" + Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1);
     case "DownloadFallbackStarted" :
         return "DownloadFallbackStarted:" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + ":" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1);
     case "DownloadFallbackFailed" :
         return "DownloadFallbackFailed";
-    case "ConnectionEstablished" :
+    case "ConnectionCreated" :
         var tmp;
         switch ($$event._1) {
           case "Agda" :
@@ -164,7 +164,17 @@ function establishFlowSnapshot($$event) {
               break;
           
         }
-        return "ConnectionEstablished:" + $$event._0 + ":" + tmp;
+        return "ConnectionCreated:" + $$event._0 + ":" + tmp;
+    case "ConnectionFinalizeFailed" :
+        throw {
+              RE_EXN_ID: "Match_failure",
+              _1: [
+                "Test__Connection.res",
+                101,
+                2
+              ],
+              Error: new Error()
+            };
     
   }
 }
@@ -1306,7 +1316,7 @@ describe("Connection", (function () {
                         }
                         var establishFlowEvents = collectEstablishFlow(listener);
                         Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
-                              "ConfigCandidatesStarted:1",
+                              "ConfigCandidatesPlanned:1",
                               "CandidateAttempted:/nonexistent/path:from config",
                               "ConfigCandidatesFailed",
                               "DownloadFallbackStarted:dev:macos-arm64",
@@ -1386,9 +1396,9 @@ describe("Connection", (function () {
                         if (result.TAG === "Ok") {
                           var connection = result._0;
                           Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
-                                "ConfigCandidatesStarted:1",
+                                "ConfigCandidatesPlanned:1",
                                 "CandidateAttempted:" + agdaMockPath + ":from config",
-                                "ConnectionEstablished:" + agdaMockPath + ":Agda"
+                                "ConnectionCreated:" + agdaMockPath + ":Agda"
                               ], undefined);
                           Curry._3(Assert.deepStrictEqual, loggedEvents, [{
                                   TAG: "Connection",
@@ -1647,11 +1657,11 @@ describe("Connection", (function () {
                         if (result.TAG === "Ok") {
                           var establishFlowEvents = collectEstablishFlow(listener);
                           Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
-                                "ConfigCandidatesStarted:1",
+                                "ConfigCandidatesPlanned:1",
                                 "CandidateAttempted:/invalid/path:from config",
                                 "ConfigCandidatesFailed",
                                 "DownloadFallbackStarted:dev:macos-arm64",
-                                "ConnectionEstablished:" + downloadedAgda.contents + ":Agda"
+                                "ConnectionCreated:" + downloadedAgda.contents + ":Agda"
                               ], undefined);
                           Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), downloadedAgda.contents, undefined);
                           Curry._3(Assert.deepStrictEqual, Config$AgdaModeVscode.Connection.getAgdaPaths(), [

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -30,6 +30,7 @@ var Connection__Command$AgdaModeVscode = require("../../src/Connection/Resolver/
 var Connection__Download$AgdaModeVscode = require("../../src/Connection/Download/Connection__Download.bs.js");
 var Connection__Candidate$AgdaModeVscode = require("../../src/Connection/Connection__Candidate.bs.js");
 var Connection__Download__Channel$AgdaModeVscode = require("../../src/Connection/Download/Connection__Download__Channel.bs.js");
+var Connection__Download__DownloadArtifact$AgdaModeVscode = require("../../src/Connection/Download/Connection__Download__DownloadArtifact.bs.js");
 
 async function withTempStorage(prefix, f) {
   var tempDir = await Promises.mkdtemp(Nodepath.join(Nodeos.tmpdir(), prefix));
@@ -130,12 +131,48 @@ function probeFlowSnapshot($$event) {
   }
 }
 
+function establishFlowSnapshot($$event) {
+  if (typeof $$event !== "object") {
+    if ($$event === "ConfigCandidatesFailed") {
+      return "ConfigCandidatesFailed";
+    } else {
+      return "ConnectionEstablishFailed";
+    }
+  }
+  switch ($$event.TAG) {
+    case "ConfigCandidatesStarted" :
+        return "ConfigCandidatesStarted:" + String($$event._0);
+    case "CandidateAttempted" :
+        return "CandidateAttempted:" + $$event._0 + ":" + Connection__Error$AgdaModeVscode.Establish.pathSourceToString($$event._1);
+    case "DownloadFallbackStarted" :
+        return "DownloadFallbackStarted:" + Connection__Download__Channel$AgdaModeVscode.toString($$event._0) + ":" + Connection__Download__DownloadArtifact$AgdaModeVscode.Platform.toAssetTag($$event._1);
+    case "DownloadFallbackFailed" :
+        return "DownloadFallbackFailed";
+    case "ConnectionEstablished" :
+        var tmp;
+        switch ($$event._1) {
+          case "Agda" :
+              tmp = "Agda";
+              break;
+          case "ALS" :
+              tmp = "ALS";
+              break;
+          case "ALSWASM" :
+              tmp = "ALSWASM";
+              break;
+          
+        }
+        return "ConnectionEstablished:" + $$event._0 + ":" + tmp;
+    
+  }
+}
+
 async function getAgdaTarget() {
   var platformDeps = Desktop$AgdaModeVscode.make();
   var connection = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
           "agda",
           "FromConfig"
-        ]], undefined);
+        ]], undefined, undefined);
   if (connection.TAG === "Ok") {
     return connection._0;
   } else {
@@ -675,7 +712,7 @@ describe("Connection", (function () {
                                     mockPath,
                                     "FromConfig"
                                   ]];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   var connection = result._0;
                                   switch (connection.TAG) {
@@ -715,7 +752,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   var connection = result._0;
                                   switch (connection.TAG) {
@@ -749,7 +786,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with invalid paths");
                                   return ;
@@ -767,7 +804,7 @@ describe("Connection", (function () {
                                 var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
                                         path,
                                         "FromConfig"
-                                      ]], undefined);
+                                      ]], undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with invalid resource candidate");
                                   return ;
@@ -784,7 +821,7 @@ describe("Connection", (function () {
                         it("should return empty error when no paths provided", (async function () {
                                 var platformDeps = Mock$AgdaModeVscode.Platform.makeBasic();
                                 var paths = [];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, paths, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with empty paths");
                                   return ;
@@ -810,7 +847,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   return ;
                                 }
@@ -832,7 +869,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   return ;
                                 }
@@ -854,7 +891,7 @@ describe("Connection", (function () {
                                     "FromConfig"
                                   ]
                                 ];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with invalid commands");
                                   return ;
@@ -926,7 +963,7 @@ describe("Connection", (function () {
                                 var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
                                         "agda",
                                         "FromConfig"
-                                      ]], undefined);
+                                      ]], undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error when resolved agda path cannot be probed");
                                   return ;
@@ -947,7 +984,7 @@ describe("Connection", (function () {
                         it("should return empty error when no commands provided", (async function () {
                                 var platformDeps = Desktop$AgdaModeVscode.make();
                                 var commands = [];
-                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined);
+                                var result = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, commands, undefined, undefined);
                                 if (result.TAG === "Ok") {
                                   Assert.fail("Expected error with empty commands");
                                   return ;
@@ -963,11 +1000,8 @@ describe("Connection", (function () {
               }));
         describe("make with logging", (function () {
                 it("should log ConnectedToAgda when Agda connection succeeds", (async function () {
-                        var loggedEvents = [];
                         var logChannel = Chan$AgdaModeVscode.make();
-                        Chan$AgdaModeVscode.on(logChannel, (function (logEvent) {
-                                loggedEvents.push(logEvent);
-                              }));
+                        var listener = Log$AgdaModeVscode.collect(logChannel);
                         var agdaMockPath = await Test__Util$AgdaModeVscode.Candidate.Agda.mock("2.6.4", "agda-mock-for-make");
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var platformDeps = Desktop$AgdaModeVscode.make();
@@ -975,6 +1009,7 @@ describe("Connection", (function () {
                         var connection = await Connection$AgdaModeVscode.makeWithFallback(platformDeps, memento, globalStorageUri, [agdaMockPath], [], logChannel);
                         if (connection.TAG === "Ok") {
                           var connection$1 = connection._0;
+                          var loggedEvents = listener(Log$AgdaModeVscode.isConnection);
                           Curry._3(Assert.deepStrictEqual, loggedEvents, [{
                                   TAG: "Connection",
                                   _0: {
@@ -1083,19 +1118,18 @@ describe("Connection", (function () {
                         }
                       }));
                 it("should not log connection events when connection fails", (async function () {
-                        var loggedEvents = [];
                         var logChannel = Chan$AgdaModeVscode.make();
-                        Chan$AgdaModeVscode.on(logChannel, (function (logEvent) {
-                                loggedEvents.push(logEvent);
-                              }));
+                        var listener = Log$AgdaModeVscode.collect(logChannel);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var platformDeps = Mock$AgdaModeVscode.Platform.makeBasic();
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
                         var match = await Connection$AgdaModeVscode.makeWithFallback(platformDeps, memento, globalStorageUri, ["/nonexistent/path"], ["nonexistent-command"], logChannel);
-                        if (match.TAG !== "Ok") {
-                          return Curry._3(Assert.deepStrictEqual, loggedEvents, [], undefined);
+                        if (match.TAG === "Ok") {
+                          Assert.fail("Expected connection to fail");
+                          return ;
                         }
-                        Assert.fail("Expected connection to fail");
+                        var loggedEvents = listener(Log$AgdaModeVscode.isConnection);
+                        return Curry._3(Assert.deepStrictEqual, loggedEvents, [], undefined);
                       }));
                 it.skip("should log connection events even when falling back to downloads", (async function () {
                         var loggedEvents = [];
@@ -1395,12 +1429,36 @@ describe("Connection", (function () {
                       }));
                 it("should update connection.paths but not PreferredCandidate after automatic fallback download", (async function () {
                         var logChannel = Chan$AgdaModeVscode.make();
+                        var listener = Log$AgdaModeVscode.collect(logChannel);
                         await Config$AgdaModeVscode.Connection.setAgdaPaths(logChannel, []);
                         await Config$AgdaModeVscode.Connection.DownloadPolicy.set("Undecided");
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var platform = Mock$AgdaModeVscode.Platform.makeWithSuccessfulDownload(downloadedAgda.contents);
                         var result = await Connection$AgdaModeVscode.makeWithFallback(platform, memento, Vscode.Uri.file("/tmp/test-storage"), ["/invalid/path"], ["invalid-command"], logChannel);
                         if (result.TAG === "Ok") {
+                          var establishFlowEvents = Core__Array.filterMap(listener((function (log) {
+                                        if (log.TAG === "Connection" && log._0.TAG === "EstablishFlow") {
+                                          return true;
+                                        } else {
+                                          return false;
+                                        }
+                                      })), (function (log) {
+                                    if (log.TAG !== "Connection") {
+                                      return ;
+                                    }
+                                    var $$event = log._0;
+                                    if ($$event.TAG === "EstablishFlow") {
+                                      return $$event._0;
+                                    }
+                                    
+                                  })).map(establishFlowSnapshot);
+                          Curry._3(Assert.deepStrictEqual, establishFlowEvents, [
+                                "ConfigCandidatesStarted:1",
+                                "CandidateAttempted:/invalid/path:from config",
+                                "ConfigCandidatesFailed",
+                                "DownloadFallbackStarted:dev:macos-arm64",
+                                "ConnectionEstablished:" + downloadedAgda.contents + ":Agda"
+                              ], undefined);
                           Curry._3(Assert.deepStrictEqual, Connection$AgdaModeVscode.getPath(result._0), downloadedAgda.contents, undefined);
                           Curry._3(Assert.deepStrictEqual, Config$AgdaModeVscode.Connection.getAgdaPaths(), [
                                 downloadedAgda.contents,
@@ -1965,5 +2023,6 @@ exports.findProbeByLocalPath = findProbeByLocalPath;
 exports.resourceFromRawPath = resourceFromRawPath;
 exports.observeProbeFlow = observeProbeFlow;
 exports.probeFlowSnapshot = probeFlowSnapshot;
+exports.establishFlowSnapshot = establishFlowSnapshot;
 exports.getAgdaTarget = getAgdaTarget;
 /*  Not a pure module */

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -25,8 +25,10 @@ var Memento$AgdaModeVscode = require("../../src/Memento.bs.js");
 var Connection$AgdaModeVscode = require("../../src/Connection/Connection.bs.js");
 var Test__Util$AgdaModeVscode = require("./Test__Util.bs.js");
 var Connection__URI$AgdaModeVscode = require("../../src/Connection/Shared/Connection__URI.bs.js");
+var Connection__Error$AgdaModeVscode = require("../../src/Connection/Shared/Connection__Error.bs.js");
 var Connection__Command$AgdaModeVscode = require("../../src/Connection/Resolver/Connection__Command.bs.js");
 var Connection__Download$AgdaModeVscode = require("../../src/Connection/Download/Connection__Download.bs.js");
+var Connection__Candidate$AgdaModeVscode = require("../../src/Connection/Connection__Candidate.bs.js");
 var Connection__Download__Channel$AgdaModeVscode = require("../../src/Connection/Download/Connection__Download__Channel.bs.js");
 
 async function withTempStorage(prefix, f) {
@@ -89,6 +91,43 @@ function findProbeByLocalPath(errors, path) {
                 }
                 
               }));
+}
+
+function resourceFromRawPath(raw) {
+  return Connection__URI$AgdaModeVscode.parse(raw)._1;
+}
+
+function observeProbeFlow() {
+  var events = [];
+  var onProbeFlow = function ($$event) {
+    events.push($$event);
+  };
+  return [
+          events,
+          onProbeFlow
+        ];
+}
+
+function probeFlowSnapshot($$event) {
+  switch ($$event.TAG) {
+    case "CandidateResolveStarted" :
+        return "CandidateResolveStarted:" + Connection__Candidate$AgdaModeVscode.toString($$event._0);
+    case "CandidateResolved" :
+        return "CandidateResolved:" + Connection__Candidate$AgdaModeVscode.toString($$event._0) + "->" + $$event._1.toString();
+    case "CandidateResolveFailed" :
+        return "CandidateResolveFailed:" + Connection__Candidate$AgdaModeVscode.toString($$event._0) + "->" + Connection__Command$AgdaModeVscode.$$Error.toString($$event._1);
+    case "ProbeStarted" :
+        return "ProbeStarted:" + $$event._0.toString();
+    case "ProbeClassifiedAsAgda" :
+        return "ProbeClassifiedAsAgda:" + $$event._0 + ":" + $$event._1;
+    case "ProbeClassifiedAsALS" :
+        return "ProbeClassifiedAsALS:" + $$event._0 + ":" + $$event._1 + ":" + $$event._2;
+    case "ProbeClassifiedAsALSWASM" :
+        return "ProbeClassifiedAsALSWASM:" + $$event._0;
+    case "ProbeFailed" :
+        return "ProbeFailed:" + $$event._0 + ":" + Connection__Error$AgdaModeVscode.Probe.toString($$event._1);
+    
+  }
 }
 
 async function getAgdaTarget() {
@@ -190,14 +229,19 @@ describe("Connection", (function () {
                       
                     });
                 it("should correctly identify Agda executable", (async function () {
-                        var result = await Connection$AgdaModeVscode.probeFilepath(agdaMockPath.contents);
+                        var match = observeProbeFlow();
+                        var result = await Connection$AgdaModeVscode.probeFilepath(agdaMockPath.contents, match[1]);
                         if (result.TAG === "Ok") {
-                          var match = result._0;
-                          var version = match[1];
+                          var match$1 = result._0;
+                          var version = match$1[1];
                           switch (version.TAG) {
                             case "IsAgda" :
-                                Curry._3(Assert.deepStrictEqual, match[0], agdaMockPath.contents, undefined);
-                                return Curry._3(Assert.deepStrictEqual, version._0, "2.6.4.1", undefined);
+                                Curry._3(Assert.deepStrictEqual, match$1[0], agdaMockPath.contents, undefined);
+                                Curry._3(Assert.deepStrictEqual, version._0, "2.6.4.1", undefined);
+                                return Curry._3(Assert.deepStrictEqual, match[0].map(probeFlowSnapshot), [
+                                            "ProbeStarted:" + resourceFromRawPath(agdaMockPath.contents).toString(),
+                                            "ProbeClassifiedAsAgda:" + probeKeyForLocalPath(agdaMockPath.contents) + ":2.6.4.1"
+                                          ], undefined);
                             case "IsALS" :
                             case "IsALSWASM" :
                                 Assert.fail("Expected Agda result, got ALS");
@@ -210,16 +254,21 @@ describe("Connection", (function () {
                         }
                       }));
                 it("should correctly identify ALS executable", (async function () {
-                        var result = await Connection$AgdaModeVscode.probeFilepath(alsMockPath.contents);
+                        var match = observeProbeFlow();
+                        var result = await Connection$AgdaModeVscode.probeFilepath(alsMockPath.contents, match[1]);
                         if (result.TAG === "Ok") {
-                          var match = result._0;
-                          var match$1 = match[1];
-                          switch (match$1.TAG) {
+                          var match$1 = result._0;
+                          var match$2 = match$1[1];
+                          switch (match$2.TAG) {
                             case "IsALS" :
-                                Curry._3(Assert.deepStrictEqual, match[0], alsMockPath.contents, undefined);
-                                Curry._3(Assert.deepStrictEqual, match$1._0, "1.2.3", undefined);
-                                Curry._3(Assert.deepStrictEqual, match$1._1, "2.6.4", undefined);
-                                return Curry._3(Assert.deepStrictEqual, match$1._2, undefined, undefined);
+                                Curry._3(Assert.deepStrictEqual, match$1[0], alsMockPath.contents, undefined);
+                                Curry._3(Assert.deepStrictEqual, match$2._0, "1.2.3", undefined);
+                                Curry._3(Assert.deepStrictEqual, match$2._1, "2.6.4", undefined);
+                                Curry._3(Assert.deepStrictEqual, match$2._2, undefined, undefined);
+                                return Curry._3(Assert.deepStrictEqual, match[0].map(probeFlowSnapshot), [
+                                            "ProbeStarted:" + resourceFromRawPath(alsMockPath.contents).toString(),
+                                            "ProbeClassifiedAsALS:" + probeKeyForLocalPath(alsMockPath.contents) + ":1.2.3:2.6.4"
+                                          ], undefined);
                             case "IsAgda" :
                             case "IsALSWASM" :
                                 Assert.fail("Expected ALS result, got Agda");
@@ -246,16 +295,21 @@ describe("Connection", (function () {
                           Nodefs.writeFileSync(tempFile$1, Buffer.from(content$1));
                           mockPath = tempFile$1;
                         }
-                        var result = await Connection$AgdaModeVscode.probeFilepath(mockPath);
+                        var match = observeProbeFlow();
+                        var result = await Connection$AgdaModeVscode.probeFilepath(mockPath, match[1]);
                         if (result.TAG === "Ok") {
                           Assert.fail("Expected NotAgdaOrALS error");
                         } else {
-                          var output = result._0;
-                          if (output.TAG === "NotAgdaOrALS") {
-                            Curry._3(Assert.deepStrictEqual, output._0.trim(), mockOutput, undefined);
+                          var probeError = result._0;
+                          if (probeError.TAG === "NotAgdaOrALS") {
+                            Curry._3(Assert.deepStrictEqual, probeError._0.trim(), mockOutput, undefined);
                           } else {
                             Assert.fail("Expected NotAgdaOrALS error, got different error");
                           }
+                          Curry._3(Assert.deepStrictEqual, match[0].map(probeFlowSnapshot), [
+                                "ProbeStarted:" + resourceFromRawPath(mockPath).toString(),
+                                "ProbeFailed:" + probeKeyForLocalPath(mockPath) + ":" + Connection__Error$AgdaModeVscode.Probe.toString(probeError)
+                              ], undefined);
                         }
                         try {
                           Nodefs.unlinkSync(mockPath);
@@ -268,7 +322,7 @@ describe("Connection", (function () {
                 it("should return CannotDetermineAgdaOrALS error for non-executable file", (async function () {
                         var nonExecutablePath = Nodepath.join(Nodeos.tmpdir(), "non-executable.txt");
                         Nodefs.writeFileSync(nonExecutablePath, Buffer.from("not executable"));
-                        var result = await Connection$AgdaModeVscode.probeFilepath(nonExecutablePath);
+                        var result = await Connection$AgdaModeVscode.probeFilepath(nonExecutablePath, undefined);
                         if (result.TAG === "Ok") {
                           Assert.fail("Expected CannotDetermineAgdaOrALS error");
                         } else if (result._0.TAG !== "CannotDetermineAgdaOrALS") {
@@ -283,7 +337,7 @@ describe("Connection", (function () {
                         }
                       }));
                 it("should return CannotDetermineAgdaOrALS error for non-existent file", (async function () {
-                        var result = await Connection$AgdaModeVscode.probeFilepath("/path/that/does/not/exist/executable");
+                        var result = await Connection$AgdaModeVscode.probeFilepath("/path/that/does/not/exist/executable", undefined);
                         if (result.TAG === "Ok") {
                           Assert.fail("Expected CannotDetermineAgdaOrALS error");
                           return ;
@@ -319,7 +373,7 @@ describe("Connection", (function () {
                         if (OS$AgdaModeVscode.onUnix) {
                           await Nodefs.promises.chmod(fileName, 493);
                         }
-                        var result = await Connection$AgdaModeVscode.probeFilepath(fileName);
+                        var result = await Connection$AgdaModeVscode.probeFilepath(fileName, undefined);
                         var match$1 = Connection__URI$AgdaModeVscode.parse(fileName);
                         var normalizedFileName = match$1._1.fsPath;
                         if (result.TAG === "Ok") {
@@ -410,7 +464,7 @@ describe("Connection", (function () {
                       }));
                 it("should handle ALS executable probing (without full connection)", (async function () {
                         this.retries(2);
-                        var result = await Connection$AgdaModeVscode.probeFilepath(alsMockPath.contents);
+                        var result = await Connection$AgdaModeVscode.probeFilepath(alsMockPath.contents, undefined);
                         if (result.TAG === "Ok") {
                           var match = result._0;
                           var match$1 = match[1];
@@ -515,7 +569,7 @@ describe("Connection", (function () {
                         if (OS$AgdaModeVscode.onUnix) {
                           await Nodefs.promises.chmod(fileName, 493);
                         }
-                        var result = await Connection$AgdaModeVscode.probeFilepath(fileName);
+                        var result = await Connection$AgdaModeVscode.probeFilepath(fileName, undefined);
                         var match$1 = Connection__URI$AgdaModeVscode.parse(fileName);
                         var normalizedFileName = match$1._1.fsPath;
                         if (result.TAG === "Ok") {
@@ -1071,11 +1125,9 @@ describe("Connection", (function () {
                             case "ConnectedToAgda" :
                             case "ConnectedToALS" :
                                 return ;
-                            case "DownloadFlow" :
-                            case "Disconnected" :
-                                Assert.fail("Expected exactly one connection event");
-                                return ;
-                            
+                            default:
+                              Assert.fail("Expected exactly one connection event");
+                              return ;
                           }
                         } else {
                           Assert.fail("Expected exactly one connection event");
@@ -1536,9 +1588,15 @@ describe("Connection", (function () {
                         Nodefs.writeFileSync(wasmPath, Buffer.from("mock wasm content"));
                         var fileUri = Vscode.Uri.file(wasmPath);
                         var uriString = fileUri.toString();
-                        var result = await Connection$AgdaModeVscode.probeFilepath(uriString);
+                        var match = observeProbeFlow();
+                        var result = await Connection$AgdaModeVscode.probeFilepath(uriString, match[1]);
                         if (result.TAG === "Ok") {
-                          assertLocalPathEqual(result._0[0], wasmPath);
+                          var resolvedPath = result._0[0];
+                          assertLocalPathEqual(resolvedPath, wasmPath);
+                          Curry._3(Assert.deepStrictEqual, match[0].map(probeFlowSnapshot), [
+                                "ProbeStarted:" + fileUri.toString(),
+                                "ProbeClassifiedAsALSWASM:" + resolvedPath
+                              ], undefined);
                         } else {
                           Assert.fail("Expected WASM probe to succeed");
                         }
@@ -1904,5 +1962,8 @@ exports.normalizeLocalPathForAssert = normalizeLocalPathForAssert;
 exports.assertLocalPathEqual = assertLocalPathEqual;
 exports.probeKeyForLocalPath = probeKeyForLocalPath;
 exports.findProbeByLocalPath = findProbeByLocalPath;
+exports.resourceFromRawPath = resourceFromRawPath;
+exports.observeProbeFlow = observeProbeFlow;
+exports.probeFlowSnapshot = probeFlowSnapshot;
 exports.getAgdaTarget = getAgdaTarget;
 /*  Not a pure module */

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -1071,6 +1071,7 @@ describe("Connection", (function () {
                             case "ConnectedToAgda" :
                             case "ConnectedToALS" :
                                 return ;
+                            case "DownloadFlow" :
                             case "Disconnected" :
                                 Assert.fail("Expected exactly one connection event");
                                 return ;

--- a/lib/js/test/tests/Test__Connection.bs.js
+++ b/lib/js/test/tests/Test__Connection.bs.js
@@ -166,15 +166,20 @@ function establishFlowSnapshot($$event) {
         }
         return "ConnectionCreated:" + $$event._0 + ":" + tmp;
     case "ConnectionFinalizeFailed" :
-        throw {
-              RE_EXN_ID: "Match_failure",
-              _1: [
-                "Test__Connection.res",
-                101,
-                2
-              ],
-              Error: new Error()
-            };
+        var tmp$1;
+        switch ($$event._1) {
+          case "Agda" :
+              tmp$1 = "Agda";
+              break;
+          case "ALS" :
+              tmp$1 = "ALS";
+              break;
+          case "ALSWASM" :
+              tmp$1 = "ALSWASM";
+              break;
+          
+        }
+        return "ConnectionFinalizeFailed:" + $$event._0 + ":" + tmp$1;
     
   }
 }
@@ -234,6 +239,16 @@ async function getAgdaTarget() {
     return PervasivesU.failwith("expected to find `agda`");
   }
 }
+
+describe("establishFlowSnapshot", (function () {
+        it("should format ConnectionFinalizeFailed correctly", (function () {
+                Curry._3(Assert.deepStrictEqual, establishFlowSnapshot({
+                          TAG: "ConnectionFinalizeFailed",
+                          _0: "/some/path",
+                          _1: "Agda"
+                        }), "ConnectionFinalizeFailed:/some/path:Agda", undefined);
+              }));
+      }));
 
 describe("Connection", (function () {
         this.timeout(10000);

--- a/lib/js/test/tests/Test__Connection__Candidate.bs.js
+++ b/lib/js/test/tests/Test__Connection__Candidate.bs.js
@@ -9,6 +9,7 @@ var Core__Option = require("@rescript/core/lib/js/src/Core__Option.bs.js");
 var Caml_splice_call = require("rescript/lib/js/caml_splice_call.js");
 var OS$AgdaModeVscode = require("../../src/Util/OS.bs.js");
 var Connection__URI$AgdaModeVscode = require("../../src/Connection/Shared/Connection__URI.bs.js");
+var Connection__Command$AgdaModeVscode = require("../../src/Connection/Resolver/Connection__Command.bs.js");
 var Connection__Candidate$AgdaModeVscode = require("../../src/Connection/Connection__Candidate.bs.js");
 
 describe("Connection__Candidate", (function () {
@@ -281,6 +282,47 @@ describe("Connection__Candidate", (function () {
                       }));
               }));
         describe("resolve", (function () {
+                var probeFlowSnapshot = function ($$event) {
+                  switch ($$event.TAG) {
+                    case "CandidateResolveStarted" :
+                        return "CandidateResolveStarted:" + Connection__Candidate$AgdaModeVscode.toString($$event._0);
+                    case "CandidateResolved" :
+                        return "CandidateResolved:" + Connection__Candidate$AgdaModeVscode.toString($$event._0) + "->" + $$event._1.toString();
+                    case "CandidateResolveFailed" :
+                        return "CandidateResolveFailed:" + Connection__Candidate$AgdaModeVscode.toString($$event._0) + "->" + Connection__Command$AgdaModeVscode.$$Error.toString($$event._1);
+                    default:
+                      return "UnexpectedProbeFlowVariant";
+                  }
+                };
+                var observeResolveProbeFlow = function () {
+                  var events = [];
+                  var onCandidateResolveStarted = function (candidate) {
+                    events.push({
+                          TAG: "CandidateResolveStarted",
+                          _0: candidate
+                        });
+                  };
+                  var onCandidateResolved = function (original, resource) {
+                    events.push({
+                          TAG: "CandidateResolved",
+                          _0: original,
+                          _1: resource
+                        });
+                  };
+                  var onCandidateResolveFailed = function (original, commandError) {
+                    events.push({
+                          TAG: "CandidateResolveFailed",
+                          _0: original,
+                          _1: commandError
+                        });
+                  };
+                  return [
+                          events,
+                          onCandidateResolveStarted,
+                          onCandidateResolved,
+                          onCandidateResolveFailed
+                        ];
+                };
                 it("should resolve Command through Platform.findCommand", (async function () {
                         var findCommand = function (command, _timeoutOpt) {
                           if (command === "agda") {
@@ -295,14 +337,20 @@ describe("Connection__Candidate", (function () {
                                       });
                           }
                         };
-                        var match = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, Connection__Candidate$AgdaModeVscode.make("agda"));
-                        if (match.TAG === "Ok") {
-                          var match$1 = match._0;
-                          var match$2 = match$1.original;
-                          if (match$2.TAG === "Command") {
-                            if (match$2._0 === "agda") {
+                        var candidate = Connection__Candidate$AgdaModeVscode.make("agda");
+                        var match = observeResolveProbeFlow();
+                        var match$1 = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, candidate, match[1], match[2], match[3]);
+                        if (match$1.TAG === "Ok") {
+                          var match$2 = match$1._0;
+                          var match$3 = match$2.original;
+                          if (match$3.TAG === "Command") {
+                            if (match$3._0 === "agda") {
                               var expected = Vscode.Uri.file(sampleResolvedPath).toString();
-                              return Curry._3(Assert.deepStrictEqual, match$1.resource.toString(), expected, undefined);
+                              Curry._3(Assert.deepStrictEqual, match$2.resource.toString(), expected, undefined);
+                              return Curry._3(Assert.deepStrictEqual, match[0].map(probeFlowSnapshot), [
+                                          "CandidateResolveStarted:agda",
+                                          "CandidateResolved:agda->" + expected
+                                        ], undefined);
                             }
                             Assert.fail("Expected resolved command to preserve original candidate");
                             return ;
@@ -312,6 +360,25 @@ describe("Connection__Candidate", (function () {
                         }
                         Assert.fail("Expected command resolution to succeed");
                       }));
+                it("should emit CandidateResolveFailed when command candidate cannot be resolved", (async function () {
+                        var findCommand = function (_command, _timeoutOpt) {
+                          return Promise.resolve({
+                                      TAG: "Error",
+                                      _0: "NotFound"
+                                    });
+                        };
+                        var candidate = Connection__Candidate$AgdaModeVscode.make("agda");
+                        var match = observeResolveProbeFlow();
+                        var result = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, candidate, match[1], match[2], match[3]);
+                        Curry._3(Assert.deepStrictEqual, result, {
+                              TAG: "Error",
+                              _0: "NotFound"
+                            }, undefined);
+                        return Curry._3(Assert.deepStrictEqual, match[0].map(probeFlowSnapshot), [
+                                    "CandidateResolveStarted:agda",
+                                    "CandidateResolveFailed:agda->Command not found"
+                                  ], undefined);
+                      }));
                 it("should leave Resource unchanged when resolving", (async function () {
                         var findCommand = function (_command, _timeoutOpt) {
                           return Promise.resolve({
@@ -320,7 +387,7 @@ describe("Connection__Candidate", (function () {
                                     });
                         };
                         var candidate = Connection__Candidate$AgdaModeVscode.make(sampleResourceUri);
-                        var match = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, candidate);
+                        var match = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, candidate, undefined, undefined, undefined);
                         if (candidate.TAG === "Command") {
                           Assert.fail("Expected Resource candidate to resolve without lookup");
                           return ;
@@ -350,7 +417,7 @@ describe("Connection__Candidate", (function () {
                                     });
                         };
                         var candidate = Connection__Candidate$AgdaModeVscode.make(sampleResourceUri);
-                        var match = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, candidate);
+                        var match = await Connection__Candidate$AgdaModeVscode.resolve(findCommand, candidate, undefined, undefined, undefined);
                         if (match.TAG === "Ok") {
                           return Curry._3(Assert.deepStrictEqual, findCommandCalls.contents, 0, undefined);
                         }

--- a/lib/js/test/tests/Test__Connection__Downloads.bs.js
+++ b/lib/js/test/tests/Test__Connection__Downloads.bs.js
@@ -130,7 +130,7 @@ describe("Connection Downloads", (function () {
                         var mockPlatformDeps = Mock$AgdaModeVscode.Platform.makeWithPlatformError(platform);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var actual = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var actual = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         var expected = Connection__Error$AgdaModeVscode.Establish.fromDownloadError({
                               TAG: "PlatformNotSupported",
                               _0: platform
@@ -148,7 +148,7 @@ describe("Connection Downloads", (function () {
                         var mockPlatformDeps = Mock$AgdaModeVscode.Platform.makeWithDownloadPolicyCounter("No", getDownloadPolicyCount);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         Curry._3(Assert.deepStrictEqual, result, {
                               TAG: "Error",
                               _0: Connection__Error$AgdaModeVscode.Establish.fromDownloadError("OptedNotToDownload")
@@ -165,7 +165,7 @@ describe("Connection Downloads", (function () {
                         var mockPlatformDeps = Mock$AgdaModeVscode.Platform.makeWithDownloadPolicyCounter("Undecided", getDownloadPolicyCount);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         Curry._3(Assert.deepStrictEqual, result, {
                               TAG: "Error",
                               _0: Connection__Error$AgdaModeVscode.Establish.fromDownloadError("OptedNotToDownload")
@@ -184,7 +184,7 @@ describe("Connection Downloads", (function () {
                         var mockPlatformDeps = Mock$AgdaModeVscode.Platform.makeWithCachedDownloadAndFlag(mockEndpoint, checkedCache);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         Curry._3(Assert.deepStrictEqual, checkedCache.contents, true, undefined);
                         if (result.TAG === "Ok") {
                           var connection = result._0;
@@ -216,7 +216,7 @@ describe("Connection Downloads", (function () {
                         var mockPlatformDeps = Mock$AgdaModeVscode.Platform.makeWithDownloadFailureAndFlags(checkedCache, checkedDownload);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         Curry._3(Assert.deepStrictEqual, checkedCache.contents, true, undefined);
                         var expected = Connection__Error$AgdaModeVscode.Establish.fromDownloadError("CannotFindCompatibleALSRelease");
                         Curry._3(Assert.deepStrictEqual, result, {
@@ -284,7 +284,7 @@ describe("Connection Downloads", (function () {
                         };
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         var expected = Connection__Error$AgdaModeVscode.Establish.fromDownloadError("CannotFindCompatibleALSRelease");
                         Curry._3(Assert.deepStrictEqual, result, {
                               TAG: "Error",
@@ -348,7 +348,7 @@ describe("Connection Downloads", (function () {
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         await Memento$AgdaModeVscode.Module.SelectedChannel.set(memento, "DevALS");
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         return Curry._3(Assert.deepStrictEqual, resolvedChannel.contents, "DevALS", undefined);
                       }));
                 it("should resolve Desktop downloads via DevALS channel", (async function () {
@@ -409,7 +409,7 @@ describe("Connection Downloads", (function () {
                         };
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         var expected = Connection__Error$AgdaModeVscode.Establish.fromDownloadError("CannotFindCompatibleALSRelease");
                         Curry._3(Assert.deepStrictEqual, result, {
                               TAG: "Error",
@@ -434,7 +434,7 @@ describe("Connection Downloads", (function () {
                         var mockPlatformDeps = Mock$AgdaModeVscode.Platform.makeWithNativeFailureAndWASMSuccess(downloadedMock, checkedCache, checkedNativeDownload, checkedWasmDownload);
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         if (result.TAG === "Ok") {
                           var match = result._0;
                           switch (match.TAG) {
@@ -503,7 +503,7 @@ describe("Connection Downloads", (function () {
                         };
                         var memento = Memento$AgdaModeVscode.make(undefined);
                         var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                        var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                         Curry._3(Assert.deepStrictEqual, checkedResolve.contents, true, undefined);
                         if (result.TAG !== "Ok") {
                           return Curry._3(Assert.deepStrictEqual, result._0.download, {
@@ -628,7 +628,7 @@ describe("Connection Downloads", (function () {
                                 };
                                 var memento = Memento$AgdaModeVscode.make(undefined);
                                 var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                                var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                                var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                                 Curry._3(Assert.deepStrictEqual, downloadAttempts.contents, [
                                       "native",
                                       "wasm"
@@ -732,7 +732,7 @@ describe("Connection Downloads", (function () {
                                 };
                                 var memento = Memento$AgdaModeVscode.make(undefined);
                                 var globalStorageUri = Vscode.Uri.file("/tmp/test-storage");
-                                var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri);
+                                var result = await Connection$AgdaModeVscode.fromDownloads(mockPlatformDeps, memento, globalStorageUri, undefined);
                                 Curry._3(Assert.deepStrictEqual, downloadAttempts.contents, ["wasm"], undefined);
                                 Curry._3(Assert.deepStrictEqual, resolvedChannels.contents, ["DevALS"], undefined);
                                 if (result.TAG !== "Ok") {

--- a/lib/js/test/tests/Test__Connection__Downloads.bs.js
+++ b/lib/js/test/tests/Test__Connection__Downloads.bs.js
@@ -863,15 +863,10 @@ describe("Connection Downloads", (function () {
                             var match = loggedEvents[0];
                             if (match.TAG === "Connection") {
                               var match$1 = match._0;
-                              switch (match$1.TAG) {
-                                case "ConnectedToAgda" :
-                                    Curry._3(Assert.deepStrictEqual, match$1._1, "2.7.0.1", undefined);
-                                    break;
-                                case "ConnectedToALS" :
-                                case "Disconnected" :
-                                    Assert.fail("Expected exactly one ConnectedToAgda event");
-                                    break;
-                                
+                              if (match$1.TAG === "ConnectedToAgda") {
+                                Curry._3(Assert.deepStrictEqual, match$1._1, "2.7.0.1", undefined);
+                              } else {
+                                Assert.fail("Expected exactly one ConnectedToAgda event");
                               }
                             } else {
                               Assert.fail("Expected exactly one ConnectedToAgda event");
@@ -927,15 +922,10 @@ describe("Connection Downloads", (function () {
                             var match = loggedEvents[0];
                             if (match.TAG === "Connection") {
                               var match$1 = match._0;
-                              switch (match$1.TAG) {
-                                case "ConnectedToAgda" :
-                                    Curry._3(Assert.deepStrictEqual, match$1._1, "2.7.0.1", undefined);
-                                    break;
-                                case "ConnectedToALS" :
-                                case "Disconnected" :
-                                    Assert.fail("Expected exactly one ConnectedToAgda event");
-                                    break;
-                                
+                              if (match$1.TAG === "ConnectedToAgda") {
+                                Curry._3(Assert.deepStrictEqual, match$1._1, "2.7.0.1", undefined);
+                              } else {
+                                Assert.fail("Expected exactly one ConnectedToAgda event");
                               }
                             } else {
                               Assert.fail("Expected exactly one ConnectedToAgda event");
@@ -1041,16 +1031,11 @@ describe("Connection Downloads", (function () {
                             var match = loggedEvents[0];
                             if (match.TAG === "Connection") {
                               var match$1 = match._0;
-                              switch (match$1.TAG) {
-                                case "ConnectedToAgda" :
-                                    Curry._3(Assert.deepStrictEqual, match$1._0, agdaMockPath, undefined);
-                                    Curry._3(Assert.deepStrictEqual, match$1._1, "2.7.0.1", undefined);
-                                    break;
-                                case "ConnectedToALS" :
-                                case "Disconnected" :
-                                    Assert.fail("Expected exactly one ConnectedToAgda event");
-                                    break;
-                                
+                              if (match$1.TAG === "ConnectedToAgda") {
+                                Curry._3(Assert.deepStrictEqual, match$1._0, agdaMockPath, undefined);
+                                Curry._3(Assert.deepStrictEqual, match$1._1, "2.7.0.1", undefined);
+                              } else {
+                                Assert.fail("Expected exactly one ConnectedToAgda event");
                               }
                             } else {
                               Assert.fail("Expected exactly one ConnectedToAgda event");

--- a/lib/js/test/tests/Test__Util.bs.js
+++ b/lib/js/test/tests/Test__Util.bs.js
@@ -415,7 +415,7 @@ async function versionGTE(command, expectedVersion) {
   var _error = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
           command,
           "FromConfig"
-        ]], undefined);
+        ]], undefined, undefined);
   if (_error.TAG !== "Ok") {
     return false;
   }
@@ -436,7 +436,7 @@ async function commandExists(command) {
   var errors = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
           command,
           "FromConfig"
-        ]], undefined);
+        ]], undefined, undefined);
   if (errors.TAG === "Ok") {
     return Connection$AgdaModeVscode.getPath(errors._0);
   }

--- a/lib/js/test/tests/Test__Util.bs.js
+++ b/lib/js/test/tests/Test__Util.bs.js
@@ -415,7 +415,7 @@ async function versionGTE(command, expectedVersion) {
   var _error = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
           command,
           "FromConfig"
-        ]]);
+        ]], undefined);
   if (_error.TAG !== "Ok") {
     return false;
   }
@@ -436,7 +436,7 @@ async function commandExists(command) {
   var errors = await Connection$AgdaModeVscode.fromPathsOrCommands(platformDeps, [[
           command,
           "FromConfig"
-        ]]);
+        ]], undefined);
   if (errors.TAG === "Ok") {
     return Connection$AgdaModeVscode.getPath(errors._0);
   }

--- a/src/Connection/Connection__Candidate.res
+++ b/src/Connection/Connection__Candidate.res
@@ -172,7 +172,18 @@ let isUnderDirectory = (candidate: t, directory: VSCode.Uri.t): bool =>
 let resolve: (
   (string, ~timeout: int=?) => promise<result<string, Connection__Command.Error.t>>,
   t,
-) => promise<result<Resolved.t, Connection__Command.Error.t>> = async (findCommand, candidate) => {
+  ~onCandidateResolveStarted: t => unit=?,
+  ~onCandidateResolved: (t, VSCode.Uri.t) => unit=?,
+  ~onCandidateResolveFailed: (t, Connection__Command.Error.t) => unit=?,
+) => promise<result<Resolved.t, Connection__Command.Error.t>> = async (
+  findCommand,
+  candidate,
+  ~onCandidateResolveStarted=_ => (),
+  ~onCandidateResolved=(_, _) => (),
+  ~onCandidateResolveFailed=(_, _) => (),
+) => {
+  onCandidateResolveStarted(candidate)
+
   switch candidate {
   | Command(command) =>
     switch await findCommand(command) {
@@ -180,12 +191,16 @@ let resolve: (
       switch Connection__URI.parse(path) {
       | FileURI(_, uri) =>
         let resolved: Resolved.t = {original: candidate, resource: uri}
+        onCandidateResolved(candidate, uri)
         Ok(resolved)
       }
-    | Error(error) => Error(error)
+    | Error(error) =>
+      onCandidateResolveFailed(candidate, error)
+      Error(error)
     }
   | Resource(uri) =>
     let resolved: Resolved.t = {original: candidate, resource: uri}
+    onCandidateResolved(candidate, uri)
     Ok(resolved)
   }
 }

--- a/src/Connection/Connection__Core.res
+++ b/src/Connection/Connection__Core.res
@@ -34,8 +34,14 @@ module type Module = {
     Platform.t,
     array<(string, Error.Establish.pathSource)>,
     ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=?,
+    ~onEstablishFlow: Log.Connection.EstablishFlow.t => unit=?,
   ) => promise<result<t, Error.Establish.t>>
-  let fromDownloads: (Platform.t, Memento.t, VSCode.Uri.t) => promise<result<t, Error.Establish.t>>
+  let fromDownloads: (
+    Platform.t,
+    Memento.t,
+    VSCode.Uri.t,
+    ~onEstablishFlow: Log.Connection.EstablishFlow.t => unit=?,
+  ) => promise<result<t, Error.Establish.t>>
 
   // messaging
   let sendRequest: (
@@ -450,10 +456,14 @@ module Module: Module = {
     platformDeps: Platform.t,
     entries: array<(string, Error.Establish.pathSource)>,
     ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=_ => (),
+    ~onEstablishFlow: Log.Connection.EstablishFlow.t => unit=_ => (),
   ): result<t, Error.Establish.t> => {
     let tasks = entries->Array.map(((raw, source)) => {
       let candidate = Candidate.make(raw)
-      () => tryCandidate(platformDeps, candidate, source, ~onProbeFlow)
+      () => {
+        onEstablishFlow(Log.Connection.EstablishFlow.CandidateAttempted(raw, source))
+        tryCandidate(platformDeps, candidate, source, ~onProbeFlow)
+      }
     })
 
     switch await tryUntilSuccess(tasks) {
@@ -472,11 +482,16 @@ module Module: Module = {
     platformDeps: Platform.t,
     memento: Memento.t,
     globalStorageUri: VSCode.Uri.t,
+    ~onEstablishFlow: Log.Connection.EstablishFlow.t => unit=_ => (),
   ): result<t, Error.Establish.t> => {
     module PlatformOps = unpack(platformDeps)
+    let failDownloadFallback = (error: Error.Establish.t) => {
+      onEstablishFlow(Log.Connection.EstablishFlow.DownloadFallbackFailed(error))
+      Error(error)
+    }
 
     switch await PlatformOps.determinePlatform() {
-    | Error(platform) => Error(Error.Establish.fromDownloadError(PlatformNotSupported(platform)))
+    | Error(platform) => failDownloadFallback(Error.Establish.fromDownloadError(PlatformNotSupported(platform)))
     | Ok(platform) =>
       // On web, always download (no alternatives exist)
       // On desktop, respect user's config
@@ -496,11 +511,15 @@ module Module: Module = {
       | Config.Connection.DownloadPolicy.Undecided =>
         // User cancelled, treat as No
         await Config.Connection.DownloadPolicy.set(No)
-        Error(Error.Establish.fromDownloadError(Connection__Download__Error.OptedNotToDownload))
+        failDownloadFallback(
+          Error.Establish.fromDownloadError(Connection__Download__Error.OptedNotToDownload),
+        )
       | No =>
         // User opted not to download, set policy and return error
         await Config.Connection.DownloadPolicy.set(No)
-        Error(Error.Establish.fromDownloadError(Connection__Download__Error.OptedNotToDownload))
+        failDownloadFallback(
+          Error.Establish.fromDownloadError(Connection__Download__Error.OptedNotToDownload),
+        )
       | Yes =>
         await Config.Connection.DownloadPolicy.set(Yes)
         // Use the selected channel from memento, defaulting to DevALS.
@@ -516,6 +535,12 @@ module Module: Module = {
           | None => Connection__Download__Channel.DevALS
           }
         }
+        onEstablishFlow(
+          Log.Connection.EstablishFlow.DownloadFallbackStarted(
+            channel,
+            Connection__Download__DownloadArtifact.Platform.fromDownloadPlatform(platform),
+          ),
+        )
         // Fresh GitHub downloads can fall back to a WASM asset from the same resolved release.
         // Cached managed downloads use their managed path metadata instead of the selected channel.
         let wasmFallbackSource: ref<option<Connection__Download__Source.t>> = ref(None)
@@ -623,19 +648,21 @@ module Module: Module = {
                 switch await make(wasmPath, source) {
                 | Ok(connection) => Ok(connection)
                 | Error(wasmError) =>
-                  Error(Error.Establish.merge(
-                    {...nativeError, download: Succeeded},
-                    {...wasmError, download: Succeeded},
-                  ))
+                  failDownloadFallback(
+                    Error.Establish.merge(
+                      {...nativeError, download: Succeeded},
+                      {...wasmError, download: Succeeded},
+                    ),
+                  )
                 }
               | Error(_) =>
-                Error({...nativeError, download: Succeeded})
+                failDownloadFallback({...nativeError, download: Succeeded})
               }
             } else {
-              Error({...nativeError, download: Succeeded})
+              failDownloadFallback({...nativeError, download: Succeeded})
             }
           }
-        | Error(error) => Error(error)
+        | Error(error) => failDownloadFallback(error)
         }
       }
     }
@@ -658,6 +685,18 @@ module Module: Module = {
     logChannel: Chan.t<Log.t>,
   ): result<t, Error.t> => {
     let logConnection = connection => {
+      let establishKind = switch connection {
+      | Agda(_, _, _) => Log.Connection.EstablishFlow.Agda
+      | ALS(_, _, _) => Log.Connection.EstablishFlow.ALS
+      | ALSWASM(_, _, _, _) => Log.Connection.EstablishFlow.ALSWASM
+      }
+      logChannel->Chan.emit(
+        Log.Connection(
+          Log.Connection.EstablishFlow(
+            Log.Connection.EstablishFlow.ConnectionEstablished(getPath(connection), establishKind),
+          ),
+        ),
+      )
       switch connection {
       | Agda(_, path, version) =>
         logChannel->Chan.emit(Log.Connection(ConnectedToAgda(path, version)))
@@ -673,6 +712,8 @@ module Module: Module = {
     }
 
     let preferredCandidate = Memento.PreferredCandidate.get(memento)
+    let onEstablishFlow = event =>
+      logChannel->Chan.emit(Log.Connection(Log.Connection.EstablishFlow(event)))
 
     // Step 0: preferred candidate, if present.
     let preferredEntries = switch preferredCandidate {
@@ -689,21 +730,33 @@ module Module: Module = {
       remainingPaths
       ->Array.toReversed
       ->Array.map(path => (path, Error.Establish.FromConfig))
+    let configCandidateCount = Array.length(preferredEntries) + Array.length(pathsWithSource)
+    onEstablishFlow(Log.Connection.EstablishFlow.ConfigCandidatesStarted(configCandidateCount))
 
     // Try step 0 (preferred candidate) -> step 1 (config paths) -> download fallback.
     // Command probes are not part of the resolution chain.
-    switch await fromPathsOrCommands(platformDeps, preferredEntries) {
+    switch await fromPathsOrCommands(platformDeps, preferredEntries, ~onEstablishFlow) {
     | Ok(connection) =>
       logConnection(connection)
       Ok(connection)
     | Error(step0Error) =>
-      switch await fromPathsOrCommands(platformDeps, pathsWithSource) {
+      switch await fromPathsOrCommands(
+        platformDeps,
+        pathsWithSource,
+        ~onEstablishFlow,
+      ) {
       | Ok(connection) =>
         logConnection(connection)
         Ok(connection)
       | Error(step1Error) =>
+        onEstablishFlow(Log.Connection.EstablishFlow.ConfigCandidatesFailed)
         let pathErrors = Error.Establish.mergeMany([step0Error, step1Error])
-      switch await fromDownloads(platformDeps, memento, globalStorageUri) {
+      switch await fromDownloads(
+        platformDeps,
+        memento,
+        globalStorageUri,
+        ~onEstablishFlow,
+      ) {
       | Ok(connection) =>
         logConnection(connection)
         // Automatic fallback: prepend (lowest priority), do NOT set PreferredCandidate
@@ -716,6 +769,7 @@ module Module: Module = {
         }
         Ok(connection)
       | Error(downloadError) =>
+        onEstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablishFailed)
         Error(Establish(Error.Establish.mergeMany([pathErrors, downloadError])))
       }
       }

--- a/src/Connection/Connection__Core.res
+++ b/src/Connection/Connection__Core.res
@@ -714,6 +714,8 @@ module Module: Module = {
     let preferredCandidate = Memento.PreferredCandidate.get(memento)
     let onEstablishFlow = event =>
       logChannel->Chan.emit(Log.Connection(Log.Connection.EstablishFlow(event)))
+    let onProbeFlow = event =>
+      logChannel->Chan.emit(Log.Connection(Log.Connection.ProbeFlow(event)))
 
     // Step 0: preferred candidate, if present.
     let preferredEntries = switch preferredCandidate {
@@ -735,7 +737,7 @@ module Module: Module = {
 
     // Try step 0 (preferred candidate) -> step 1 (config paths) -> download fallback.
     // Command probes are not part of the resolution chain.
-    switch await fromPathsOrCommands(platformDeps, preferredEntries, ~onEstablishFlow) {
+    switch await fromPathsOrCommands(platformDeps, preferredEntries, ~onEstablishFlow, ~onProbeFlow) {
     | Ok(connection) =>
       logConnection(connection)
       Ok(connection)
@@ -744,6 +746,7 @@ module Module: Module = {
         platformDeps,
         pathsWithSource,
         ~onEstablishFlow,
+        ~onProbeFlow,
       ) {
       | Ok(connection) =>
         logConnection(connection)

--- a/src/Connection/Connection__Core.res
+++ b/src/Connection/Connection__Core.res
@@ -33,6 +33,7 @@ module type Module = {
   let fromPathsOrCommands: (
     Platform.t,
     array<(string, Error.Establish.pathSource)>,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=?,
   ) => promise<result<t, Error.Establish.t>>
   let fromDownloads: (Platform.t, Memento.t, VSCode.Uri.t) => promise<result<t, Error.Establish.t>>
 
@@ -274,11 +275,12 @@ module Module: Module = {
     resolved: Candidate.Resolved.t,
     source: Error.Establish.pathSource,
     ~pathForErrors: string=resolvedPathForErrors(resolved),
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=_ => (),
   ): result<
     t,
     Error.Establish.t,
   > => {
-    switch await probeResolved(resolved) {
+    switch await probeResolved(resolved, ~onProbeFlow) {
     | Ok(path, IsAgda(agdaVersion)) =>
       let connection = await Agda.make(path, agdaVersion)
       Ok(Agda(connection, path, agdaVersion))
@@ -416,15 +418,24 @@ module Module: Module = {
     platformDeps: Platform.t,
     candidate: Candidate.t,
     source: Error.Establish.pathSource,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=_ => (),
   ): result<t, Error.Establish.t> => {
     module PlatformOps = unpack(platformDeps)
-    switch await Candidate.resolve(PlatformOps.findCommand, candidate) {
+    switch await Candidate.resolve(
+      PlatformOps.findCommand,
+      candidate,
+      ~onCandidateResolveStarted=c => onProbeFlow(Log.Connection.ProbeFlow.CandidateResolveStarted(c)),
+      ~onCandidateResolved=(original, resource) =>
+        onProbeFlow(Log.Connection.ProbeFlow.CandidateResolved(original, resource)),
+      ~onCandidateResolveFailed=(original, commandError) =>
+        onProbeFlow(Log.Connection.ProbeFlow.CandidateResolveFailed(original, commandError)),
+    ) {
     | Ok(resolved) =>
       let resolvedSource = switch resolved.original {
       | Candidate.Command(command) => Error.Establish.FromCommandLookup(command)
       | Candidate.Resource(_) => source
       }
-      await makeResolved(resolved, resolvedSource)
+      await makeResolved(resolved, resolvedSource, ~onProbeFlow)
     | Error(commandError) =>
       switch candidate {
       | Candidate.Command(command) => Error(Error.Establish.fromCommandError(command, commandError))
@@ -438,10 +449,11 @@ module Module: Module = {
   let fromPathsOrCommands = async (
     platformDeps: Platform.t,
     entries: array<(string, Error.Establish.pathSource)>,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=_ => (),
   ): result<t, Error.Establish.t> => {
     let tasks = entries->Array.map(((raw, source)) => {
       let candidate = Candidate.make(raw)
-      () => tryCandidate(platformDeps, candidate, source)
+      () => tryCandidate(platformDeps, candidate, source, ~onProbeFlow)
     })
 
     switch await tryUntilSuccess(tasks) {

--- a/src/Connection/Connection__Core.res
+++ b/src/Connection/Connection__Core.res
@@ -693,7 +693,7 @@ module Module: Module = {
       logChannel->Chan.emit(
         Log.Connection(
           Log.Connection.EstablishFlow(
-            Log.Connection.EstablishFlow.ConnectionEstablished(getPath(connection), establishKind),
+            Log.Connection.EstablishFlow.ConnectionCreated(getPath(connection), establishKind),
           ),
         ),
       )
@@ -733,7 +733,7 @@ module Module: Module = {
       ->Array.toReversed
       ->Array.map(path => (path, Error.Establish.FromConfig))
     let configCandidateCount = Array.length(preferredEntries) + Array.length(pathsWithSource)
-    onEstablishFlow(Log.Connection.EstablishFlow.ConfigCandidatesStarted(configCandidateCount))
+    onEstablishFlow(Log.Connection.EstablishFlow.ConfigCandidatesPlanned(configCandidateCount))
 
     // Try step 0 (preferred candidate) -> step 1 (config paths) -> download fallback.
     // Command probes are not part of the resolution chain.

--- a/src/Connection/Connection__Core.res
+++ b/src/Connection/Connection__Core.res
@@ -51,10 +51,14 @@ module type Module = {
     | IsAgda(string) // Agda version
     | IsALS(string, string, option<Connection__Protocol__LSP__Binding.executableOptions>) // ALS version, Agda version, LSP options
     | IsALSWASM(VSCode.Uri.t) // ALS WASM file
-  let probeFilepath: string => promise<result<(string, probeResult), Error.Probe.t>>
+  let probeFilepath: (
+    string,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=?,
+  ) => promise<result<(string, probeResult), Error.Probe.t>>
   let probeCandidate: (
     Platform.t,
     Candidate.t,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=?,
   ) => promise<result<(Candidate.Resolved.t, probeResult), Error.Establish.t>>
 }
 
@@ -162,19 +166,21 @@ module Module: Module = {
     resolved
   }
 
-  let probeResolved = async (resolved: Candidate.Resolved.t) => {
+  let probeResolved = async (
+    resolved: Candidate.Resolved.t,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=_ => (),
+  ) => {
     let {resource} = resolved
+    onProbeFlow(Log.Connection.ProbeFlow.ProbeStarted(resource))
+
     let resourceString = resource->VSCode.Uri.toString
+    let pathKey = resolvedPathForErrors(resolved)
     // Check if it's a WASM file first (assume all WASM files are ALS)
     // Use URI string for .wasm check since fsPath may mangle non-file schemes (e.g. vscode-userdata:)
     if String.endsWith(resourceString, ".wasm") {
       // For file:// scheme (desktop), use fsPath as the path key
       // For other schemes (web), use the URI string to preserve the scheme
-      let pathKey = if VSCode.Uri.scheme(resource) == "file" {
-        VSCode.Uri.fsPath(resource)
-      } else {
-        resourceString
-      }
+      onProbeFlow(Log.Connection.ProbeFlow.ProbeClassifiedAsALSWASM(pathKey))
       Ok(pathKey, IsALSWASM(resource))
     } else {
       // IMPORTANT: Convert URI to platform-specific file system path
@@ -188,11 +194,20 @@ module Module: Module = {
       | Ok(output) =>
         // try Agda
         switch String.match(output, %re("/Agda version (.*)/")) {
-        | Some([_, Some(version)]) => Ok(fsPath, IsAgda(version))
+        | Some([_, Some(version)]) =>
+          onProbeFlow(Log.Connection.ProbeFlow.ProbeClassifiedAsAgda(fsPath, version))
+          Ok(fsPath, IsAgda(version))
         | _ =>
           // try ALS
           switch String.match(output, %re("/Agda v(.*) Language Server v(.*)/")) {
           | Some([_, Some(agdaVersion), Some(alsVersion)]) =>
+            onProbeFlow(
+              Log.Connection.ProbeFlow.ProbeClassifiedAsALS(
+                fsPath,
+                alsVersion,
+                agdaVersion,
+              ),
+            )
             let lspOptions = switch await checkForPrebuiltDataDirectory(fsPath) {
             | Some(assetPath) =>
               let env = Dict.fromArray([("Agda_datadir", assetPath)])
@@ -200,29 +215,46 @@ module Module: Module = {
             | None => None
             }
             Ok(fsPath, IsALS(alsVersion, agdaVersion, lspOptions))
-          | _ => Error(Error.Probe.NotAgdaOrALS(output))
+          | _ =>
+            let error = Error.Probe.NotAgdaOrALS(output)
+            onProbeFlow(Log.Connection.ProbeFlow.ProbeFailed(pathKey, error))
+            Error(error)
           }
         }
-      | Error(error) => Error(Error.Probe.CannotDetermineAgdaOrALS(error))
+      | Error(error) =>
+        let probeError = Error.Probe.CannotDetermineAgdaOrALS(error)
+        onProbeFlow(Log.Connection.ProbeFlow.ProbeFailed(pathKey, probeError))
+        Error(probeError)
       }
     }
   }
 
   // see if it's a Agda executable or a language server
-  let probeFilepath = async path => await probeResolved(resolvedFromRawResource(path))
+  let probeFilepath = async (path, ~onProbeFlow=_ => ()) =>
+    await probeResolved(resolvedFromRawResource(path), ~onProbeFlow)
 
   let probeCandidate = async (
     platformDeps: Platform.t,
     candidate: Candidate.t,
+    ~onProbeFlow: Log.Connection.ProbeFlow.t => unit=_ => (),
   ): result<(Candidate.Resolved.t, probeResult), Error.Establish.t> => {
     module PlatformOps = unpack(platformDeps)
-    switch await Candidate.resolve(PlatformOps.findCommand, candidate) {
+    switch await Candidate.resolve(
+      PlatformOps.findCommand,
+      candidate,
+      ~onCandidateResolveStarted=candidate =>
+        onProbeFlow(Log.Connection.ProbeFlow.CandidateResolveStarted(candidate)),
+      ~onCandidateResolved=(original, resource) =>
+        onProbeFlow(Log.Connection.ProbeFlow.CandidateResolved(original, resource)),
+      ~onCandidateResolveFailed=(original, commandError) =>
+        onProbeFlow(Log.Connection.ProbeFlow.CandidateResolveFailed(original, commandError)),
+    ) {
     | Ok(resolved) =>
       let source = switch resolved.original {
       | Candidate.Command(command) => Error.Establish.FromCommandLookup(command)
       | Candidate.Resource(_) => Error.Establish.FromConfig
       }
-      switch await probeResolved(resolved) {
+      switch await probeResolved(resolved, ~onProbeFlow) {
       | Ok(_, probeResult) => Ok((resolved, probeResult))
       | Error(error) =>
         Error(

--- a/src/Connection/Connection__Switch.res
+++ b/src/Connection/Connection__Switch.res
@@ -338,13 +338,18 @@ let switchAgdaVersion = async (state: State.t, selectedPath: string) => {
       | ALSWASM(_, _, _, {alsVersion: None}) => ()
       }
       onEstablishFlow(
-        Log.Connection.EstablishFlow.ConnectionEstablished(Core.getPath(conn), establishKind(conn)),
+        Log.Connection.EstablishFlow.ConnectionCreated(Core.getPath(conn), establishKind(conn)),
       )
       onSwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchSucceeded(Core.getPath(conn)))
       let _ = await Core.destroy(Some(conn), state.channels.log)
     } catch {
     | exn =>
-      onEstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablishFailed)
+      onEstablishFlow(
+        Log.Connection.EstablishFlow.ConnectionFinalizeFailed(
+          Core.getPath(conn),
+          establishKind(conn),
+        ),
+      )
       onSwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchFailed(selectedPath))
       let _ = await Core.destroy(Some(conn), state.channels.log)
       raise(exn)

--- a/src/Connection/Connection__Switch.res
+++ b/src/Connection/Connection__Switch.res
@@ -280,13 +280,25 @@ let switchAgdaVersion = async (state: State.t, selectedPath: string) => {
 
   let onProbeFlow = event =>
     state.channels.log->Chan.emit(Log.Connection(Log.Connection.ProbeFlow(event)))
+  let onEstablishFlow = event =>
+    state.channels.log->Chan.emit(Log.Connection(Log.Connection.EstablishFlow(event)))
+  let establishKind = connection =>
+    switch connection {
+    | Core.Agda(_, _, _) => Log.Connection.EstablishFlow.Agda
+    | Core.ALS(_, _, _) => Log.Connection.EstablishFlow.ALS
+    | Core.ALSWASM(_, _, _, _) => Log.Connection.EstablishFlow.ALSWASM
+    }
 
   switch await Core.fromPathsOrCommands(
     state.platformDeps,
     [(selectedPath, Core.Error.Establish.FromConfig)],
     ~onProbeFlow,
+    ~onEstablishFlow,
   ) {
   | Ok(conn) =>
+    onEstablishFlow(
+      Log.Connection.EstablishFlow.ConnectionEstablished(Core.getPath(conn), establishKind(conn)),
+    )
     Util.log("[ debug ] switchAgdaVersion: connection succeeded", Core.toString(conn))
     await Registry__Connection.shutdown()
 
@@ -325,6 +337,7 @@ let switchAgdaVersion = async (state: State.t, selectedPath: string) => {
     }
     let _ = await Core.destroy(Some(conn), state.channels.log)
   | Error(error) => {
+      onEstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablishFailed)
       let (errorHeader, errorBody) = Core.Error.toString(Establish(error))
       Util.log("[ debug ] switchAgdaVersion: connection failed", errorHeader ++ " | " ++ errorBody)
       let header = AgdaModeVscode.View.Header.Error(

--- a/src/Connection/Connection__Switch.res
+++ b/src/Connection/Connection__Switch.res
@@ -282,12 +282,16 @@ let switchAgdaVersion = async (state: State.t, selectedPath: string) => {
     state.channels.log->Chan.emit(Log.Connection(Log.Connection.ProbeFlow(event)))
   let onEstablishFlow = event =>
     state.channels.log->Chan.emit(Log.Connection(Log.Connection.EstablishFlow(event)))
+  let onSwitchUIFlow = event =>
+    state.channels.log->Chan.emit(Log.Connection(Log.Connection.SwitchUIFlow(event)))
   let establishKind = connection =>
     switch connection {
     | Core.Agda(_, _, _) => Log.Connection.EstablishFlow.Agda
     | Core.ALS(_, _, _) => Log.Connection.EstablishFlow.ALS
     | Core.ALSWASM(_, _, _, _) => Log.Connection.EstablishFlow.ALSWASM
     }
+
+  onSwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchRequested(selectedPath))
 
   switch await Core.fromPathsOrCommands(
     state.platformDeps,
@@ -296,47 +300,57 @@ let switchAgdaVersion = async (state: State.t, selectedPath: string) => {
     ~onEstablishFlow,
   ) {
   | Ok(conn) =>
-    onEstablishFlow(
-      Log.Connection.EstablishFlow.ConnectionEstablished(Core.getPath(conn), establishKind(conn)),
-    )
-    Util.log("[ debug ] switchAgdaVersion: connection succeeded", Core.toString(conn))
-    await Registry__Connection.shutdown()
+    try {
+      Util.log("[ debug ] switchAgdaVersion: connection succeeded", Core.toString(conn))
+      await Registry__Connection.shutdown()
 
-    await Memento.PreferredCandidate.set(state.memento, Some(selectedPath))
+      await Memento.PreferredCandidate.set(state.memento, Some(selectedPath))
 
-    await State__View.Panel.displayConnectionStatus(state, Some(conn))
-    await State__View.Panel.display(
-      state,
-      AgdaModeVscode.View.Header.Success("Switched to " ++ Core.toString(conn)),
-      [],
-    )
-    switch conn {
-    | Agda(_, path, version) =>
-      let resolved = resolvedFromConnectionPath(path)
-      await Memento.ResolvedMetadata.setKind(
-        state.memento,
-        resolved,
-        ResolvedMetadata.Agda(Some(version)),
+      await State__View.Panel.displayConnectionStatus(state, Some(conn))
+      await State__View.Panel.display(
+        state,
+        AgdaModeVscode.View.Header.Success("Switched to " ++ Core.toString(conn)),
+        [],
       )
-    | ALS(_, path, {alsVersion: Some(v), agdaVersion, lspOptions}) =>
-      let resolved = resolvedFromConnectionPath(path)
-      await Memento.ResolvedMetadata.setKind(
-        state.memento,
-        resolved,
-        ResolvedMetadata.ALS(Native, Some(v, agdaVersion, lspOptions)),
+      switch conn {
+      | Agda(_, path, version) =>
+        let resolved = resolvedFromConnectionPath(path)
+        await Memento.ResolvedMetadata.setKind(
+          state.memento,
+          resolved,
+          ResolvedMetadata.Agda(Some(version)),
+        )
+      | ALS(_, path, {alsVersion: Some(v), agdaVersion, lspOptions}) =>
+        let resolved = resolvedFromConnectionPath(path)
+        await Memento.ResolvedMetadata.setKind(
+          state.memento,
+          resolved,
+          ResolvedMetadata.ALS(Native, Some(v, agdaVersion, lspOptions)),
+        )
+      | ALS(_, _, {alsVersion: None}) => ()
+      | ALSWASM(_, _, path, {alsVersion: Some(v), agdaVersion, lspOptions}) =>
+        let resolved = resolvedFromConnectionPath(path)
+        await Memento.ResolvedMetadata.setKind(
+          state.memento,
+          resolved,
+          ResolvedMetadata.ALS(WASM, Some(v, agdaVersion, lspOptions)),
+        )
+      | ALSWASM(_, _, _, {alsVersion: None}) => ()
+      }
+      onEstablishFlow(
+        Log.Connection.EstablishFlow.ConnectionEstablished(Core.getPath(conn), establishKind(conn)),
       )
-    | ALS(_, _, {alsVersion: None}) => ()
-    | ALSWASM(_, _, path, {alsVersion: Some(v), agdaVersion, lspOptions}) =>
-      let resolved = resolvedFromConnectionPath(path)
-      await Memento.ResolvedMetadata.setKind(
-        state.memento,
-        resolved,
-        ResolvedMetadata.ALS(WASM, Some(v, agdaVersion, lspOptions)),
-      )
-    | ALSWASM(_, _, _, {alsVersion: None}) => ()
+      onSwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchSucceeded(Core.getPath(conn)))
+      let _ = await Core.destroy(Some(conn), state.channels.log)
+    } catch {
+    | exn =>
+      onEstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablishFailed)
+      onSwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchFailed(selectedPath))
+      let _ = await Core.destroy(Some(conn), state.channels.log)
+      raise(exn)
     }
-    let _ = await Core.destroy(Some(conn), state.channels.log)
   | Error(error) => {
+      onSwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchFailed(selectedPath))
       onEstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablishFailed)
       let (errorHeader, errorBody) = Core.Error.toString(Establish(error))
       Util.log("[ debug ] switchAgdaVersion: connection failed", errorHeader ++ " | " ++ errorBody)

--- a/src/Connection/Connection__Switch.res
+++ b/src/Connection/Connection__Switch.res
@@ -6,6 +6,7 @@ module SwitchVersionManager = {
   type t = {
     memento: Memento.t,
     globalStorageUri: VSCode.Uri.t,
+    logChannel: Chan.t<Log.t>,
   }
 
   let inferCandidateKind = (raw: string) => {
@@ -65,6 +66,7 @@ module SwitchVersionManager = {
   let make = (state: State.t): t => {
     memento: state.memento,
     globalStorageUri: state.globalStorageUri,
+    logChannel: state.channels.log,
   }
 
   let getItemData = async (
@@ -149,9 +151,11 @@ module SwitchVersionManager = {
       false
     } else {
       module PlatformOps = unpack(platformDeps)
+      let onProbeFlow = event =>
+        self.logChannel->Chan.emit(Log.Connection(Log.Connection.ProbeFlow(event)))
       let probePromises = pathsToProbe->Array.map(async path => {
         let candidate = Candidate.make(path)
-        switch await Core.probeCandidate(platformDeps, candidate) {
+        switch await Core.probeCandidate(platformDeps, candidate, ~onProbeFlow) {
         | Ok((resolved, IsAgda(agdaVersion))) =>
           await Memento.ResolvedMetadata.setKind(
             self.memento,

--- a/src/Connection/Connection__Switch.res
+++ b/src/Connection/Connection__Switch.res
@@ -278,9 +278,13 @@ let switchAgdaVersion = async (state: State.t, selectedPath: string) => {
     [],
   )
 
+  let onProbeFlow = event =>
+    state.channels.log->Chan.emit(Log.Connection(Log.Connection.ProbeFlow(event)))
+
   switch await Core.fromPathsOrCommands(
     state.platformDeps,
     [(selectedPath, Core.Error.Establish.FromConfig)],
+    ~onProbeFlow,
   ) {
   | Ok(conn) =>
     Util.log("[ debug ] switchAgdaVersion: connection succeeded", Core.toString(conn))

--- a/src/Connection/Download/Connection__Download__Flow.res
+++ b/src/Connection/Download/Connection__Download__Flow.res
@@ -5,6 +5,7 @@ let sourceForSelection = async (
   ~channel: Connection__Download__Channel.t,
   ~platform: Connection__Download__DownloadArtifact.Platform.t,
   ~versionString: string,
+  ~onEvent: Log.Connection.DownloadFlow.t => unit=_ => (),
 ): result<Connection__Download__Source.t, Connection__Download__Error.t> => {
   module PlatformOps = unpack(platformDeps)
 
@@ -25,7 +26,14 @@ let sourceForSelection = async (
     let resolver = PlatformOps.resolveDownloadChannel(channel, true)
     switch await resolver(memento, globalStorageUri, downloadPlatform) {
     | Error(error) => Error(error)
-    | Ok(Connection__Download__Source.FromURL(_, _, _) as source) => Ok(source)
+    | Ok(Connection__Download__Source.FromURL(_, _, _) as source) =>
+      onEvent(
+        Log.Connection.DownloadFlow.SourceResolved(
+          Log.Connection.DownloadFlow.URL,
+          Connection__Download__Source.toVersionString(source),
+        ),
+      )
+      Ok(source)
     | Ok(Connection__Download__Source.FromGitHub(_, descriptor)) =>
       let release = descriptor.release
       let assets = switch platform {
@@ -51,8 +59,37 @@ let sourceForSelection = async (
       )
 
       switch matchingSource {
-      | None => Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
-      | Some(source) => Ok(source)
+      | None =>
+        if platform != Connection__Download__DownloadArtifact.Platform.Wasm {
+          switch Connection__Download__Assets.wasm(release)->Array.get(0) {
+          | None => Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
+          | Some(wasmAsset) =>
+            let wasmSource = Connection__Download__Source.FromGitHub(channel, {
+              Connection__Download__GitHub.DownloadDescriptor.asset: wasmAsset,
+              release,
+              saveAsFileName: descriptor.saveAsFileName,
+            })
+            let wasmVersion = Connection__Download__Source.toVersionString(wasmSource)
+            onEvent(Log.Connection.DownloadFlow.FallbackChosen(wasmVersion))
+            onEvent(
+              Log.Connection.DownloadFlow.SourceResolved(
+                Log.Connection.DownloadFlow.GitHub,
+                wasmVersion,
+              ),
+            )
+            Ok(wasmSource)
+          }
+        } else {
+          Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
+        }
+      | Some(source) =>
+        onEvent(
+          Log.Connection.DownloadFlow.SourceResolved(
+            Log.Connection.DownloadFlow.GitHub,
+            Connection__Download__Source.toVersionString(source),
+          ),
+        )
+        Ok(source)
       }
     }
     }

--- a/src/Connection/UI/Connection__UI__Handlers.res
+++ b/src/Connection/UI/Connection__UI__Handlers.res
@@ -20,6 +20,13 @@ let handleDownload = async (
   state.channels.log->Chan.emit(
     Log.SwitchVersionUI(Log.SwitchVersion.SelectedDownloadAction(downloaded, versionString)),
   )
+  state.channels.log->Chan.emit(
+    Log.Connection(
+      Log.Connection.DownloadFlow(
+        Log.Connection.DownloadFlow.SelectionRequested(channel, platform, versionString, downloaded),
+      ),
+    ),
+  )
 
   if downloaded {
     switch await Connection__Download__ManagedStorage.findCandidateForSelection(
@@ -28,8 +35,27 @@ let handleDownload = async (
       ~platform,
       ~versionString,
     ) {
-    | None => ()
+    | None =>
+      state.channels.log->Chan.emit(
+        Log.Connection(
+          Log.Connection.DownloadFlow(Log.Connection.DownloadFlow.ManagedMiss(versionString)),
+        ),
+      )
     | Some(downloadedPath) =>
+      state.channels.log->Chan.emit(
+        Log.Connection(
+          Log.Connection.DownloadFlow(
+            Log.Connection.DownloadFlow.ManagedHit(versionString, downloadedPath),
+          ),
+        ),
+      )
+      state.channels.log->Chan.emit(
+        Log.Connection(
+          Log.Connection.DownloadFlow(
+            Log.Connection.DownloadFlow.ReusedExistingArtifact(downloadedPath),
+          ),
+        ),
+      )
       await Config.Connection.addAgdaPath(state.channels.log, downloadedPath)
       VSCode.Window.showInformationMessage(
         versionString ++ " is already downloaded",
@@ -39,34 +65,63 @@ let handleDownload = async (
   } else {
     module PlatformOps = unpack(platformDeps)
     let onTrace = event => state.channels.log->Chan.emit(Log.DownloadTrace(event))
-    let downloadResult = switch await Connection__Download__Flow.sourceForSelection(
+    let onFlowEvent = event =>
+      state.channels.log->Chan.emit(Log.Connection(Log.Connection.DownloadFlow(event)))
+    let sourceResult = await Connection__Download__Flow.sourceForSelection(
       state.memento,
       state.globalStorageUri,
       platformDeps,
       ~channel,
       ~platform,
       ~versionString,
-    ) {
-    | Error(error) => Error(error)
-    | Ok(source) => await PlatformOps.download(state.globalStorageUri, source, ~trace=onTrace)
-    }
-
-    switch downloadResult {
+      ~onEvent=onFlowEvent,
+    )
+    switch sourceResult {
     | Error(error) =>
       VSCode.Window.showErrorMessage(
         AgdaModeVscode.Connection__Download__Error.toString(error),
         [],
       )->Promise.done
-    | Ok(downloadedPath) =>
-      await Config.Connection.addAgdaPath(state.channels.log, downloadedPath)
-      switch refreshUI {
-      | Some(refreshFn) => await refreshFn()
-      | None => ()
+    | Ok(source) =>
+      state.channels.log->Chan.emit(
+        Log.Connection(
+          Log.Connection.DownloadFlow(
+            Log.Connection.DownloadFlow.DownloadStarted(channel, platform, versionString),
+          ),
+        ),
+      )
+      let downloadResult = await PlatformOps.download(state.globalStorageUri, source, ~trace=onTrace)
+      switch downloadResult {
+      | Error(error) =>
+        state.channels.log->Chan.emit(
+          Log.Connection(
+            Log.Connection.DownloadFlow(
+              Log.Connection.DownloadFlow.DownloadFailed(
+                AgdaModeVscode.Connection__Download__Error.toString(error),
+              ),
+            ),
+          ),
+        )
+        VSCode.Window.showErrorMessage(
+          AgdaModeVscode.Connection__Download__Error.toString(error),
+          [],
+        )->Promise.done
+      | Ok(downloadedPath) =>
+        state.channels.log->Chan.emit(
+          Log.Connection(
+            Log.Connection.DownloadFlow(Log.Connection.DownloadFlow.DownloadSucceeded(downloadedPath)),
+          ),
+        )
+        await Config.Connection.addAgdaPath(state.channels.log, downloadedPath)
+        switch refreshUI {
+        | Some(refreshFn) => await refreshFn()
+        | None => ()
+        }
+        VSCode.Window.showInformationMessage(
+          versionString ++ " successfully downloaded",
+          [],
+        )->Promise.done
       }
-      VSCode.Window.showInformationMessage(
-        versionString ++ " successfully downloaded",
-        [],
-      )->Promise.done
     }
   }
   state.channels.log->Chan.emit(Log.SwitchVersionUI(Log.SwitchVersion.SelectionCompleted))
@@ -175,7 +230,6 @@ let onSelection = (
             )->Promise.done
           }
         | DownloadAction(downloaded, versionString, platform) =>
-          Util.log("[ debug ] user clicked: download button = " ++ selectedItem.label, "")
           view->Picker.destroy
           await handleDownload(
             state,

--- a/src/State/Log.res
+++ b/src/State/Log.res
@@ -66,6 +66,45 @@ module SwitchVersion = {
 }
 
 module Connection = {
+  module EstablishFlow = {
+    type connectionKind = Agda | ALS | ALSWASM
+
+    type t =
+      | ConfigCandidatesStarted(int)
+      | CandidateAttempted(string, Connection__Error.Establish.pathSource)
+      | ConfigCandidatesFailed
+      | DownloadFallbackStarted(
+          Connection__Download__Channel.t,
+          Connection__Download__DownloadArtifact.Platform.t,
+        )
+      | DownloadFallbackFailed(Connection__Error.Establish.t)
+      | ConnectionEstablished(string, connectionKind)
+      | ConnectionEstablishFailed
+
+    let toString = event =>
+      switch event {
+      | ConfigCandidatesStarted(count) => "ConfigCandidatesStarted: " ++ string_of_int(count)
+      | CandidateAttempted(pathOrCommand, source) =>
+        "CandidateAttempted: " ++
+        pathOrCommand ++
+        " (" ++
+        Connection__Error.Establish.pathSourceToString(source) ++
+        ")"
+      | ConfigCandidatesFailed => "ConfigCandidatesFailed"
+      | DownloadFallbackStarted(channel, platform) =>
+        "DownloadFallbackStarted: channel=" ++
+        Connection__Download__Channel.toString(channel) ++
+        " platform=" ++
+        Connection__Download__DownloadArtifact.Platform.toAssetTag(platform)
+      | DownloadFallbackFailed(error) =>
+        "DownloadFallbackFailed: " ++ Connection__Error.Establish.toString(error)
+      | ConnectionEstablished(path, Agda) => "ConnectionEstablished: " ++ path ++ " (Agda)"
+      | ConnectionEstablished(path, ALS) => "ConnectionEstablished: " ++ path ++ " (ALS)"
+      | ConnectionEstablished(path, ALSWASM) => "ConnectionEstablished: " ++ path ++ " (ALSWASM)"
+      | ConnectionEstablishFailed => "ConnectionEstablishFailed"
+      }
+  }
+
   module ProbeFlow = {
     type t =
       | CandidateResolveStarted(Connection__Candidate.t)
@@ -150,6 +189,7 @@ module Connection = {
   }
 
   type t =
+    | EstablishFlow(EstablishFlow.t) // top-level connection-establishment flow
     | ProbeFlow(ProbeFlow.t) // structured probe / candidate-resolution observability event
     | DownloadFlow(DownloadFlow.t) // structured download flow observability event
     | ConnectedToAgda(string, string) // path, version
@@ -158,6 +198,7 @@ module Connection = {
 
   let toString = event =>
     switch event {
+    | EstablishFlow(event) => "[ EstablishFlow    ] " ++ EstablishFlow.toString(event)
     | ProbeFlow(event) => "[ ProbeFlow        ] " ++ ProbeFlow.toString(event)
     | DownloadFlow(event) => "[ DownloadFlow     ] " ++ DownloadFlow.toString(event)
     | ConnectedToAgda(path, version) => `ConnectedToAgda: ${path} - Agda v${version}`
@@ -233,7 +274,9 @@ let isConfig = log =>
 
 let isConnection = log =>
   switch log {
-  | Connection(_) => true
+  | Connection(Connection.ConnectedToAgda(_, _))
+  | Connection(Connection.ConnectedToALS(_, _))
+  | Connection(Connection.Disconnected(_)) => true
   | _ => false
   }
 

--- a/src/State/Log.res
+++ b/src/State/Log.res
@@ -102,7 +102,7 @@ module Connection = {
     type connectionKind = Agda | ALS | ALSWASM
 
     type t =
-      | ConfigCandidatesStarted(int)
+      | ConfigCandidatesPlanned(int)
       | CandidateAttempted(string, Connection__Error.Establish.pathSource)
       | ConfigCandidatesFailed
       | DownloadFallbackStarted(
@@ -110,12 +110,14 @@ module Connection = {
           Connection__Download__DownloadArtifact.Platform.t,
         )
       | DownloadFallbackFailed(Connection__Error.Establish.t)
-      | ConnectionEstablished(string, connectionKind)
+      // Connection.t object created; outer flows (SwitchUIFlow, ActivationFlow) report operation success
+      | ConnectionCreated(string, connectionKind)
       | ConnectionEstablishFailed
+      | ConnectionFinalizeFailed(string, connectionKind)
 
     let toString = event =>
       switch event {
-      | ConfigCandidatesStarted(count) => "ConfigCandidatesStarted: " ++ string_of_int(count)
+      | ConfigCandidatesPlanned(count) => "ConfigCandidatesPlanned: " ++ string_of_int(count)
       | CandidateAttempted(pathOrCommand, source) =>
         "CandidateAttempted: " ++
         pathOrCommand ++
@@ -130,10 +132,14 @@ module Connection = {
         Connection__Download__DownloadArtifact.Platform.toAssetTag(platform)
       | DownloadFallbackFailed(error) =>
         "DownloadFallbackFailed: " ++ Connection__Error.Establish.toString(error)
-      | ConnectionEstablished(path, Agda) => "ConnectionEstablished: " ++ path ++ " (Agda)"
-      | ConnectionEstablished(path, ALS) => "ConnectionEstablished: " ++ path ++ " (ALS)"
-      | ConnectionEstablished(path, ALSWASM) => "ConnectionEstablished: " ++ path ++ " (ALSWASM)"
+      | ConnectionCreated(path, Agda) => "ConnectionCreated: " ++ path ++ " (Agda)"
+      | ConnectionCreated(path, ALS) => "ConnectionCreated: " ++ path ++ " (ALS)"
+      | ConnectionCreated(path, ALSWASM) => "ConnectionCreated: " ++ path ++ " (ALSWASM)"
       | ConnectionEstablishFailed => "ConnectionEstablishFailed"
+      | ConnectionFinalizeFailed(path, Agda) => "ConnectionFinalizeFailed: " ++ path ++ " (Agda)"
+      | ConnectionFinalizeFailed(path, ALS) => "ConnectionFinalizeFailed: " ++ path ++ " (ALS)"
+      | ConnectionFinalizeFailed(path, ALSWASM) =>
+        "ConnectionFinalizeFailed: " ++ path ++ " (ALSWASM)"
       }
   }
 

--- a/src/State/Log.res
+++ b/src/State/Log.res
@@ -66,13 +66,56 @@ module SwitchVersion = {
 }
 
 module Connection = {
+  module DownloadFlow = {
+    type sourceKind = Managed | GitHub | URL
+
+    type t =
+      | SelectionRequested(
+          Connection__Download__Channel.t,
+          Connection__Download__DownloadArtifact.Platform.t,
+          string,
+          bool,
+        ) // channel, platform, versionString, alreadyDownloaded
+      | ManagedHit(string, string) // versionString, path
+      | ManagedMiss(string) // versionString
+      | SourceResolved(sourceKind, string) // sourceKind, versionString
+      | ReusedExistingArtifact(string) // path
+      | DownloadStarted(
+          Connection__Download__Channel.t,
+          Connection__Download__DownloadArtifact.Platform.t,
+          string,
+        ) // channel, platform, versionString
+      | DownloadSucceeded(string) // path
+      | DownloadFailed(string) // errorMsg
+      | FallbackChosen(string) // versionString
+
+    let toString = event =>
+      switch event {
+      | SelectionRequested(channel, platform, vs, downloaded) =>
+        `SelectionRequested: channel=${Connection__Download__Channel.toString(channel)} platform=${Connection__Download__DownloadArtifact.Platform.toAssetTag(platform)} version=${vs} downloaded=${string_of_bool(downloaded)}`
+      | ManagedHit(vs, path) => `ManagedHit: ${vs} at ${path}`
+      | ManagedMiss(vs) => `ManagedMiss: ${vs}`
+      | SourceResolved(Managed, vs) => `SourceResolved(Managed): ${vs}`
+      | SourceResolved(GitHub, vs) => `SourceResolved(GitHub): ${vs}`
+      | SourceResolved(URL, vs) => `SourceResolved(URL): ${vs}`
+      | ReusedExistingArtifact(path) => `ReusedExistingArtifact: ${path}`
+      | DownloadStarted(channel, platform, vs) =>
+        `DownloadStarted: channel=${Connection__Download__Channel.toString(channel)} platform=${Connection__Download__DownloadArtifact.Platform.toAssetTag(platform)} version=${vs}`
+      | DownloadSucceeded(path) => `DownloadSucceeded: ${path}`
+      | DownloadFailed(msg) => `DownloadFailed: ${msg}`
+      | FallbackChosen(vs) => `FallbackChosen: ${vs}`
+      }
+  }
+
   type t =
+    | DownloadFlow(DownloadFlow.t) // structured download flow observability event
     | ConnectedToAgda(string, string) // path, version
     | ConnectedToALS(string, option<(string, string)>) // path, ALS version, Agda version
     | Disconnected(string) // path
 
   let toString = event =>
     switch event {
+    | DownloadFlow(event) => "[ DownloadFlow     ] " ++ DownloadFlow.toString(event)
     | ConnectedToAgda(path, version) => `ConnectedToAgda: ${path} - Agda v${version}`
     | ConnectedToALS(path, Some(alsVersion, agdaVersion)) =>
       `ConnectedToALS: ${path} - Agda v${agdaVersion} Language Server v${alsVersion}`

--- a/src/State/Log.res
+++ b/src/State/Log.res
@@ -113,6 +113,7 @@ module Connection = {
       // Connection.t object created; outer flows (SwitchUIFlow, ActivationFlow) report operation success
       | ConnectionCreated(string, connectionKind)
       | ConnectionEstablishFailed
+      // emitted from the switch path only: connection was created, but post-establish switch finalization failed
       | ConnectionFinalizeFailed(string, connectionKind)
 
     let toString = event =>

--- a/src/State/Log.res
+++ b/src/State/Log.res
@@ -66,6 +66,48 @@ module SwitchVersion = {
 }
 
 module Connection = {
+  module ProbeFlow = {
+    type t =
+      | CandidateResolveStarted(Connection__Candidate.t)
+      | CandidateResolved(Connection__Candidate.t, VSCode.Uri.t)
+      | CandidateResolveFailed(Connection__Candidate.t, Connection__Command.Error.t)
+      | ProbeStarted(VSCode.Uri.t)
+      | ProbeClassifiedAsAgda(string, string) // path, agdaVersion
+      | ProbeClassifiedAsALS(string, string, string) // path, alsVersion, agdaVersion
+      | ProbeClassifiedAsALSWASM(string) // pathOrUri
+      | ProbeFailed(string, Connection__Error.Probe.t) // pathKey, error
+
+    let toString = event =>
+      switch event {
+      | CandidateResolveStarted(candidate) =>
+        "CandidateResolveStarted: " ++ Connection__Candidate.toString(candidate)
+      | CandidateResolved(original, resource) =>
+        "CandidateResolved: " ++
+        Connection__Candidate.toString(original) ++
+        " -> " ++
+        VSCode.Uri.toString(resource)
+      | CandidateResolveFailed(original, commandError) =>
+        "CandidateResolveFailed: " ++
+        Connection__Candidate.toString(original) ++
+        " -> " ++
+        Connection__Command.Error.toString(commandError)
+      | ProbeStarted(resource) => "ProbeStarted: " ++ VSCode.Uri.toString(resource)
+      | ProbeClassifiedAsAgda(path, version) =>
+        "ProbeClassifiedAsAgda: " ++ path ++ " (Agda v" ++ version ++ ")"
+      | ProbeClassifiedAsALS(path, alsVersion, agdaVersion) =>
+        "ProbeClassifiedAsALS: " ++
+        path ++
+        " (ALS v" ++
+        alsVersion ++
+        ", Agda v" ++
+        agdaVersion ++
+        ")"
+      | ProbeClassifiedAsALSWASM(pathOrUri) => "ProbeClassifiedAsALSWASM: " ++ pathOrUri
+      | ProbeFailed(pathKey, error) =>
+        "ProbeFailed: " ++ pathKey ++ " -> " ++ Connection__Error.Probe.toString(error)
+      }
+  }
+
   module DownloadFlow = {
     type sourceKind = Managed | GitHub | URL
 
@@ -108,6 +150,7 @@ module Connection = {
   }
 
   type t =
+    | ProbeFlow(ProbeFlow.t) // structured probe / candidate-resolution observability event
     | DownloadFlow(DownloadFlow.t) // structured download flow observability event
     | ConnectedToAgda(string, string) // path, version
     | ConnectedToALS(string, option<(string, string)>) // path, ALS version, Agda version
@@ -115,6 +158,7 @@ module Connection = {
 
   let toString = event =>
     switch event {
+    | ProbeFlow(event) => "[ ProbeFlow        ] " ++ ProbeFlow.toString(event)
     | DownloadFlow(event) => "[ DownloadFlow     ] " ++ DownloadFlow.toString(event)
     | ConnectedToAgda(path, version) => `ConnectedToAgda: ${path} - Agda v${version}`
     | ConnectedToALS(path, Some(alsVersion, agdaVersion)) =>

--- a/src/State/Log.res
+++ b/src/State/Log.res
@@ -66,6 +66,38 @@ module SwitchVersion = {
 }
 
 module Connection = {
+  module ActivationFlow = {
+    type t =
+      | ActivationStarted
+      | ExistingConnectionReused
+      | FreshEstablishStarted
+      | ActivationSucceeded
+      | ActivationFailed
+
+    let toString = event =>
+      switch event {
+      | ActivationStarted => "ActivationStarted"
+      | ExistingConnectionReused => "ExistingConnectionReused"
+      | FreshEstablishStarted => "FreshEstablishStarted"
+      | ActivationSucceeded => "ActivationSucceeded"
+      | ActivationFailed => "ActivationFailed"
+      }
+  }
+
+  module SwitchUIFlow = {
+    type t =
+      | SwitchRequested(string) // selectedPath
+      | SwitchSucceeded(string) // finalPath
+      | SwitchFailed(string) // selectedPath
+
+    let toString = event =>
+      switch event {
+      | SwitchRequested(selectedPath) => "SwitchRequested: " ++ selectedPath
+      | SwitchSucceeded(finalPath) => "SwitchSucceeded: " ++ finalPath
+      | SwitchFailed(selectedPath) => "SwitchFailed: " ++ selectedPath
+      }
+  }
+
   module EstablishFlow = {
     type connectionKind = Agda | ALS | ALSWASM
 
@@ -189,6 +221,8 @@ module Connection = {
   }
 
   type t =
+    | ActivationFlow(ActivationFlow.t) // top-level activation/acquisition flow
+    | SwitchUIFlow(SwitchUIFlow.t) // top-level switch-ui intent/result flow
     | EstablishFlow(EstablishFlow.t) // top-level connection-establishment flow
     | ProbeFlow(ProbeFlow.t) // structured probe / candidate-resolution observability event
     | DownloadFlow(DownloadFlow.t) // structured download flow observability event
@@ -198,6 +232,8 @@ module Connection = {
 
   let toString = event =>
     switch event {
+    | ActivationFlow(event) => "[ ActivationFlow   ] " ++ ActivationFlow.toString(event)
+    | SwitchUIFlow(event) => "[ SwitchUIFlow    ] " ++ SwitchUIFlow.toString(event)
     | EstablishFlow(event) => "[ EstablishFlow    ] " ++ EstablishFlow.toString(event)
     | ProbeFlow(event) => "[ ProbeFlow        ] " ++ ProbeFlow.toString(event)
     | DownloadFlow(event) => "[ DownloadFlow     ] " ++ DownloadFlow.toString(event)

--- a/src/State/State__Connection.res
+++ b/src/State/State__Connection.res
@@ -36,7 +36,11 @@ let sendRequest = async (
     }
   }
 
-  let make = () =>
+  state.channels.log->Chan.emit(Log.Connection(Log.Connection.ActivationFlow(ActivationStarted)))
+  let freshEstablishStarted = ref(false)
+  let make = () => {
+    freshEstablishStarted := true
+    state.channels.log->Chan.emit(Log.Connection(Log.Connection.ActivationFlow(FreshEstablishStarted)))
     Connection.makeWithFallback(
       state.platformDeps,
       state.memento,
@@ -45,10 +49,18 @@ let sendRequest = async (
       ["als", "agda"],
       state.channels.log,
     )
+  }
 
   switch await Registry__Connection.acquire(state.id, make) {
-  | Error(error) => await State__View.Panel.displayConnectionError(state, error)
-  | Ok(connection) => await sendRequestAndHandleResponses(connection, state, request, handleResponse)
+  | Error(error) =>
+    state.channels.log->Chan.emit(Log.Connection(Log.Connection.ActivationFlow(ActivationFailed)))
+    await State__View.Panel.displayConnectionError(state, error)
+  | Ok(connection) =>
+    if !freshEstablishStarted.contents {
+      state.channels.log->Chan.emit(Log.Connection(Log.Connection.ActivationFlow(ExistingConnectionReused)))
+    }
+    state.channels.log->Chan.emit(Log.Connection(Log.Connection.ActivationFlow(ActivationSucceeded)))
+    await sendRequestAndHandleResponses(connection, state, request, handleResponse)
   }
 }
 

--- a/test/tests/Connection/Test__Connection__Download.res
+++ b/test/tests/Connection/Test__Connection__Download.res
@@ -1191,6 +1191,67 @@ describe("Download", () => {
         "als-v6-Agda-2.8.0-macos-arm64.zip",
       )
     })
+
+    Async.it(
+      "sourceForSelection should emit SourceResolved(GitHub) via onEvent callback for matching asset",
+      async () => {
+        let nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip")
+        let wasmAsset = makeAsset("als-dev-Agda-2.8.0-wasm.wasm")
+        let release = makeRelease("dev", [nativeAsset, wasmAsset])
+        let platform = makePlatform(
+          Connection__Download__Platform.MacOS_Arm,
+          makeGitHubSource(Connection__Download__Channel.DevALS, release, nativeAsset, "dev-als"),
+        )
+
+        let events: array<Log.Connection.DownloadFlow.t> = []
+        let _ = await Connection__Download__Flow.sourceForSelection(
+          Memento.make(None),
+          VSCode.Uri.file("/tmp/agda-flow-onEvent"),
+          platform,
+          ~channel=Connection__Download__Channel.DevALS,
+          ~platform=Connection__Download__DownloadArtifact.Platform.Wasm,
+          ~versionString="Agda v2.8.0 Language Server (dev build)",
+          ~onEvent=event => events->Array.push(event),
+        )
+
+        Assert.deepStrictEqual(
+          events,
+          [Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.GitHub, "Agda v2.8.0 Language Server (dev build)")],
+        )
+      },
+    )
+
+    Async.it(
+      "sourceForSelection should emit FallbackChosen when native not found but WASM exists",
+      async () => {
+        let wasmAsset = makeAsset("als-dev-Agda-2.8.0-wasm.wasm")
+        let nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip")
+        let release = makeRelease("dev", [nativeAsset, wasmAsset])
+        let platform = makePlatform(
+          Connection__Download__Platform.MacOS_Arm,
+          makeGitHubSource(Connection__Download__Channel.DevALS, release, nativeAsset, "dev-als"),
+        )
+
+        let events: array<Log.Connection.DownloadFlow.t> = []
+        let _ = await Connection__Download__Flow.sourceForSelection(
+          Memento.make(None),
+          VSCode.Uri.file("/tmp/agda-flow-fallback"),
+          platform,
+          ~channel=Connection__Download__Channel.DevALS,
+          ~platform=Connection__Download__DownloadArtifact.Platform.MacOSArm64,
+          ~versionString="Agda v9.9.9 Language Server (dev build)",
+          ~onEvent=event => events->Array.push(event),
+        )
+
+        Assert.deepStrictEqual(
+          events,
+          [
+            Log.Connection.DownloadFlow.FallbackChosen("Agda v2.8.0 Language Server (dev build)"),
+            Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.GitHub, "Agda v2.8.0 Language Server (dev build)"),
+          ],
+        )
+      },
+    )
   })
 
   describe("ManagedStorage.findAnyWasmDownloaded", () => {

--- a/test/tests/Connection/Test__Connection__Download.res
+++ b/test/tests/Connection/Test__Connection__Download.res
@@ -1164,6 +1164,65 @@ describe("Download", () => {
       Assert.deepStrictEqual(result, Ok(source))
     })
 
+    Async.it(
+      "sourceForSelection should emit SourceResolved(URL) and no fallback for FromURL sources",
+      async () => {
+        let source = Connection__Download__Source.FromURL(
+          Connection__Download__Channel.DevALS,
+          "https://example.invalid/als.wasm",
+          "dev-als",
+        )
+        let sourceVersion = Connection__Download__Source.toVersionString(source)
+        let platform = makePlatform(Connection__Download__Platform.Web, source)
+
+        let events: array<Log.Connection.DownloadFlow.t> = []
+        let result = await Connection__Download__Flow.sourceForSelection(
+          Memento.make(None),
+          VSCode.Uri.file("/tmp/agda-flow-url-events"),
+          platform,
+          ~channel=Connection__Download__Channel.DevALS,
+          ~platform=Connection__Download__DownloadArtifact.Platform.Wasm,
+          ~versionString="ignored for URL source",
+          ~onEvent=event => events->Array.push(event),
+        )
+
+        Assert.deepStrictEqual(result, Ok(source))
+        Assert.deepStrictEqual(
+          events,
+          [Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.URL, sourceVersion)],
+        )
+      },
+    )
+
+    Async.it(
+      "sourceForSelection should not emit download lifecycle events when GitHub resolution fails before download",
+      async () => {
+        let nativeAsset = makeAsset("als-dev-Agda-2.8.0-macos-arm64.zip")
+        let release = makeRelease("dev", [nativeAsset])
+        let platform = makePlatform(
+          Connection__Download__Platform.MacOS_Arm,
+          makeGitHubSource(Connection__Download__Channel.DevALS, release, nativeAsset, "dev-als"),
+        )
+
+        let events: array<Log.Connection.DownloadFlow.t> = []
+        let result = await Connection__Download__Flow.sourceForSelection(
+          Memento.make(None),
+          VSCode.Uri.file("/tmp/agda-flow-prefail"),
+          platform,
+          ~channel=Connection__Download__Channel.DevALS,
+          ~platform=Connection__Download__DownloadArtifact.Platform.MacOSArm64,
+          ~versionString="Agda v9.9.9 Language Server (dev build)",
+          ~onEvent=event => events->Array.push(event),
+        )
+
+        Assert.deepStrictEqual(
+          result,
+          Error(Connection__Download__Error.CannotFindCompatibleALSRelease),
+        )
+        Assert.deepStrictEqual(events, [])
+      },
+    )
+
     Async.it("should use canonical LatestALS release assets", async () => {
       let latestAsset = makeAsset("als-v6-Agda-2.8.0-macos-arm64.zip")
       let release = makeRelease("v6", [
@@ -2330,6 +2389,14 @@ describe("Download", () => {
       }
     }
 
+    let collectDownloadFlowEvents = (events: array<Log.t>): array<Log.Connection.DownloadFlow.t> =>
+      events->Array.filterMap(event =>
+        switch event {
+        | Log.Connection(Log.Connection.DownloadFlow(flowEvent)) => Some(flowEvent)
+        | _ => None
+        }
+      )
+
     Async.it(
       "GitHub.download should forward trace to asFile",
       async () => {
@@ -2482,6 +2549,89 @@ describe("Download", () => {
             }
           )
           Assert.deepStrictEqual(hasDownloadTrace, true)
+        })
+      },
+    )
+
+    Async.it(
+      "handleDownload should emit SelectionRequested, SourceResolved(URL), DownloadStarted, DownloadSucceeded for URL-backed source",
+      async () => {
+        await withTempDir("agda-flow-log-url-", async storageUri => {
+          let channels: State.channels = {
+            inputMethod: Chan.make(),
+            responseHandled: Chan.make(),
+            commandHandled: Chan.make(),
+            log: Chan.make(),
+          }
+          let mockEditor: VSCode.TextEditor.t = %raw(`{ document: { fileName: "test.agda" } }`)
+          let mockExtensionUri = VSCode.Uri.file(NodeJs.Process.cwd(NodeJs.Process.process))
+          let state = State.make(
+            "test-id-flow-url",
+            Mock.Platform.makeBasic(),
+            channels,
+            storageUri,
+            mockExtensionUri,
+            Memento.make(None),
+            mockEditor,
+            None,
+          )
+
+          let logEvents: ref<array<Log.t>> = ref([])
+          let _ = Chan.on(state.channels.log, event => {
+            logEvents := logEvents.contents->Array.concat([event])
+          })
+
+          let urlSource = Connection__Download__Source.FromURL(
+            Connection__Download__Channel.DevALS,
+            "https://example.invalid/dev-als.wasm",
+            "dev-als",
+          )
+          let sourceVersion = Connection__Download__Source.toVersionString(urlSource)
+
+          let platform: Platform.t = {
+            module MockPlatform = {
+              let determinePlatform = async () => Ok(Connection__Download__Platform.MacOS_Arm)
+              let askUserAboutDownloadPolicy = async () => Config.Connection.DownloadPolicy.Yes
+              let alreadyDownloaded = _globalStorageUri => Promise.resolve(None)
+              let resolveDownloadChannel = Mock.DownloadDescriptor.mockWith(_ => Ok(urlSource))
+              let download = (_globalStorageUri, _source, ~trace=Connection__Download__Trace.noop) => {
+                trace(Trace.FetchStarted("https://example.invalid/dev-als.wasm"))
+                Promise.resolve(Ok("/mock/url-backed/path"))
+              }
+              let findCommand = (_command, ~timeout as _timeout=1000) =>
+                Promise.resolve(Error(Connection__Command.Error.NotFound))
+            }
+            module(MockPlatform)
+          }
+
+          let selectedVersionString = "manual URL selection"
+          await Connection__UI__Handlers.handleDownload(
+            state,
+            platform,
+            Connection__Download__DownloadArtifact.Platform.MacOSArm64,
+            false,
+            selectedVersionString,
+            ~channel=Connection__Download__Channel.DevALS,
+          )
+
+          Assert.deepStrictEqual(
+            collectDownloadFlowEvents(logEvents.contents),
+            [
+              Log.Connection.DownloadFlow.SelectionRequested(
+                Connection__Download__Channel.DevALS,
+                Connection__Download__DownloadArtifact.Platform.MacOSArm64,
+                selectedVersionString,
+                false,
+              ),
+              Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.URL, sourceVersion),
+              Log.Connection.DownloadFlow.DownloadStarted(
+                Connection__Download__Channel.DevALS,
+                Connection__Download__DownloadArtifact.Platform.MacOSArm64,
+                selectedVersionString,
+              ),
+              Log.Connection.DownloadFlow.DownloadSucceeded("/mock/url-backed/path"),
+            ],
+          )
         })
       },
     )

--- a/test/tests/Connection/Test__Connection__Switch.res
+++ b/test/tests/Connection/Test__Connection__Switch.res
@@ -1309,7 +1309,7 @@ describe("Connection__Switch", () => {
             })
 
           let missingPath = "/__agda_mode_vscode_nonexistent__/binary_should_not_exist_280"
-          let missingUri = VSCode.Uri.file(missingPath)
+          let Connection__URI.FileURI(_, missingUri) = Connection__URI.parse(missingPath)
           let missingPathKey = VSCode.Uri.fsPath(missingUri)
           let missingUriString = VSCode.Uri.toString(missingUri)
           let observedConnections = observeConnectionEvents(state)

--- a/test/tests/Connection/Test__Connection__Switch.res
+++ b/test/tests/Connection/Test__Connection__Switch.res
@@ -794,6 +794,18 @@ describe("Connection__Switch", () => {
       let createTestStateWithPlatform = (platform: Platform.t) =>
         createTestStateWithPlatformAndStorage(platform, VSCode.Uri.file(NodeJs.Os.tmpdir()))
 
+      let observeProbeFlow = (state: State.t) => {
+        let events: ref<array<Log.Connection.ProbeFlow.t>> = ref([])
+        let _ = state.channels.log->Chan.on(logEvent =>
+          switch logEvent {
+          | Log.Connection(Log.Connection.ProbeFlow(event)) =>
+            events.contents = Array.concat(events.contents, [event])
+          | _ => ()
+          }
+        )
+        events
+      }
+
       Async.it(
         "should write probe metadata under resolved identity for bare command candidates",
         async () => {
@@ -876,6 +888,8 @@ describe("Connection__Switch", () => {
               }
             )
 
+          let probeFlowEvents = observeProbeFlow(state)
+
           let changed = await Connection__Switch.SwitchVersionManager.probeVersions(
             manager,
             platform,
@@ -885,10 +899,60 @@ describe("Connection__Switch", () => {
             original: Connection__Candidate.make(devALSPath),
             resource: VSCode.Uri.file(devALSPath),
           }
+          let expectedCandidate = Connection__Candidate.make(devALSPath)
+          let expectedResolvedResource = switch expectedCandidate {
+          | Connection__Candidate.Resource(uri) => uri
+          | Connection__Candidate.Command(_) =>
+            raise(Failure("Expected DevALS path candidate to parse as resource"))
+          }
+          let observedProbeFlow =
+            probeFlowEvents.contents->Array.map(event =>
+              switch event {
+              | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+                ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
+              | Log.Connection.ProbeFlow.CandidateResolved(candidate, resource) =>
+                (
+                  "CandidateResolved",
+                  Connection__Candidate.toString(candidate),
+                  VSCode.Uri.toString(resource),
+                  "",
+                )
+              | Log.Connection.ProbeFlow.ProbeStarted(resource) =>
+                ("ProbeStarted", VSCode.Uri.toString(resource), "", "")
+              | Log.Connection.ProbeFlow.ProbeClassifiedAsALS(path, alsVersion, agdaVersion) =>
+                ("ProbeClassifiedAsALS", path, alsVersion, agdaVersion)
+              | unexpected =>
+                ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
+              }
+            )
 
           Assert.deepStrictEqual(
             preProbeKind,
             Some(Memento.ResolvedMetadata.ALS(Native, Some(("dev", "2.8.0", None)))),
+          )
+          Assert.deepStrictEqual(
+            observedProbeFlow,
+            [
+              (
+                "CandidateResolveStarted",
+                Connection__Candidate.toString(expectedCandidate),
+                "",
+                "",
+              ),
+              (
+                "CandidateResolved",
+                Connection__Candidate.toString(expectedCandidate),
+                VSCode.Uri.toString(expectedResolvedResource),
+                "",
+              ),
+              ("ProbeStarted", VSCode.Uri.toString(expectedResolvedResource), "", ""),
+              (
+                "ProbeClassifiedAsALS",
+                VSCode.Uri.fsPath(expectedResolvedResource),
+                "1.2.3",
+                "2.8.0",
+              ),
+            ],
           )
           Assert.deepStrictEqual(changed, true)
           Assert.deepStrictEqual(
@@ -943,6 +1007,170 @@ describe("Connection__Switch", () => {
 
           await Config.Connection.setAgdaPaths(state.channels.log, previousPaths)
           let _ = await FS.deleteRecursive(VSCode.Uri.file(storagePath))
+        },
+      )
+
+      Async.it(
+        "should emit ProbeFlow events including ProbeFailed when probing a non-executable file",
+        async () => {
+          let nonExecPath = NodeJs.Path.join([
+            NodeJs.Os.tmpdir(),
+            "agda-probe-fail-test-" ++ string_of_int(int_of_float(Js.Date.now())) ++ ".txt",
+          ])
+          NodeJs.Fs.writeFileSync(nonExecPath, NodeJs.Buffer.fromString("not an executable"))
+
+          let platform = makeMockPlatform()
+          let state = createTestStateWithPlatform(platform)
+          let manager = Connection__Switch.SwitchVersionManager.make(state)
+          let previousPaths = Config.Connection.getAgdaPaths()
+          let probeFlowEvents = observeProbeFlow(state)
+
+          await Config.Connection.setAgdaPaths(state.channels.log, [nonExecPath])
+
+          let changed = await Connection__Switch.SwitchVersionManager.probeVersions(
+            manager,
+            platform,
+          )
+
+          let pathKey = VSCode.Uri.fsPath(VSCode.Uri.file(nonExecPath))
+          let resourceUri = VSCode.Uri.toString(VSCode.Uri.file(nonExecPath))
+          let resolved: Connection__Candidate.Resolved.t = {
+            original: Connection__Candidate.make(nonExecPath),
+            resource: VSCode.Uri.file(nonExecPath),
+          }
+
+          let observedProbeFlow =
+            probeFlowEvents.contents->Array.map(event =>
+              switch event {
+              | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+                ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
+              | Log.Connection.ProbeFlow.CandidateResolved(candidate, resource) =>
+                (
+                  "CandidateResolved",
+                  Connection__Candidate.toString(candidate),
+                  VSCode.Uri.toString(resource),
+                  "",
+                )
+              | Log.Connection.ProbeFlow.ProbeStarted(resource) =>
+                ("ProbeStarted", VSCode.Uri.toString(resource), "", "")
+              | Log.Connection.ProbeFlow.ProbeFailed(pk, _error) =>
+                ("ProbeFailed", pk, "", "")
+              | unexpected =>
+                ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
+              }
+            )
+
+          let mementoEntry = Memento.ResolvedMetadata.get(state.memento, resolved)
+
+          let testResult = try {
+            Assert.deepStrictEqual(
+              observedProbeFlow,
+              [
+                ("CandidateResolveStarted", resourceUri, "", ""),
+                ("CandidateResolved", resourceUri, resourceUri, ""),
+                ("ProbeStarted", resourceUri, "", ""),
+                ("ProbeFailed", pathKey, "", ""),
+              ],
+            )
+            Assert.deepStrictEqual(changed, true)
+            Assert.deepStrictEqual(
+              mementoEntry->Option.map(e => e.kind),
+              Some(Memento.ResolvedMetadata.Unknown),
+            )
+            Assert.deepStrictEqual(
+              mementoEntry->Option.map(e => Option.isSome(e.error)),
+              Some(true),
+            )
+            Ok(())
+          } catch {
+          | _ as e => Error(e)
+          }
+
+          await Config.Connection.setAgdaPaths(state.channels.log, previousPaths)
+          try { NodeJs.Fs.unlinkSync(nonExecPath) } catch { | _ => () }
+
+          switch testResult {
+          | Ok(_) => ()
+          | Error(e) => raise(e)
+          }
+        },
+      )
+
+      Async.it(
+        "should emit CandidateResolveFailed ProbeFlow event when a bare command cannot be resolved",
+        async () => {
+          let bareCommand = "agda-probe-command-fail-test"
+          let platform = makeMockPlatform()
+          let state = createTestStateWithPlatform(platform)
+          let manager = Connection__Switch.SwitchVersionManager.make(state)
+          let previousPaths = Config.Connection.getAgdaPaths()
+
+          let unrelatedResolved: Connection__Candidate.Resolved.t = {
+            original: Connection__Candidate.make("/usr/bin/agda-unrelated"),
+            resource: VSCode.Uri.file("/usr/bin/agda-unrelated"),
+          }
+          await Memento.ResolvedMetadata.setKind(
+            state.memento,
+            unrelatedResolved,
+            Memento.ResolvedMetadata.Agda(Some("2.6.0")),
+          )
+
+          let probeFlowEvents = observeProbeFlow(state)
+
+          await Config.Connection.setAgdaPaths(state.channels.log, [bareCommand])
+
+          let changed = await Connection__Switch.SwitchVersionManager.probeVersions(
+            manager,
+            platform,
+          )
+
+          let observedProbeFlow =
+            probeFlowEvents.contents->Array.map(event =>
+              switch event {
+              | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+                ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
+              | Log.Connection.ProbeFlow.CandidateResolveFailed(candidate, error) =>
+                (
+                  "CandidateResolveFailed",
+                  Connection__Candidate.toString(candidate),
+                  Connection__Command.Error.toString(error),
+                  "",
+                )
+              | unexpected =>
+                ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
+              }
+            )
+
+          let testResult = try {
+            Assert.deepStrictEqual(
+              observedProbeFlow,
+              [
+                ("CandidateResolveStarted", bareCommand, "", ""),
+                ("CandidateResolveFailed", bareCommand, "Command not found", ""),
+              ],
+            )
+            Assert.deepStrictEqual(changed, true)
+            Assert.deepStrictEqual(
+              Memento.ResolvedMetadata.get(state.memento, unrelatedResolved)->Option.map(
+                e => e.kind,
+              ),
+              Some(Memento.ResolvedMetadata.Agda(Some("2.6.0"))),
+            )
+            Assert.deepStrictEqual(
+              Array.length(Memento.ResolvedMetadata.entries(state.memento)->Dict.toArray),
+              1,
+            )
+            Ok(())
+          } catch {
+          | _ as e => Error(e)
+          }
+
+          await Config.Connection.setAgdaPaths(state.channels.log, previousPaths)
+
+          switch testResult {
+          | Ok(_) => ()
+          | Error(e) => raise(e)
+          }
         },
       )
     })
@@ -1029,6 +1257,18 @@ describe("Connection__Switch", () => {
 
       let createTestState = () => createTestStateWithPlatform(makeMockPlatform())
 
+      let observeProbeFlow = (state: State.t) => {
+        let events: ref<array<Log.Connection.ProbeFlow.t>> = ref([])
+        let _ = state.channels.log->Chan.on(logEvent =>
+          switch logEvent {
+          | Log.Connection(Log.Connection.ProbeFlow(event)) =>
+            events.contents = Array.concat(events.contents, [event])
+          | _ => ()
+          }
+        )
+        events
+      }
+
       Async.it(
         "should keep existing shared connection when switch target cannot be established",
         async () => {
@@ -1045,13 +1285,39 @@ describe("Connection__Switch", () => {
             })
 
           let missingPath = "/__agda_mode_vscode_nonexistent__/binary_should_not_exist_280"
+          let missingUri = VSCode.Uri.file(missingPath)
+          let missingPathKey = VSCode.Uri.fsPath(missingUri)
+          let missingUriString = VSCode.Uri.toString(missingUri)
+          let probeFlowEvents = observeProbeFlow(state)
+
           let completion =
             Connection.switchCandidate(state, missingPath)->Promise.thenResolve(_ => "done")
           let timeout = Util.Promise_.setTimeout(1000)->Promise.thenResolve(_ => "timeout")
           let winner = await Promise.race([completion, timeout])
 
+          let observedProbeFlow = probeFlowEvents.contents->Array.map(event =>
+            switch event {
+            | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+              ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
+            | Log.Connection.ProbeFlow.CandidateResolved(candidate, resource) =>
+              ("CandidateResolved", Connection__Candidate.toString(candidate), VSCode.Uri.toString(resource), "")
+            | Log.Connection.ProbeFlow.ProbeStarted(resource) =>
+              ("ProbeStarted", VSCode.Uri.toString(resource), "", "")
+            | Log.Connection.ProbeFlow.ProbeFailed(pk, _error) =>
+              ("ProbeFailed", pk, "", "")
+            | unexpected =>
+              ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
+            }
+          )
+
           switch winner {
           | "done" =>
+            Assert.deepStrictEqual(observedProbeFlow, [
+              ("CandidateResolveStarted", missingUriString, "", ""),
+              ("CandidateResolved", missingUriString, missingUriString, ""),
+              ("ProbeStarted", missingUriString, "", ""),
+              ("ProbeFailed", missingPathKey, "", ""),
+            ])
             switch Registry__Connection.status.contents {
             | Active(resource) =>
               Assert.deepStrictEqual(Connection.getPath(resource.connection), existingPath)
@@ -1076,7 +1342,34 @@ describe("Connection__Switch", () => {
           let platform = makeMockPlatformWithBareCommands()
           let state = createTestStateWithPlatform(platform)
 
+          let mockAgdaUri = VSCode.Uri.file(mockAgda.contents)
+          let mockAgdaUriString = VSCode.Uri.toString(mockAgdaUri)
+          let mockAgdaFsPath = VSCode.Uri.fsPath(mockAgdaUri)
+          let probeFlowEvents = observeProbeFlow(state)
+
           await Connection.switchCandidate(state, "agda")
+
+          let observedProbeFlow = probeFlowEvents.contents->Array.map(event =>
+            switch event {
+            | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+              ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
+            | Log.Connection.ProbeFlow.CandidateResolved(candidate, resource) =>
+              ("CandidateResolved", Connection__Candidate.toString(candidate), VSCode.Uri.toString(resource), "")
+            | Log.Connection.ProbeFlow.ProbeStarted(resource) =>
+              ("ProbeStarted", VSCode.Uri.toString(resource), "", "")
+            | Log.Connection.ProbeFlow.ProbeClassifiedAsAgda(path, version) =>
+              ("ProbeClassifiedAsAgda", path, version, "")
+            | unexpected =>
+              ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
+            }
+          )
+
+          Assert.deepStrictEqual(observedProbeFlow, [
+            ("CandidateResolveStarted", "agda", "", ""),
+            ("CandidateResolved", "agda", mockAgdaUriString, ""),
+            ("ProbeStarted", mockAgdaUriString, "", ""),
+            ("ProbeClassifiedAsAgda", mockAgdaFsPath, "2.7.0.1", ""),
+          ])
 
           module PlatformOps = unpack(platform)
           let resolved = switch await Connection__Candidate.resolve(

--- a/test/tests/Connection/Test__Connection__Switch.res
+++ b/test/tests/Connection/Test__Connection__Switch.res
@@ -1257,29 +1257,41 @@ describe("Connection__Switch", () => {
 
       let createTestState = () => createTestStateWithPlatform(makeMockPlatform())
 
-      let observeProbeFlow = (state: State.t) => {
-        let events: ref<array<Log.Connection.ProbeFlow.t>> = ref([])
+      let observeConnectionEvents = (state: State.t): ref<array<Log.Connection.t>> => {
+        let events: ref<array<Log.Connection.t>> = ref([])
         let _ = state.channels.log->Chan.on(logEvent =>
           switch logEvent {
-          | Log.Connection(Log.Connection.ProbeFlow(event)) =>
-            events.contents = Array.concat(events.contents, [event])
+          | Log.Connection(connectionEvent) =>
+            events.contents = Array.concat(events.contents, [connectionEvent])
           | _ => ()
           }
         )
         events
       }
 
-      let observeEstablishFlow = (state: State.t) => {
-        let events: ref<array<Log.Connection.EstablishFlow.t>> = ref([])
-        let _ = state.channels.log->Chan.on(logEvent =>
-          switch logEvent {
-          | Log.Connection(Log.Connection.EstablishFlow(event)) =>
-            events.contents = Array.concat(events.contents, [event])
-          | _ => ()
+      let probeFlowEvents = (observedConnections: ref<array<Log.Connection.t>>) =>
+        observedConnections.contents->Array.filterMap(connectionEvent =>
+          switch connectionEvent {
+          | Log.Connection.ProbeFlow(event) => Some(event)
+          | _ => None
           }
         )
-        events
-      }
+
+      let establishFlowEvents = (observedConnections: ref<array<Log.Connection.t>>) =>
+        observedConnections.contents->Array.filterMap(connectionEvent =>
+          switch connectionEvent {
+          | Log.Connection.EstablishFlow(event) => Some(event)
+          | _ => None
+          }
+        )
+
+      let switchUIFlowEvents = (observedConnections: ref<array<Log.Connection.t>>) =>
+        observedConnections.contents->Array.filterMap(connectionEvent =>
+          switch connectionEvent {
+          | Log.Connection.SwitchUIFlow(event) => Some(event)
+          | _ => None
+          }
+        )
 
       Async.it(
         "should keep existing shared connection when switch target cannot be established",
@@ -1300,15 +1312,14 @@ describe("Connection__Switch", () => {
           let missingUri = VSCode.Uri.file(missingPath)
           let missingPathKey = VSCode.Uri.fsPath(missingUri)
           let missingUriString = VSCode.Uri.toString(missingUri)
-          let probeFlowEvents = observeProbeFlow(state)
-          let establishFlowEvents = observeEstablishFlow(state)
+          let observedConnections = observeConnectionEvents(state)
 
           let completion =
             Connection.switchCandidate(state, missingPath)->Promise.thenResolve(_ => "done")
           let timeout = Util.Promise_.setTimeout(1000)->Promise.thenResolve(_ => "timeout")
           let winner = await Promise.race([completion, timeout])
 
-          let observedProbeFlow = probeFlowEvents.contents->Array.map(event =>
+          let observedProbeFlow = probeFlowEvents(observedConnections)->Array.map(event =>
             switch event {
             | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
               ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
@@ -1322,7 +1333,7 @@ describe("Connection__Switch", () => {
               ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
             }
           )
-          let observedEstablishFlow = establishFlowEvents.contents->Array.map(event =>
+          let observedEstablishFlow = establishFlowEvents(observedConnections)->Array.map(event =>
             switch event {
             | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
               (
@@ -1334,6 +1345,16 @@ describe("Connection__Switch", () => {
               ("ConnectionEstablishFailed", "", "")
             | unexpected =>
               ("Unexpected", Log.Connection.EstablishFlow.toString(unexpected), "")
+            }
+          )
+          let observedSwitchUIFlow = switchUIFlowEvents(observedConnections)->Array.map(event =>
+            switch event {
+            | Log.Connection.SwitchUIFlow.SwitchRequested(path) =>
+              ("SwitchRequested", path)
+            | Log.Connection.SwitchUIFlow.SwitchSucceeded(path) =>
+              ("SwitchSucceeded", path)
+            | Log.Connection.SwitchUIFlow.SwitchFailed(path) =>
+              ("SwitchFailed", path)
             }
           )
 
@@ -1348,6 +1369,10 @@ describe("Connection__Switch", () => {
             Assert.deepStrictEqual(observedEstablishFlow, [
               ("CandidateAttempted", missingPath, "from config"),
               ("ConnectionEstablishFailed", "", ""),
+            ])
+            Assert.deepStrictEqual(observedSwitchUIFlow, [
+              ("SwitchRequested", missingPath),
+              ("SwitchFailed", missingPath),
             ])
             switch Registry__Connection.status.contents {
             | Active(resource) =>
@@ -1376,12 +1401,11 @@ describe("Connection__Switch", () => {
           let mockAgdaUri = VSCode.Uri.file(mockAgda.contents)
           let mockAgdaUriString = VSCode.Uri.toString(mockAgdaUri)
           let mockAgdaFsPath = VSCode.Uri.fsPath(mockAgdaUri)
-          let probeFlowEvents = observeProbeFlow(state)
-          let establishFlowEvents = observeEstablishFlow(state)
+          let observedConnections = observeConnectionEvents(state)
 
           await Connection.switchCandidate(state, "agda")
 
-          let observedProbeFlow = probeFlowEvents.contents->Array.map(event =>
+          let observedProbeFlow = probeFlowEvents(observedConnections)->Array.map(event =>
             switch event {
             | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
               ("CandidateResolveStarted", Connection__Candidate.toString(candidate), "", "")
@@ -1395,7 +1419,7 @@ describe("Connection__Switch", () => {
               ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
             }
           )
-          let observedEstablishFlow = establishFlowEvents.contents->Array.map(event =>
+          let observedEstablishFlow = establishFlowEvents(observedConnections)->Array.map(event =>
             switch event {
             | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
               (
@@ -1419,6 +1443,16 @@ describe("Connection__Switch", () => {
               ("Unexpected", Log.Connection.EstablishFlow.toString(unexpected), "", "")
             }
           )
+          let observedSwitchUIFlow = switchUIFlowEvents(observedConnections)->Array.map(event =>
+            switch event {
+            | Log.Connection.SwitchUIFlow.SwitchRequested(path) =>
+              ("SwitchRequested", path)
+            | Log.Connection.SwitchUIFlow.SwitchSucceeded(path) =>
+              ("SwitchSucceeded", path)
+            | Log.Connection.SwitchUIFlow.SwitchFailed(path) =>
+              ("SwitchFailed", path)
+            }
+          )
 
           Assert.deepStrictEqual(observedProbeFlow, [
             ("CandidateResolveStarted", "agda", "", ""),
@@ -1429,6 +1463,27 @@ describe("Connection__Switch", () => {
           Assert.deepStrictEqual(observedEstablishFlow, [
             ("CandidateAttempted", "agda", "from config", ""),
             ("ConnectionEstablished", mockAgdaFsPath, "Agda", ""),
+          ])
+          Assert.deepStrictEqual(observedSwitchUIFlow, [
+            ("SwitchRequested", "agda"),
+            ("SwitchSucceeded", mockAgdaFsPath),
+          ])
+
+          let orderedKeys = observedConnections.contents->Array.filterMap(event =>
+            switch event {
+            | Log.Connection.EstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablished(path, _)) =>
+              Some("ConnectionEstablished:" ++ path)
+            | Log.Connection.SwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchSucceeded(path)) =>
+              Some("SwitchSucceeded:" ++ path)
+            | Log.Connection.Disconnected(path) =>
+              Some("Disconnected:" ++ path)
+            | _ => None
+            }
+          )
+          Assert.deepStrictEqual(orderedKeys, [
+            "ConnectionEstablished:" ++ mockAgdaFsPath,
+            "SwitchSucceeded:" ++ mockAgdaFsPath,
+            "Disconnected:" ++ mockAgdaFsPath,
           ])
 
           module PlatformOps = unpack(platform)

--- a/test/tests/Connection/Test__Connection__Switch.res
+++ b/test/tests/Connection/Test__Connection__Switch.res
@@ -1428,9 +1428,9 @@ describe("Connection__Switch", () => {
                 Connection.Error.Establish.pathSourceToString(source),
                 "",
               )
-            | Log.Connection.EstablishFlow.ConnectionEstablished(path, kind) =>
+            | Log.Connection.EstablishFlow.ConnectionCreated(path, kind) =>
               (
-                "ConnectionEstablished",
+                "ConnectionCreated",
                 path,
                 switch kind {
                 | Log.Connection.EstablishFlow.Agda => "Agda"
@@ -1462,7 +1462,7 @@ describe("Connection__Switch", () => {
           ])
           Assert.deepStrictEqual(observedEstablishFlow, [
             ("CandidateAttempted", "agda", "from config", ""),
-            ("ConnectionEstablished", mockAgdaFsPath, "Agda", ""),
+            ("ConnectionCreated", mockAgdaFsPath, "Agda", ""),
           ])
           Assert.deepStrictEqual(observedSwitchUIFlow, [
             ("SwitchRequested", "agda"),
@@ -1471,8 +1471,8 @@ describe("Connection__Switch", () => {
 
           let orderedKeys = observedConnections.contents->Array.filterMap(event =>
             switch event {
-            | Log.Connection.EstablishFlow(Log.Connection.EstablishFlow.ConnectionEstablished(path, _)) =>
-              Some("ConnectionEstablished:" ++ path)
+            | Log.Connection.EstablishFlow(Log.Connection.EstablishFlow.ConnectionCreated(path, _)) =>
+              Some("ConnectionCreated:" ++ path)
             | Log.Connection.SwitchUIFlow(Log.Connection.SwitchUIFlow.SwitchSucceeded(path)) =>
               Some("SwitchSucceeded:" ++ path)
             | Log.Connection.Disconnected(path) =>
@@ -1481,7 +1481,7 @@ describe("Connection__Switch", () => {
             }
           )
           Assert.deepStrictEqual(orderedKeys, [
-            "ConnectionEstablished:" ++ mockAgdaFsPath,
+            "ConnectionCreated:" ++ mockAgdaFsPath,
             "SwitchSucceeded:" ++ mockAgdaFsPath,
             "Disconnected:" ++ mockAgdaFsPath,
           ])
@@ -1500,6 +1500,88 @@ describe("Connection__Switch", () => {
             Memento.ResolvedMetadata.get(state.memento, resolved)->Option.map(entry => entry.kind),
             Some(Memento.ResolvedMetadata.Agda(Some("2.7.0.1"))),
           )
+        },
+      )
+
+      Async.it(
+        "should emit ConnectionFinalizeFailed when post-establish finalization throws",
+        async () => {
+          let platform = makeMockPlatformWithBareCommands()
+          let state = createTestStateWithPlatform(platform)
+          let mockAgdaUri = VSCode.Uri.file(mockAgda.contents)
+          let mockAgdaFsPath = VSCode.Uri.fsPath(mockAgdaUri)
+          let observedConnections = observeConnectionEvents(state)
+
+          // Inject a failing setKind to trigger the post-establish catch block
+          let restoreSetKind: unit => unit = %raw(`
+            (() => {
+              const original = Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind;
+              Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind = () => Promise.reject(new Error("finalize injection"));
+              return () => { Memento$AgdaModeVscode.Module.ResolvedMetadata.setKind = original; };
+            })()
+          `)
+
+          let completion =
+            Connection.switchCandidate(state, "agda")
+            ->Promise.catch(_ => Promise.resolve())
+            ->Promise.thenResolve(_ => "done")
+          let timeout = Util.Promise_.setTimeout(1000)->Promise.thenResolve(_ => "timeout")
+          let winner = await Promise.race([completion, timeout])
+
+          try {
+            let observedEstablishFlow = establishFlowEvents(observedConnections)->Array.map(event =>
+              switch event {
+              | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
+                (
+                  "CandidateAttempted",
+                  pathOrCommand,
+                  Connection.Error.Establish.pathSourceToString(source),
+                  "",
+                )
+              | Log.Connection.EstablishFlow.ConnectionFinalizeFailed(path, kind) =>
+                (
+                  "ConnectionFinalizeFailed",
+                  path,
+                  switch kind {
+                  | Log.Connection.EstablishFlow.Agda => "Agda"
+                  | Log.Connection.EstablishFlow.ALS => "ALS"
+                  | Log.Connection.EstablishFlow.ALSWASM => "ALSWASM"
+                  },
+                  "",
+                )
+              | unexpected =>
+                ("Unexpected", Log.Connection.EstablishFlow.toString(unexpected), "", "")
+              }
+            )
+            let observedSwitchUIFlow = switchUIFlowEvents(observedConnections)->Array.map(event =>
+              switch event {
+              | Log.Connection.SwitchUIFlow.SwitchRequested(path) => ("SwitchRequested", path)
+              | Log.Connection.SwitchUIFlow.SwitchSucceeded(path) => ("SwitchSucceeded", path)
+              | Log.Connection.SwitchUIFlow.SwitchFailed(path) => ("SwitchFailed", path)
+              }
+            )
+
+            switch winner {
+            | "done" =>
+              Assert.deepStrictEqual(observedEstablishFlow, [
+                ("CandidateAttempted", "agda", "from config", ""),
+                ("ConnectionFinalizeFailed", mockAgdaFsPath, "Agda", ""),
+              ])
+              Assert.deepStrictEqual(observedSwitchUIFlow, [
+                ("SwitchRequested", "agda"),
+                ("SwitchFailed", "agda"),
+              ])
+            | "timeout" =>
+              Registry__Connection.status := Empty
+              Assert.fail("switchAgdaVersion hung during post-establish failure")
+            | _ => Assert.fail("Unexpected race result")
+            }
+            restoreSetKind()
+          } catch {
+          | exn =>
+            restoreSetKind()
+            raise(exn)
+          }
         },
       )
 

--- a/test/tests/Connection/Test__Connection__Switch.res
+++ b/test/tests/Connection/Test__Connection__Switch.res
@@ -1269,6 +1269,18 @@ describe("Connection__Switch", () => {
         events
       }
 
+      let observeEstablishFlow = (state: State.t) => {
+        let events: ref<array<Log.Connection.EstablishFlow.t>> = ref([])
+        let _ = state.channels.log->Chan.on(logEvent =>
+          switch logEvent {
+          | Log.Connection(Log.Connection.EstablishFlow(event)) =>
+            events.contents = Array.concat(events.contents, [event])
+          | _ => ()
+          }
+        )
+        events
+      }
+
       Async.it(
         "should keep existing shared connection when switch target cannot be established",
         async () => {
@@ -1289,6 +1301,7 @@ describe("Connection__Switch", () => {
           let missingPathKey = VSCode.Uri.fsPath(missingUri)
           let missingUriString = VSCode.Uri.toString(missingUri)
           let probeFlowEvents = observeProbeFlow(state)
+          let establishFlowEvents = observeEstablishFlow(state)
 
           let completion =
             Connection.switchCandidate(state, missingPath)->Promise.thenResolve(_ => "done")
@@ -1309,6 +1322,20 @@ describe("Connection__Switch", () => {
               ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
             }
           )
+          let observedEstablishFlow = establishFlowEvents.contents->Array.map(event =>
+            switch event {
+            | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
+              (
+                "CandidateAttempted",
+                pathOrCommand,
+                Connection.Error.Establish.pathSourceToString(source),
+              )
+            | Log.Connection.EstablishFlow.ConnectionEstablishFailed =>
+              ("ConnectionEstablishFailed", "", "")
+            | unexpected =>
+              ("Unexpected", Log.Connection.EstablishFlow.toString(unexpected), "")
+            }
+          )
 
           switch winner {
           | "done" =>
@@ -1317,6 +1344,10 @@ describe("Connection__Switch", () => {
               ("CandidateResolved", missingUriString, missingUriString, ""),
               ("ProbeStarted", missingUriString, "", ""),
               ("ProbeFailed", missingPathKey, "", ""),
+            ])
+            Assert.deepStrictEqual(observedEstablishFlow, [
+              ("CandidateAttempted", missingPath, "from config"),
+              ("ConnectionEstablishFailed", "", ""),
             ])
             switch Registry__Connection.status.contents {
             | Active(resource) =>
@@ -1346,6 +1377,7 @@ describe("Connection__Switch", () => {
           let mockAgdaUriString = VSCode.Uri.toString(mockAgdaUri)
           let mockAgdaFsPath = VSCode.Uri.fsPath(mockAgdaUri)
           let probeFlowEvents = observeProbeFlow(state)
+          let establishFlowEvents = observeEstablishFlow(state)
 
           await Connection.switchCandidate(state, "agda")
 
@@ -1363,12 +1395,40 @@ describe("Connection__Switch", () => {
               ("Unexpected", Log.Connection.ProbeFlow.toString(unexpected), "", "")
             }
           )
+          let observedEstablishFlow = establishFlowEvents.contents->Array.map(event =>
+            switch event {
+            | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
+              (
+                "CandidateAttempted",
+                pathOrCommand,
+                Connection.Error.Establish.pathSourceToString(source),
+                "",
+              )
+            | Log.Connection.EstablishFlow.ConnectionEstablished(path, kind) =>
+              (
+                "ConnectionEstablished",
+                path,
+                switch kind {
+                | Log.Connection.EstablishFlow.Agda => "Agda"
+                | Log.Connection.EstablishFlow.ALS => "ALS"
+                | Log.Connection.EstablishFlow.ALSWASM => "ALSWASM"
+                },
+                "",
+              )
+            | unexpected =>
+              ("Unexpected", Log.Connection.EstablishFlow.toString(unexpected), "", "")
+            }
+          )
 
           Assert.deepStrictEqual(observedProbeFlow, [
             ("CandidateResolveStarted", "agda", "", ""),
             ("CandidateResolved", "agda", mockAgdaUriString, ""),
             ("ProbeStarted", mockAgdaUriString, "", ""),
             ("ProbeClassifiedAsAgda", mockAgdaFsPath, "2.7.0.1", ""),
+          ])
+          Assert.deepStrictEqual(observedEstablishFlow, [
+            ("CandidateAttempted", "agda", "from config", ""),
+            ("ConnectionEstablished", mockAgdaFsPath, "Agda", ""),
           ])
 
           module PlatformOps = unpack(platform)

--- a/test/tests/Connection/Test__Connection__UI.res
+++ b/test/tests/Connection/Test__Connection__UI.res
@@ -911,6 +911,17 @@ describe("Connection UI", () => {
       },
     )
 
+    let observeDownloadFlow = (state: State.t): array<Log.Connection.DownloadFlow.t> => {
+      let events: array<Log.Connection.DownloadFlow.t> = []
+      let _ = state.channels.log->Chan.on(log =>
+        switch log {
+        | Log.Connection(Log.Connection.DownloadFlow(event)) => events->Array.push(event)
+        | _ => ()
+        }
+      )
+      events
+    }
+
     Async.it(
       "handleDownload downloaded=true WASM on desktop should add managed WASM path to config",
       async () =>
@@ -925,13 +936,14 @@ describe("Connection UI", () => {
 
           let platform: Platform.t = module(Mock.Platform.Basic)
           let state = createTestStateWithPlatformAndStorage(platform, globalStorageUri)
+          let versionString = "Agda v2.8.0 Language Server (dev build)"
 
           await Connection__UI__Handlers.handleDownload(
             state,
             platform,
             Connection__Download__DownloadArtifact.Platform.Wasm,
             true,
-            "Agda v2.8.0 Language Server (dev build)",
+            versionString,
             ~channel=Connection__Download__Channel.DevALS,
             ~refreshUI=None,
           )
@@ -1005,16 +1017,15 @@ describe("Connection UI", () => {
             let determinePlatform = async () => Ok(Connection__Download__Platform.MacOS_Arm)
             let askUserAboutDownloadPolicy = async () => Config.Connection.DownloadPolicy.Yes
             let alreadyDownloaded = _globalStorageUri => Promise.resolve(None)
+            let urlSource = Connection__Download__Source.FromURL(
+              Connection__Download__Channel.DevALS,
+              "https://example.invalid/dev-als.wasm",
+              "dev-als",
+            )
             let resolveDownloadChannel = Mock.DownloadDescriptor.mockWith(channel =>
               switch channel {
               | Connection__Download__Channel.DevALS =>
-                Ok(
-                  Connection__Download__Source.FromURL(
-                    Connection__Download__Channel.DevALS,
-                    "https://example.invalid/dev-als.wasm",
-                    "dev-als",
-                  ),
-                )
+                Ok(urlSource)
               | _ => Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
               }
             )
@@ -1040,15 +1051,43 @@ describe("Connection UI", () => {
           ~getDownloadItems=_channel => Promise.resolve([]),
         )
 
+        let events = observeDownloadFlow(state)
+        let requestedVersionString = "ALS vTest"
+        let resolvedSourceVersion = Connection__Download__Source.toVersionString(
+          Connection__Download__Source.FromURL(
+            Connection__Download__Channel.DevALS,
+            "https://example.invalid/dev-als.wasm",
+            "dev-als",
+          ),
+        )
+
         await Connection__UI__Handlers.handleDownload(
           state,
           platform,
           Connection__Download__DownloadArtifact.Platform.Wasm,
           false,
-          "ALS vTest",
+          requestedVersionString,
           ~channel=Connection__Download__Channel.DevALS,
         )
 
+        Assert.deepStrictEqual(events, [
+          Log.Connection.DownloadFlow.SelectionRequested(
+            Connection__Download__Channel.DevALS,
+            Connection__Download__DownloadArtifact.Platform.Wasm,
+            requestedVersionString,
+            false,
+          ),
+          Log.Connection.DownloadFlow.SourceResolved(
+            Log.Connection.DownloadFlow.URL,
+            resolvedSourceVersion,
+          ),
+          Log.Connection.DownloadFlow.DownloadStarted(
+            Connection__Download__Channel.DevALS,
+            Connection__Download__DownloadArtifact.Platform.Wasm,
+            requestedVersionString,
+          ),
+          Log.Connection.DownloadFlow.DownloadSucceeded(downloadedPath),
+        ])
         Assert.deepStrictEqual(downloadedChannel.contents, Some(Connection__Download__Channel.DevALS))
       },
     )
@@ -1102,13 +1141,7 @@ describe("Connection UI", () => {
           let downloadedPath = "/tmp/flow-obs-wasm/als.wasm"
           let platform = Mock.Platform.makeWithSuccessfulDownload(downloadedPath)
           let state = createTestStateWithPlatform(platform)
-          let events: array<Log.Connection.DownloadFlow.t> = []
-          let _ = state.channels.log->Chan.on(log =>
-            switch log {
-            | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
-            | _ => ()
-            }
-          )
+          let events = observeDownloadFlow(state)
 
           await Connection__UI__Handlers.handleDownload(
             state,
@@ -1157,13 +1190,7 @@ describe("Connection UI", () => {
 
             let platform = Mock.Platform.makeBasic()
             let state = createTestStateWithPlatformAndStorage(platform, storageUri)
-            let events: array<Log.Connection.DownloadFlow.t> = []
-            let _ = state.channels.log->Chan.on(log =>
-              switch log {
-              | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
-              | _ => ()
-              }
-            )
+            let events = observeDownloadFlow(state)
 
             await Connection__UI__Handlers.handleDownload(
               state,
@@ -1198,13 +1225,7 @@ describe("Connection UI", () => {
           await withTempStorage("flow-managed-miss-", async (_tempDir, storageUri) => {
             let platform = Mock.Platform.makeBasic()
             let state = createTestStateWithPlatformAndStorage(platform, storageUri)
-            let events: array<Log.Connection.DownloadFlow.t> = []
-            let _ = state.channels.log->Chan.on(log =>
-              switch log {
-              | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
-              | _ => ()
-              }
-            )
+            let events = observeDownloadFlow(state)
 
             await Connection__UI__Handlers.handleDownload(
               state,
@@ -1233,7 +1254,7 @@ describe("Connection UI", () => {
       )
 
       Async.it(
-        "handleDownload downloaded=false should emit SelectionRequested, SourceResolved, DownloadStarted, DownloadFailed on download error",
+        "handleDownload downloaded=false should emit download-requested -> source-resolved -> download-started -> download-failed on download error",
         async () => {
           let cannotFindMsg = Connection__Download__Error.toString(
             Connection__Download__Error.CannotFindCompatibleALSRelease,
@@ -1264,13 +1285,7 @@ describe("Connection UI", () => {
           }
           let platform: Platform.t = module(MockFailPlatform)
           let state = createTestStateWithPlatform(platform)
-          let events: array<Log.Connection.DownloadFlow.t> = []
-          let _ = state.channels.log->Chan.on(log =>
-            switch log {
-            | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
-            | _ => ()
-            }
-          )
+          let events = observeDownloadFlow(state)
 
           await Connection__UI__Handlers.handleDownload(
             state,
@@ -1282,24 +1297,22 @@ describe("Connection UI", () => {
             ~refreshUI=None,
           )
 
-          Assert.deepStrictEqual(
-            events,
-            [
-              Log.Connection.DownloadFlow.SelectionRequested(
-                Connection__Download__Channel.DevALS,
-                Connection__Download__DownloadArtifact.Platform.Wasm,
-                versionString,
-                false,
-              ),
-              Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.GitHub, versionString),
-              Log.Connection.DownloadFlow.DownloadStarted(
-                Connection__Download__Channel.DevALS,
-                Connection__Download__DownloadArtifact.Platform.Wasm,
-                versionString,
-              ),
-              Log.Connection.DownloadFlow.DownloadFailed(cannotFindMsg),
-            ],
-          )
+          let expectedFlowEvents = [
+            Log.Connection.DownloadFlow.SelectionRequested(
+              Connection__Download__Channel.DevALS,
+              Connection__Download__DownloadArtifact.Platform.Wasm,
+              versionString,
+              false,
+            ),
+            Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.GitHub, versionString),
+            Log.Connection.DownloadFlow.DownloadStarted(
+              Connection__Download__Channel.DevALS,
+              Connection__Download__DownloadArtifact.Platform.Wasm,
+              versionString,
+            ),
+            Log.Connection.DownloadFlow.DownloadFailed(cannotFindMsg),
+          ]
+          Assert.deepStrictEqual(events, expectedFlowEvents)
         },
       )
     })

--- a/test/tests/Connection/Test__Connection__UI.res
+++ b/test/tests/Connection/Test__Connection__UI.res
@@ -99,49 +99,73 @@ describe("Connection UI", () => {
     Async.it(
       "candidate rows should route selection through the candidate seam",
       async () => {
-        let state = createTestState()
-        let view = Connection__UI__Picker.make(state.channels.log)
-        let selectedChannel = ref(Connection__Download__Channel.DevALS)
-        let switchCalled = ref(None)
-        let sawDestroyed = ref(false)
-        let sawSelectionCompleted = ref(false)
-        let entry: Memento.ResolvedMetadata.entry = {
-          kind: Memento.ResolvedMetadata.Agda(Some("2.7.0.1")),
-          timestamp: Date.make(),
-          error: None,
-        }
-        let _ = state.channels.log->Chan.on(logEvent =>
-          switch logEvent {
-          | Log.SwitchVersionUI(Log.SwitchVersion.Destroyed) => sawDestroyed := true
-          | Log.SwitchVersionUI(Log.SwitchVersion.SelectionCompleted) =>
-            sawSelectionCompleted := true
-          | _ => ()
+        let mockAgda =
+          await Test__Util.Candidate.Agda.mock(~version="2.7.0.1", ~name="agda-ui-switch-flow")
+        try {
+          let state = createTestState()
+          let view = Connection__UI__Picker.make(state.channels.log)
+          let selectedChannel = ref(Connection__Download__Channel.DevALS)
+          let sawDestroyed = ref(false)
+          let sawSelectionCompleted = ref(false)
+          let switchUIFlowEvents: array<Log.Connection.SwitchUIFlow.t> = []
+          let entry: Memento.ResolvedMetadata.entry = {
+            kind: Memento.ResolvedMetadata.Agda(Some("2.7.0.1")),
+            timestamp: Date.make(),
+            error: None,
           }
-        )
+          let _ = state.channels.log->Chan.on(logEvent =>
+            switch logEvent {
+            | Log.SwitchVersionUI(Log.SwitchVersion.Destroyed) => sawDestroyed := true
+            | Log.SwitchVersionUI(Log.SwitchVersion.SelectionCompleted) =>
+              sawSelectionCompleted := true
+            | Log.Connection(Log.Connection.SwitchUIFlow(event)) =>
+              switchUIFlowEvents->Array.push(event)
+            | _ => ()
+            }
+          )
 
-        let selectedItem =
-          makePickerItem(state, Candidate("/tmp/agda", "/tmp/agda", entry, false))
+          let onSelectionCompleted = Log.on(
+            state.channels.log,
+            log =>
+              switch log {
+              | Log.SwitchVersionUI(SelectionCompleted) => true
+              | _ => false
+              },
+          )
 
-        Connection__UI__Handlers.onSelection(
-          state,
-          makeMockPlatform(),
-          selectedChannel,
-          _downloadItems => Promise.resolve(),
-          view,
-          [selectedItem],
-          ~hasSelectionChanged=_ => true,
-          ~switchCandidate=path => {
-            switchCalled := Some(path)
-            Promise.resolve()
-          },
-          ~getDownloadItems=_channel => Promise.resolve([]),
-        )
+          let selectedItem =
+            makePickerItem(state, Candidate(mockAgda, mockAgda, entry, false))
 
-        await Test__Util.wait(200)
+          Connection__UI__Handlers.onSelection(
+            state,
+            makeMockPlatform(),
+            selectedChannel,
+            _downloadItems => Promise.resolve(),
+            view,
+            [selectedItem],
+            ~hasSelectionChanged=_ => true,
+            ~switchCandidate=path => Connection.switchCandidate(state, path),
+            ~getDownloadItems=_channel => Promise.resolve([]),
+          )
 
-        Assert.deepStrictEqual(switchCalled.contents, Some("/tmp/agda"))
-        Assert.deepStrictEqual(sawDestroyed.contents, true)
-        Assert.deepStrictEqual(sawSelectionCompleted.contents, true)
+          await onSelectionCompleted
+
+          Assert.deepStrictEqual(
+            switchUIFlowEvents,
+            [
+              Log.Connection.SwitchUIFlow.SwitchRequested(mockAgda),
+              Log.Connection.SwitchUIFlow.SwitchSucceeded(mockAgda),
+            ],
+          )
+          Assert.deepStrictEqual(Memento.PreferredCandidate.get(state.memento), Some(mockAgda))
+          Assert.deepStrictEqual(sawDestroyed.contents, true)
+          Assert.deepStrictEqual(sawSelectionCompleted.contents, true)
+        } catch {
+        | exn =>
+          await Test__Util.Candidate.Agda.destroy(mockAgda)
+          raise(exn)
+        }
+        await Test__Util.Candidate.Agda.destroy(mockAgda)
       },
     )
 

--- a/test/tests/Connection/Test__Connection__UI.res
+++ b/test/tests/Connection/Test__Connection__UI.res
@@ -1208,7 +1208,7 @@ describe("Connection UI", () => {
               "dev",
               "als-dev-Agda-2.8.0-wasm",
             ])
-            let wasmFile = NodeJs.Path.join([artifactDir, "als.wasm"])
+            let wasmFile = NodeJs.Path.join([artifactDir, "als.wasm"])->VSCode.Uri.file->VSCode.Uri.fsPath
             await NodeJs.Fs.mkdir(artifactDir, {recursive: true, mode: 0o777})
             NodeJs.Fs.writeFileSync(wasmFile, NodeJs.Buffer.fromString("mock wasm"))
 

--- a/test/tests/Connection/Test__Connection__UI.res
+++ b/test/tests/Connection/Test__Connection__UI.res
@@ -1092,6 +1092,217 @@ describe("Connection UI", () => {
         Assert.deepStrictEqual(hasSelectOtherChannels, true)
       },
     )
+
+    describe("DownloadFlow observability", () => {
+      let versionString = "Agda v2.8.0 Language Server (dev build)"
+
+      Async.it(
+        "handleDownload downloaded=false should emit SelectionRequested, SourceResolved, DownloadStarted, DownloadSucceeded",
+        async () => {
+          let downloadedPath = "/tmp/flow-obs-wasm/als.wasm"
+          let platform = Mock.Platform.makeWithSuccessfulDownload(downloadedPath)
+          let state = createTestStateWithPlatform(platform)
+          let events: array<Log.Connection.DownloadFlow.t> = []
+          let _ = state.channels.log->Chan.on(log =>
+            switch log {
+            | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
+            | _ => ()
+            }
+          )
+
+          await Connection__UI__Handlers.handleDownload(
+            state,
+            platform,
+            Connection__Download__DownloadArtifact.Platform.Wasm,
+            false,
+            versionString,
+            ~channel=Connection__Download__Channel.DevALS,
+            ~refreshUI=None,
+          )
+
+          Assert.deepStrictEqual(
+            events,
+            [
+              Log.Connection.DownloadFlow.SelectionRequested(
+                Connection__Download__Channel.DevALS,
+                Connection__Download__DownloadArtifact.Platform.Wasm,
+                versionString,
+                false,
+              ),
+              Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.GitHub, versionString),
+              Log.Connection.DownloadFlow.DownloadStarted(
+                Connection__Download__Channel.DevALS,
+                Connection__Download__DownloadArtifact.Platform.Wasm,
+                versionString,
+              ),
+              Log.Connection.DownloadFlow.DownloadSucceeded(downloadedPath),
+            ],
+          )
+        },
+      )
+
+      Async.it(
+        "handleDownload downloaded=true should emit SelectionRequested, ManagedHit, ReusedExistingArtifact when artifact found",
+        async () => {
+          await withTempStorage("flow-managed-hit-", async (tempDir, storageUri) => {
+            let artifactDir = NodeJs.Path.join([
+              tempDir,
+              "releases",
+              "dev",
+              "als-dev-Agda-2.8.0-wasm",
+            ])
+            let wasmFile = NodeJs.Path.join([artifactDir, "als.wasm"])
+            await NodeJs.Fs.mkdir(artifactDir, {recursive: true, mode: 0o777})
+            NodeJs.Fs.writeFileSync(wasmFile, NodeJs.Buffer.fromString("mock wasm"))
+
+            let platform = Mock.Platform.makeBasic()
+            let state = createTestStateWithPlatformAndStorage(platform, storageUri)
+            let events: array<Log.Connection.DownloadFlow.t> = []
+            let _ = state.channels.log->Chan.on(log =>
+              switch log {
+              | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
+              | _ => ()
+              }
+            )
+
+            await Connection__UI__Handlers.handleDownload(
+              state,
+              platform,
+              Connection__Download__DownloadArtifact.Platform.Wasm,
+              true,
+              versionString,
+              ~channel=Connection__Download__Channel.DevALS,
+              ~refreshUI=None,
+            )
+
+            Assert.deepStrictEqual(
+              events,
+              [
+                Log.Connection.DownloadFlow.SelectionRequested(
+                  Connection__Download__Channel.DevALS,
+                  Connection__Download__DownloadArtifact.Platform.Wasm,
+                  versionString,
+                  true,
+                ),
+                Log.Connection.DownloadFlow.ManagedHit(versionString, wasmFile),
+                Log.Connection.DownloadFlow.ReusedExistingArtifact(wasmFile),
+              ],
+            )
+          })
+        },
+      )
+
+      Async.it(
+        "handleDownload downloaded=true should emit SelectionRequested, ManagedMiss when artifact not found",
+        async () => {
+          await withTempStorage("flow-managed-miss-", async (_tempDir, storageUri) => {
+            let platform = Mock.Platform.makeBasic()
+            let state = createTestStateWithPlatformAndStorage(platform, storageUri)
+            let events: array<Log.Connection.DownloadFlow.t> = []
+            let _ = state.channels.log->Chan.on(log =>
+              switch log {
+              | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
+              | _ => ()
+              }
+            )
+
+            await Connection__UI__Handlers.handleDownload(
+              state,
+              platform,
+              Connection__Download__DownloadArtifact.Platform.Wasm,
+              true,
+              versionString,
+              ~channel=Connection__Download__Channel.DevALS,
+              ~refreshUI=None,
+            )
+
+            Assert.deepStrictEqual(
+              events,
+              [
+                Log.Connection.DownloadFlow.SelectionRequested(
+                  Connection__Download__Channel.DevALS,
+                  Connection__Download__DownloadArtifact.Platform.Wasm,
+                  versionString,
+                  true,
+                ),
+                Log.Connection.DownloadFlow.ManagedMiss(versionString),
+              ],
+            )
+          })
+        },
+      )
+
+      Async.it(
+        "handleDownload downloaded=false should emit SelectionRequested, SourceResolved, DownloadStarted, DownloadFailed on download error",
+        async () => {
+          let cannotFindMsg = Connection__Download__Error.toString(
+            Connection__Download__Error.CannotFindCompatibleALSRelease,
+          )
+          module MockFailPlatform = {
+            let determinePlatform = async () => Ok(Connection__Download__Platform.MacOS_Arm)
+            let askUserAboutDownloadPolicy = async () => Config.Connection.DownloadPolicy.Yes
+            let alreadyDownloaded = _globalStorageUri => Promise.resolve(None)
+            let resolveDownloadChannel = Mock.DownloadDescriptor.mockWith(channel =>
+              switch channel {
+              | Connection__Download__Channel.DevALS =>
+                Ok(
+                  Connection__Download__Source.FromGitHub(
+                    channel,
+                    Mock.DownloadDescriptor.mockDevALSDescriptor,
+                  ),
+                )
+              | _ => Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
+              }
+            )
+            let download = (
+              _globalStorageUri,
+              _source,
+              ~trace as _=Connection__Download__Trace.noop,
+            ) => Promise.resolve(Error(Connection__Download__Error.CannotFindCompatibleALSRelease))
+            let findCommand = (_command, ~timeout as _timeout=1000) =>
+              Promise.resolve(Error(Connection__Command.Error.NotFound))
+          }
+          let platform: Platform.t = module(MockFailPlatform)
+          let state = createTestStateWithPlatform(platform)
+          let events: array<Log.Connection.DownloadFlow.t> = []
+          let _ = state.channels.log->Chan.on(log =>
+            switch log {
+            | Log.Connection(Log.Connection.DownloadFlow(e)) => events->Array.push(e)
+            | _ => ()
+            }
+          )
+
+          await Connection__UI__Handlers.handleDownload(
+            state,
+            platform,
+            Connection__Download__DownloadArtifact.Platform.Wasm,
+            false,
+            versionString,
+            ~channel=Connection__Download__Channel.DevALS,
+            ~refreshUI=None,
+          )
+
+          Assert.deepStrictEqual(
+            events,
+            [
+              Log.Connection.DownloadFlow.SelectionRequested(
+                Connection__Download__Channel.DevALS,
+                Connection__Download__DownloadArtifact.Platform.Wasm,
+                versionString,
+                false,
+              ),
+              Log.Connection.DownloadFlow.SourceResolved(Log.Connection.DownloadFlow.GitHub, versionString),
+              Log.Connection.DownloadFlow.DownloadStarted(
+                Connection__Download__Channel.DevALS,
+                Connection__Download__DownloadArtifact.Platform.Wasm,
+                versionString,
+              ),
+              Log.Connection.DownloadFlow.DownloadFailed(cannotFindMsg),
+            ],
+          )
+        },
+      )
+    })
   })
 
   describe("Background update", () => {

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -97,6 +97,31 @@ let probeFlowSnapshot = event =>
     "ProbeFailed:" ++ pathKey ++ ":" ++ Connection__Error.Probe.toString(probeError)
   }
 
+let establishFlowSnapshot = event =>
+  switch event {
+  | Log.Connection.EstablishFlow.ConfigCandidatesStarted(count) =>
+    "ConfigCandidatesStarted:" ++ string_of_int(count)
+  | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
+    "CandidateAttempted:" ++ pathOrCommand ++ ":" ++ Connection.Error.Establish.pathSourceToString(source)
+  | Log.Connection.EstablishFlow.ConfigCandidatesFailed => "ConfigCandidatesFailed"
+  | Log.Connection.EstablishFlow.DownloadFallbackStarted(channel, platform) =>
+    "DownloadFallbackStarted:"
+    ++ Connection__Download__Channel.toString(channel)
+    ++ ":"
+    ++ Connection__Download__DownloadArtifact.Platform.toAssetTag(platform)
+  | Log.Connection.EstablishFlow.DownloadFallbackFailed(_error) => "DownloadFallbackFailed"
+  | Log.Connection.EstablishFlow.ConnectionEstablished(path, kind) =>
+    "ConnectionEstablished:"
+    ++ path
+    ++ ":"
+    ++ switch kind {
+       | Log.Connection.EstablishFlow.Agda => "Agda"
+       | Log.Connection.EstablishFlow.ALS => "ALS"
+       | Log.Connection.EstablishFlow.ALSWASM => "ALSWASM"
+       }
+  | Log.Connection.EstablishFlow.ConnectionEstablishFailed => "ConnectionEstablishFailed"
+  }
+
 let getAgdaTarget = async () => {
   let platformDeps = Desktop.make()
   switch await Connection.fromPathsOrCommands(
@@ -1018,16 +1043,9 @@ describe("Connection", () => {
          * 1. Setup a mock Agda executable
          * 2. Create Connection.makeWithFallback with log channel
          * 3. Verify ConnectedToAgda event is logged with correct path and version
-         */
-        let loggedEvents = []
+        */
         let logChannel = Chan.make()
-
-        // Subscribe to log channel to capture all log events
-        let _ = logChannel->Chan.on(
-          logEvent => {
-            loggedEvents->Array.push(logEvent)
-          },
-        )
+        let listener = Log.collect(logChannel)
 
         // Setup mock Agda using Test__Util
         let agdaMockPath = await Test__Util.Candidate.Agda.mock(
@@ -1050,6 +1068,7 @@ describe("Connection", () => {
           logChannel,
         ) {
         | Ok(connection) =>
+          let loggedEvents = listener(~filter=Log.isConnection)
           // VERIFY: ConnectedToAgda event was logged with exact details
           Assert.deepStrictEqual(
             loggedEvents,
@@ -1158,15 +1177,8 @@ describe("Connection", () => {
          * 2. Verify no ConnectedTo* events are logged
          * 3. Verify Connection.makeWithFallback returns Error
          */
-        let loggedEvents = []
         let logChannel = Chan.make()
-
-        // Subscribe to log channel to capture all log events
-        let _ = logChannel->Chan.on(
-          logEvent => {
-            loggedEvents->Array.push(logEvent)
-          },
-        )
+        let listener = Log.collect(logChannel)
 
         // Create minimal memento and platformDeps (using mock to avoid dialogs)
         let memento = Memento.make(None)
@@ -1184,7 +1196,8 @@ describe("Connection", () => {
         ) {
         | Ok(_) => Assert.fail("Expected connection to fail")
         | Error(_) =>
-          // VERIFY: No connection events were logged
+          let loggedEvents = listener(~filter=Log.isConnection)
+          // VERIFY: No ConnectedTo* lifecycle events were logged
           Assert.deepStrictEqual(loggedEvents, [])
         }
       },
@@ -1575,6 +1588,7 @@ describe("Connection", () => {
       "should update connection.paths but not PreferredCandidate after automatic fallback download",
       async () => {
         let logChannel = Chan.make()
+        let listener = Log.collect(logChannel)
         await Config.Connection.setAgdaPaths(logChannel, [])
         await Config.Connection.DownloadPolicy.set(Undecided)
         let memento = Memento.make(None)
@@ -1591,6 +1605,28 @@ describe("Connection", () => {
 
         switch result {
         | Ok(connection) =>
+          let establishFlowEvents =
+            listener(~filter=log =>
+              switch log {
+              | Log.Connection(Log.Connection.EstablishFlow(_)) => true
+              | _ => false
+              }
+            )
+            ->Array.filterMap(log =>
+              switch log {
+              | Log.Connection(Log.Connection.EstablishFlow(event)) => Some(event)
+              | _ => None
+              }
+            )
+            ->Array.map(establishFlowSnapshot)
+
+          Assert.deepStrictEqual(establishFlowEvents, [
+            "ConfigCandidatesStarted:1",
+            "CandidateAttempted:/invalid/path:from config",
+            "ConfigCandidatesFailed",
+            "DownloadFallbackStarted:dev:macos-arm64",
+            "ConnectionEstablished:" ++ downloadedAgda.contents ++ ":Agda",
+          ])
           Assert.deepStrictEqual(connection->Connection.getPath, downloadedAgda.contents)
           Assert.deepStrictEqual(
             Config.Connection.getAgdaPaths(),

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -64,6 +64,39 @@ let findProbeByLocalPath = (
   )
 }
 
+let resourceFromRawPath = raw =>
+  switch Connection__URI.parse(raw) {
+  | FileURI(_, uri) => uri
+  }
+
+let observeProbeFlow = () => {
+  let events: array<Log.Connection.ProbeFlow.t> = []
+  let onProbeFlow = event => events->Array.push(event)
+  (events, onProbeFlow)
+}
+
+let probeFlowSnapshot = event =>
+  switch event {
+  | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+    "CandidateResolveStarted:" ++ Connection__Candidate.toString(candidate)
+  | Log.Connection.ProbeFlow.CandidateResolved(original, resource) =>
+    "CandidateResolved:" ++ Connection__Candidate.toString(original) ++ "->" ++ VSCode.Uri.toString(resource)
+  | Log.Connection.ProbeFlow.CandidateResolveFailed(original, commandError) =>
+    "CandidateResolveFailed:" ++
+    Connection__Candidate.toString(original) ++
+    "->" ++
+    Connection__Command.Error.toString(commandError)
+  | Log.Connection.ProbeFlow.ProbeStarted(resource) => "ProbeStarted:" ++ VSCode.Uri.toString(resource)
+  | Log.Connection.ProbeFlow.ProbeClassifiedAsAgda(path, version) =>
+    "ProbeClassifiedAsAgda:" ++ path ++ ":" ++ version
+  | Log.Connection.ProbeFlow.ProbeClassifiedAsALS(path, alsVersion, agdaVersion) =>
+    "ProbeClassifiedAsALS:" ++ path ++ ":" ++ alsVersion ++ ":" ++ agdaVersion
+  | Log.Connection.ProbeFlow.ProbeClassifiedAsALSWASM(pathOrUri) =>
+    "ProbeClassifiedAsALSWASM:" ++ pathOrUri
+  | Log.Connection.ProbeFlow.ProbeFailed(pathKey, probeError) =>
+    "ProbeFailed:" ++ pathKey ++ ":" ++ Connection__Error.Probe.toString(probeError)
+  }
+
 let getAgdaTarget = async () => {
   let platformDeps = Desktop.make()
   switch await Connection.fromPathsOrCommands(
@@ -207,12 +240,17 @@ describe("Connection", () => {
     Async.it(
       "should correctly identify Agda executable",
       async () => {
-        let result = await Connection.probeFilepath(agdaMockPath.contents)
+        let (events, onProbeFlow) = observeProbeFlow()
+        let result = await Connection.probeFilepath(agdaMockPath.contents, ~onProbeFlow)
 
         switch result {
         | Ok(path, IsAgda(version)) =>
           Assert.deepStrictEqual(path, agdaMockPath.contents)
           Assert.deepStrictEqual(version, "2.6.4.1")
+          Assert.deepStrictEqual(events->Array.map(probeFlowSnapshot), [
+            "ProbeStarted:" ++ resourceFromRawPath(agdaMockPath.contents)->VSCode.Uri.toString,
+            "ProbeClassifiedAsAgda:" ++ probeKeyForLocalPath(agdaMockPath.contents) ++ ":2.6.4.1",
+          ])
         | Ok(_, _) => Assert.fail("Expected Agda result, got ALS")
         | Error(_) => Assert.fail("Expected successful probe of Agda mock")
         }
@@ -222,7 +260,8 @@ describe("Connection", () => {
     Async.it(
       "should correctly identify ALS executable",
       async () => {
-        let result = await Connection.probeFilepath(alsMockPath.contents)
+        let (events, onProbeFlow) = observeProbeFlow()
+        let result = await Connection.probeFilepath(alsMockPath.contents, ~onProbeFlow)
 
         switch result {
         | Ok(path, IsALS(alsVersion, agdaVersion, lspOptions)) =>
@@ -231,6 +270,12 @@ describe("Connection", () => {
           Assert.deepStrictEqual(agdaVersion, "2.6.4")
           // lspOptions should be None for this mock (no prebuilt data directory)
           Assert.deepStrictEqual(lspOptions, None)
+          Assert.deepStrictEqual(events->Array.map(probeFlowSnapshot), [
+            "ProbeStarted:" ++ resourceFromRawPath(alsMockPath.contents)->VSCode.Uri.toString,
+            "ProbeClassifiedAsALS:" ++
+            probeKeyForLocalPath(alsMockPath.contents) ++
+            ":1.2.3:2.6.4",
+          ])
         | Ok(_, _) => Assert.fail("Expected ALS result, got Agda")
         | Error(_) => Assert.fail("Expected successful probe of ALS mock")
         }
@@ -257,14 +302,26 @@ describe("Connection", () => {
           tempFile
         }
 
-        let result = await Connection.probeFilepath(mockPath)
+        let (events, onProbeFlow) = observeProbeFlow()
+        let result = await Connection.probeFilepath(mockPath, ~onProbeFlow)
 
         switch result {
-        | Error(Connection__Error.Probe.NotAgdaOrALS(output)) =>
-          // Trim output to handle potential newline characters
-          Assert.deepStrictEqual(String.trim(output), mockOutput)
+        | Error(probeError) =>
+          switch probeError {
+          | Connection__Error.Probe.NotAgdaOrALS(output) =>
+            // Trim output to handle potential newline characters
+            Assert.deepStrictEqual(String.trim(output), mockOutput)
+          | _ => Assert.fail("Expected NotAgdaOrALS error, got different error")
+          }
+
+          Assert.deepStrictEqual(events->Array.map(probeFlowSnapshot), [
+            "ProbeStarted:" ++ resourceFromRawPath(mockPath)->VSCode.Uri.toString,
+            "ProbeFailed:" ++
+            probeKeyForLocalPath(mockPath) ++
+            ":" ++
+            Connection__Error.Probe.toString(probeError),
+          ])
         | Ok(_) => Assert.fail("Expected NotAgdaOrALS error")
-        | Error(_) => Assert.fail("Expected NotAgdaOrALS error, got different error")
         }
 
         // Cleanup
@@ -1744,11 +1801,16 @@ describe("Connection", () => {
         // Probe using a file:// URI (as stored in connection.paths for WASM downloads)
         let fileUri = VSCode.Uri.file(wasmPath)
         let uriString = VSCode.Uri.toString(fileUri)
-        let result = await Connection.probeFilepath(uriString)
+        let (events, onProbeFlow) = observeProbeFlow()
+        let result = await Connection.probeFilepath(uriString, ~onProbeFlow)
 
         switch result {
         | Ok((resolvedPath, _probeResult)) =>
           assertLocalPathEqual(resolvedPath, wasmPath)
+          Assert.deepStrictEqual(events->Array.map(probeFlowSnapshot), [
+            "ProbeStarted:" ++ fileUri->VSCode.Uri.toString,
+            "ProbeClassifiedAsALSWASM:" ++ resolvedPath,
+          ])
         | Error(_) => Assert.fail("Expected WASM probe to succeed")
         }
 

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -99,8 +99,8 @@ let probeFlowSnapshot = event =>
 
 let establishFlowSnapshot = event =>
   switch event {
-  | Log.Connection.EstablishFlow.ConfigCandidatesStarted(count) =>
-    "ConfigCandidatesStarted:" ++ string_of_int(count)
+  | Log.Connection.EstablishFlow.ConfigCandidatesPlanned(count) =>
+    "ConfigCandidatesPlanned:" ++ string_of_int(count)
   | Log.Connection.EstablishFlow.CandidateAttempted(pathOrCommand, source) =>
     "CandidateAttempted:" ++ pathOrCommand ++ ":" ++ Connection.Error.Establish.pathSourceToString(source)
   | Log.Connection.EstablishFlow.ConfigCandidatesFailed => "ConfigCandidatesFailed"
@@ -110,8 +110,8 @@ let establishFlowSnapshot = event =>
     ++ ":"
     ++ Connection__Download__DownloadArtifact.Platform.toAssetTag(platform)
   | Log.Connection.EstablishFlow.DownloadFallbackFailed(_error) => "DownloadFallbackFailed"
-  | Log.Connection.EstablishFlow.ConnectionEstablished(path, kind) =>
-    "ConnectionEstablished:"
+  | Log.Connection.EstablishFlow.ConnectionCreated(path, kind) =>
+    "ConnectionCreated:"
     ++ path
     ++ ":"
     ++ switch kind {
@@ -1340,7 +1340,7 @@ describe("Connection", () => {
           let establishFlowEvents = collectEstablishFlow(listener)
 
           Assert.deepStrictEqual(establishFlowEvents, [
-            "ConfigCandidatesStarted:1",
+            "ConfigCandidatesPlanned:1",
             "CandidateAttempted:/nonexistent/path:from config",
             "ConfigCandidatesFailed",
             "DownloadFallbackStarted:dev:macos-arm64",
@@ -1469,9 +1469,9 @@ describe("Connection", () => {
         switch result {
         | Ok(connection) =>
           Assert.deepStrictEqual(establishFlowEvents, [
-            "ConfigCandidatesStarted:1",
+            "ConfigCandidatesPlanned:1",
             "CandidateAttempted:" ++ agdaMockPath ++ ":from config",
-            "ConnectionEstablished:" ++ agdaMockPath ++ ":Agda",
+            "ConnectionCreated:" ++ agdaMockPath ++ ":Agda",
           ])
           // Should have logged connection to the mock path
           Assert.deepStrictEqual(
@@ -1786,11 +1786,11 @@ describe("Connection", () => {
           let establishFlowEvents = collectEstablishFlow(listener)
 
           Assert.deepStrictEqual(establishFlowEvents, [
-            "ConfigCandidatesStarted:1",
+            "ConfigCandidatesPlanned:1",
             "CandidateAttempted:/invalid/path:from config",
             "ConfigCandidatesFailed",
             "DownloadFallbackStarted:dev:macos-arm64",
-            "ConnectionEstablished:" ++ downloadedAgda.contents ++ ":Agda",
+            "ConnectionCreated:" ++ downloadedAgda.contents ++ ":Agda",
           ])
           Assert.deepStrictEqual(connection->Connection.getPath, downloadedAgda.contents)
           Assert.deepStrictEqual(

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -122,20 +122,50 @@ let establishFlowSnapshot = event =>
   | Log.Connection.EstablishFlow.ConnectionEstablishFailed => "ConnectionEstablishFailed"
   }
 
-let collectEstablishFlow = (listener: (~filter: Log.t => bool=?) => array<Log.t>) =>
-  listener(~filter=log =>
-    switch log {
-    | Log.Connection(Log.Connection.EstablishFlow(_)) => true
-    | _ => false
-    }
-  )
+let collectConnectionFlowSnapshots = (
+  listener: (~filter: Log.t => bool=?) => array<Log.t>,
+  pickEvent: Log.Connection.t => option<'event>,
+  toSnapshot: 'event => string,
+): array<string> =>
+  listener()
   ->Array.filterMap(log =>
     switch log {
-    | Log.Connection(Log.Connection.EstablishFlow(event)) => Some(event)
+    | Log.Connection(connectionEvent) => pickEvent(connectionEvent)
     | _ => None
     }
   )
-  ->Array.map(establishFlowSnapshot)
+  ->Array.map(toSnapshot)
+
+let collectEstablishFlow = (listener: (~filter: Log.t => bool=?) => array<Log.t>) =>
+  collectConnectionFlowSnapshots(
+    listener,
+    connectionEvent =>
+      switch connectionEvent {
+      | Log.Connection.EstablishFlow(event) => Some(event)
+      | _ => None
+      },
+    establishFlowSnapshot,
+  )
+
+let activationFlowSnapshot = event =>
+  switch event {
+  | Log.Connection.ActivationFlow.ActivationStarted => "ActivationStarted"
+  | Log.Connection.ActivationFlow.ExistingConnectionReused => "ExistingConnectionReused"
+  | Log.Connection.ActivationFlow.FreshEstablishStarted => "FreshEstablishStarted"
+  | Log.Connection.ActivationFlow.ActivationSucceeded => "ActivationSucceeded"
+  | Log.Connection.ActivationFlow.ActivationFailed => "ActivationFailed"
+  }
+
+let collectActivationFlow = (listener: (~filter: Log.t => bool=?) => array<Log.t>) =>
+  collectConnectionFlowSnapshots(
+    listener,
+    connectionEvent =>
+      switch connectionEvent {
+      | Log.Connection.ActivationFlow(event) => Some(event)
+      | _ => None
+      },
+    activationFlowSnapshot,
+  )
 
 let getAgdaTarget = async () => {
   let platformDeps = Desktop.make()
@@ -1049,6 +1079,88 @@ describe("Connection", () => {
 
   describe("make with logging", () => {
     Async.it(
+      "State__Connection.sendRequest should log ActivationFlow for reused existing connection",
+      async () => {
+        let ctx = await AgdaMode.makeAndLoad("GoalTypeAndContext.agda")
+        let listener = Log.collect(ctx.channels.log)
+
+        let _ = await ctx.state->State__Connection.sendRequestAndCollectResponses(Request.Load)
+        let activationEvents = collectActivationFlow(listener)
+
+        Assert.deepStrictEqual(activationEvents, [
+          "ActivationStarted",
+          "ExistingConnectionReused",
+          "ActivationSucceeded",
+        ])
+        await ctx->AgdaMode.quit
+      },
+    )
+
+    Async.it(
+      "State__Connection.sendRequest should log ActivationFlow for fresh establish failure",
+      async () => {
+        let configLogChannel = Chan.make()
+        let previousPaths = Config.Connection.getAgdaPaths()
+        let restorePaths = async () => {
+          await Config.Connection.setAgdaPaths(configLogChannel, previousPaths)
+        }
+        await Config.Connection.setAgdaPaths(
+          configLogChannel,
+          ["/__activation_flow_test_nonexistent__/agda"],
+        )
+
+        module FailingPlatform = {
+          let determinePlatform = async () => Ok(Connection__Download__Platform.MacOS_Arm)
+          let askUserAboutDownloadPolicy = async () => Config.Connection.DownloadPolicy.No
+          let alreadyDownloaded = _ => Promise.resolve(None)
+          let resolveDownloadChannel = (_channel, _allowFallback) =>
+            async (_memento, _globalStorageUri, _platform) =>
+              Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
+          let download = (_globalStorageUri, _source, ~trace as _=Connection__Download__Trace.noop) =>
+            Promise.resolve(Error(Connection__Download__Error.CannotFindCompatibleALSRelease))
+          let findCommand = (_command, ~timeout as _timeout=1000) =>
+            Promise.resolve(Error(Connection__Command.Error.NotFound))
+        }
+
+        let channels: State.channels = {
+          inputMethod: Chan.make(),
+          responseHandled: Chan.make(),
+          commandHandled: Chan.make(),
+          log: Chan.make(),
+        }
+        let listener = Log.collect(channels.log)
+        let editor = await File.open_(Path.asset("GoalTypeAndContext.agda"))
+        let state = State.make(
+          "activation-failure-" ++ string_of_int(int_of_float(Js.Date.now())),
+          module(FailingPlatform),
+          channels,
+          VSCode.Uri.file("/tmp/test-storage"),
+          Path.extensionUri,
+          Memento.make(None),
+          editor,
+          None,
+        )
+
+        try {
+          await State__Connection.sendRequest(state, _response => Promise.resolve(), Request.Load)
+          let activationEvents = collectActivationFlow(listener)
+          Assert.deepStrictEqual(activationEvents, [
+            "ActivationStarted",
+            "FreshEstablishStarted",
+            "ActivationFailed",
+          ])
+          let _ = await State.destroy(state, false)
+          await restorePaths()
+        } catch {
+        | exn =>
+          let _ = await State.destroy(state, false)
+          await restorePaths()
+          raise(exn)
+        }
+      },
+    )
+
+    Async.it(
       "should log ConnectedToAgda when Agda connection succeeds",
       async () => {
         /**
@@ -1234,6 +1346,26 @@ describe("Connection", () => {
             "DownloadFallbackStarted:dev:macos-arm64",
             "DownloadFallbackFailed",
             "ConnectionEstablishFailed",
+          ])
+
+          let probeFlowEvents = collectConnectionFlowSnapshots(
+            listener,
+            connectionEvent =>
+              switch connectionEvent {
+              | Log.Connection.ProbeFlow(event) => Some(event)
+              | _ => None
+              },
+            event =>
+              switch event {
+              | Log.Connection.ProbeFlow.ProbeFailed(pathKey, _) => "ProbeFailed:" ++ pathKey
+              | other => probeFlowSnapshot(other)
+              },
+          )
+          Assert.deepStrictEqual(probeFlowEvents, [
+            "CandidateResolveStarted:file:///nonexistent/path",
+            "CandidateResolved:file:///nonexistent/path->file:///nonexistent/path",
+            "ProbeStarted:file:///nonexistent/path",
+            "ProbeFailed:/nonexistent/path",
           ])
 
           let loggedEvents = listener(~filter=Log.isConnection)

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -122,6 +122,21 @@ let establishFlowSnapshot = event =>
   | Log.Connection.EstablishFlow.ConnectionEstablishFailed => "ConnectionEstablishFailed"
   }
 
+let collectEstablishFlow = (listener: (~filter: Log.t => bool=?) => array<Log.t>) =>
+  listener(~filter=log =>
+    switch log {
+    | Log.Connection(Log.Connection.EstablishFlow(_)) => true
+    | _ => false
+    }
+  )
+  ->Array.filterMap(log =>
+    switch log {
+    | Log.Connection(Log.Connection.EstablishFlow(event)) => Some(event)
+    | _ => None
+    }
+  )
+  ->Array.map(establishFlowSnapshot)
+
 let getAgdaTarget = async () => {
   let platformDeps = Desktop.make()
   switch await Connection.fromPathsOrCommands(
@@ -1180,9 +1195,23 @@ describe("Connection", () => {
         let logChannel = Chan.make()
         let listener = Log.collect(logChannel)
 
-        // Create minimal memento and platformDeps (using mock to avoid dialogs)
+        // Create minimal memento and platformDeps with deterministic fallback failure
         let memento = Memento.make(None)
-        let platformDeps = Mock.Platform.makeBasic()
+        let platformDeps: Platform.t = {
+          module MockPlatform = {
+            let determinePlatform = async () => Ok(Connection__Download__Platform.MacOS_Arm)
+            let askUserAboutDownloadPolicy = async () => Config.Connection.DownloadPolicy.Yes
+            let alreadyDownloaded = _ => Promise.resolve(None)
+            let resolveDownloadChannel = (_channel, _allowFallback) =>
+              async (_memento, _globalStorageUri, _platform) =>
+                Error(Connection__Download__Error.CannotFindCompatibleALSRelease)
+            let download = (_globalStorageUri, _source, ~trace as _=Connection__Download__Trace.noop) =>
+              Promise.resolve(Error(Connection__Download__Error.CannotFindCompatibleALSRelease))
+            let findCommand = (_command, ~timeout as _timeout=1000) =>
+              Promise.resolve(Error(Connection__Command.Error.NotFound))
+          }
+          module(MockPlatform)
+        }
         let globalStorageUri = VSCode.Uri.file("/tmp/test-storage")
 
         // INVOKE: Connection.makeWithFallback with invalid paths and commands
@@ -1196,6 +1225,17 @@ describe("Connection", () => {
         ) {
         | Ok(_) => Assert.fail("Expected connection to fail")
         | Error(_) =>
+          let establishFlowEvents = collectEstablishFlow(listener)
+
+          Assert.deepStrictEqual(establishFlowEvents, [
+            "ConfigCandidatesStarted:1",
+            "CandidateAttempted:/nonexistent/path:from config",
+            "ConfigCandidatesFailed",
+            "DownloadFallbackStarted:dev:macos-arm64",
+            "DownloadFallbackFailed",
+            "ConnectionEstablishFailed",
+          ])
+
           let loggedEvents = listener(~filter=Log.isConnection)
           // VERIFY: No ConnectedTo* lifecycle events were logged
           Assert.deepStrictEqual(loggedEvents, [])
@@ -1291,10 +1331,16 @@ describe("Connection", () => {
           ["invalid-command"], // invalid commands
           logChannel,
         )
+        let establishFlowEvents = collectEstablishFlow(listener)
         let loggedEvents = listener(~filter=Log.isConnection)
 
         switch result {
         | Ok(connection) =>
+          Assert.deepStrictEqual(establishFlowEvents, [
+            "ConfigCandidatesStarted:1",
+            "CandidateAttempted:" ++ agdaMockPath ++ ":from config",
+            "ConnectionEstablished:" ++ agdaMockPath ++ ":Agda",
+          ])
           // Should have logged connection to the mock path
           Assert.deepStrictEqual(
             loggedEvents,
@@ -1605,20 +1651,7 @@ describe("Connection", () => {
 
         switch result {
         | Ok(connection) =>
-          let establishFlowEvents =
-            listener(~filter=log =>
-              switch log {
-              | Log.Connection(Log.Connection.EstablishFlow(_)) => true
-              | _ => false
-              }
-            )
-            ->Array.filterMap(log =>
-              switch log {
-              | Log.Connection(Log.Connection.EstablishFlow(event)) => Some(event)
-              | _ => None
-              }
-            )
-            ->Array.map(establishFlowSnapshot)
+          let establishFlowEvents = collectEstablishFlow(listener)
 
           Assert.deepStrictEqual(establishFlowEvents, [
             "ConfigCandidatesStarted:1",

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -1381,11 +1381,14 @@ describe("Connection", () => {
               | other => probeFlowSnapshot(other)
               },
           )
+          let Connection__URI.FileURI(_, nonexistentUri) = Connection__URI.parse("/nonexistent/path")
+          let nonexistentUriString = VSCode.Uri.toString(nonexistentUri)
+          let nonexistentFsPath = VSCode.Uri.fsPath(nonexistentUri)
           Assert.deepStrictEqual(probeFlowEvents, [
-            "CandidateResolveStarted:file:///nonexistent/path",
-            "CandidateResolved:file:///nonexistent/path->file:///nonexistent/path",
-            "ProbeStarted:file:///nonexistent/path",
-            "ProbeFailed:/nonexistent/path",
+            "CandidateResolveStarted:" ++ nonexistentUriString,
+            "CandidateResolved:" ++ nonexistentUriString ++ "->" ++ nonexistentUriString,
+            "ProbeStarted:" ++ nonexistentUriString,
+            "ProbeFailed:" ++ nonexistentFsPath,
           ])
 
           let loggedEvents = listener(~filter=Log.isConnection)

--- a/test/tests/Test__Connection.res
+++ b/test/tests/Test__Connection.res
@@ -120,6 +120,15 @@ let establishFlowSnapshot = event =>
        | Log.Connection.EstablishFlow.ALSWASM => "ALSWASM"
        }
   | Log.Connection.EstablishFlow.ConnectionEstablishFailed => "ConnectionEstablishFailed"
+  | Log.Connection.EstablishFlow.ConnectionFinalizeFailed(path, kind) =>
+    "ConnectionFinalizeFailed:"
+    ++ path
+    ++ ":"
+    ++ switch kind {
+       | Log.Connection.EstablishFlow.Agda => "Agda"
+       | Log.Connection.EstablishFlow.ALS => "ALS"
+       | Log.Connection.EstablishFlow.ALSWASM => "ALSWASM"
+       }
   }
 
 let collectConnectionFlowSnapshots = (
@@ -177,6 +186,17 @@ let getAgdaTarget = async () => {
   | Error(_) => failwith("expected to find `agda`")
   }
 }
+
+describe("establishFlowSnapshot", () => {
+  it("should format ConnectionFinalizeFailed correctly", () => {
+    Assert.deepStrictEqual(
+      establishFlowSnapshot(
+        Log.Connection.EstablishFlow.ConnectionFinalizeFailed("/some/path", Log.Connection.EstablishFlow.Agda),
+      ),
+      "ConnectionFinalizeFailed:/some/path:Agda",
+    )
+  })
+})
 
 // TODO: rewrite everything here
 describe("Connection", () => {

--- a/test/tests/Test__Connection__Candidate.res
+++ b/test/tests/Test__Connection__Candidate.res
@@ -340,20 +340,87 @@ describe("Connection__Candidate", () => {
   })
 
   describe("resolve", () => {
+    let probeFlowSnapshot = event =>
+      switch event {
+      | Log.Connection.ProbeFlow.CandidateResolveStarted(candidate) =>
+        "CandidateResolveStarted:" ++ Candidate.toString(candidate)
+      | Log.Connection.ProbeFlow.CandidateResolved(original, resource) =>
+        "CandidateResolved:" ++
+        Candidate.toString(original) ++
+        "->" ++
+        VSCode.Uri.toString(resource)
+      | Log.Connection.ProbeFlow.CandidateResolveFailed(original, commandError) =>
+        "CandidateResolveFailed:" ++
+        Candidate.toString(original) ++
+        "->" ++
+        Connection__Command.Error.toString(commandError)
+      | Log.Connection.ProbeFlow.ProbeStarted(_)
+      | Log.Connection.ProbeFlow.ProbeClassifiedAsAgda(_, _)
+      | Log.Connection.ProbeFlow.ProbeClassifiedAsALS(_, _, _)
+      | Log.Connection.ProbeFlow.ProbeClassifiedAsALSWASM(_)
+      | Log.Connection.ProbeFlow.ProbeFailed(_, _) => "UnexpectedProbeFlowVariant"
+      }
+
+    let observeResolveProbeFlow = () => {
+      let events: array<Log.Connection.ProbeFlow.t> = []
+      let onCandidateResolveStarted = candidate =>
+        events->Array.push(Log.Connection.ProbeFlow.CandidateResolveStarted(candidate))
+      let onCandidateResolved = (original, resource) =>
+        events->Array.push(Log.Connection.ProbeFlow.CandidateResolved(original, resource))
+      let onCandidateResolveFailed = (original, commandError) =>
+        events->Array.push(Log.Connection.ProbeFlow.CandidateResolveFailed(original, commandError))
+      (events, onCandidateResolveStarted, onCandidateResolved, onCandidateResolveFailed)
+    }
+
     Async.it("should resolve Command through Platform.findCommand", async () => {
       let findCommand = (command, ~timeout as _timeout=1000) =>
         switch command {
         | "agda" => Promise.resolve(Ok(sampleResolvedPath))
         | _ => Promise.resolve(Error(Connection__Command.Error.NotFound))
         }
+      let candidate = Candidate.make("agda")
+      let (events, onCandidateResolveStarted, onCandidateResolved, onCandidateResolveFailed) =
+        observeResolveProbeFlow()
 
-      switch await Candidate.resolve(findCommand, Candidate.make("agda")) {
+      switch await Candidate.resolve(
+        findCommand,
+        candidate,
+        ~onCandidateResolveStarted,
+        ~onCandidateResolved,
+        ~onCandidateResolveFailed,
+      ) {
       | Ok({original: Command("agda"), resource}) =>
         let expected = VSCode.Uri.file(sampleResolvedPath)->VSCode.Uri.toString
         Assert.deepStrictEqual(resource->VSCode.Uri.toString, expected)
+        Assert.deepStrictEqual(events->Array.map(probeFlowSnapshot), [
+          "CandidateResolveStarted:agda",
+          "CandidateResolved:agda->" ++ expected,
+        ])
       | Error(_) => Assert.fail("Expected command resolution to succeed")
       | _ => Assert.fail("Expected resolved command to preserve original candidate")
       }
+    })
+
+    Async.it("should emit CandidateResolveFailed when command candidate cannot be resolved", async () => {
+      let findCommand = (_command, ~timeout as _timeout=1000) =>
+        Promise.resolve(Error(Connection__Command.Error.NotFound))
+      let candidate = Candidate.make("agda")
+      let (events, onCandidateResolveStarted, onCandidateResolved, onCandidateResolveFailed) =
+        observeResolveProbeFlow()
+
+      let result = await Candidate.resolve(
+        findCommand,
+        candidate,
+        ~onCandidateResolveStarted,
+        ~onCandidateResolved,
+        ~onCandidateResolveFailed,
+      )
+
+      Assert.deepStrictEqual(result, Error(Connection__Command.Error.NotFound))
+      Assert.deepStrictEqual(events->Array.map(probeFlowSnapshot), [
+        "CandidateResolveStarted:agda",
+        "CandidateResolveFailed:agda->Command not found",
+      ])
     })
 
     Async.it("should leave Resource unchanged when resolving", async () => {


### PR DESCRIPTION
  ## Summary

  This PR adds structured, connection-scoped observability across the main connection lifecycle.

  New event families under Log.Connection:

  - DownloadFlow
  - ProbeFlow
  - EstablishFlow
  - ActivationFlow
  - SwitchUIFlow

  ## What changed

  - Added typed download-flow events and wired them through download selection, source resolution, managed storage, and execution paths
  - Added typed probe-flow events for candidate resolution and probing
  - Added typed establish-flow events for config probing, fallback, connection creation, and failure/finalization outcomes
  - Added activation-flow events in State__Connection.sendRequest
  - Added switch-ui events in Connection__Switch.switchAgdaVersion

  ## Semantics clarified

  - ConnectionEstablished -> ConnectionCreated
  - ConfigCandidatesStarted -> ConfigCandidatesPlanned
  - added ConnectionFinalizeFailed for post-establish switch failures

  ## Testing

  Strengthened tests across:

  - download UI / download flow
  - probe flow
  - establish flow
  - activation flow
  - switch UI flow