### PR TITLE
Align workflows for trunk-based PR flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         
       - name: Install dependencies
-        run: npm version && npm install
+        run: npm version && npm ci
         
       - name: Build stuff
         run: npm run dry-run-publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ defaults:
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master, dev, web, ci, ci-* ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, dev, ci, ci-* ]
+    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This PR aligns CI workflows with trunk-based development. It restricts test workflow triggers to master-only PR/push events. 

It updates release workflow `checkout` action to `v6`, and switches release dependency install from `npm install` to `npm ci` for deterministic builds.