### PR TITLE
Use layout-independent Backslash for input method activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,8 @@ Press backslash "\\" and you should see a keyboard popping up in the panel, with
 
 Unicode input also works in the input prompt, though it's a bit less powerful.
 
-If you are having trouble typing the backslash "\\", you can change it by:
-1. Go to "Preferences: Open Keyboard Shortcuts" and configure the keybinding of "Agda: Activate input method" (`agda-mode.input-symbol[Activate]`).
-2. Go to "Settings > Agda Mode > Input Method: Activation Key" and replace it with the same keybinding as above.
+If you are having trouble typing the backslash "\\", go to "Preferences: Open Keyboard Shortcuts" and configure the keybinding of "Agda: Activate input method" (`agda-mode.input-symbol[Activate]`).
+By default, this command is bound to VS Code's layout-independent `[Backslash]` scan code.
 
 Cancel `agdaMode.inputMethod.enable` in the settings to disable the input method.
 

--- a/package.json
+++ b/package.json
@@ -702,11 +702,6 @@
 			},
 			{
 				"command": "agda-mode.input-symbol[Activate]",
-				"key": "\\",
-				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && editorTextFocus && variableLanguage"
-			},
-			{
-				"command": "agda-mode.input-symbol[Activate]",
 				"key": "[Backslash]",
 				"when": "config.agdaMode.inputMethod.enabled && !agdaModeTyping && editorLangId =~ /.*(l?agda(-(markdown|typst|latex|tex|rst|org|forester))?).*/ && editorTextFocus"
 			},


### PR DESCRIPTION
  ## Summary

  - remove the layout-dependent `\` keybinding for input method activation
  - remove the unrelated `variableLanguage` guard along with that binding
  - keep the layout-independent `[Backslash]` scan-code binding
  - update README instructions for rebinding the input method shortcut

  ## Motivation

  On some keyboard layouts, such as Neo2.0, VS Code can report `ISO_Level3_Shift` as `\`. This caused `agda-mode.input-symbol[Activate]` to trigger
  unexpectedly through the layout-dependent `\` binding.

  The removed binding also depended on `variableLanguage`, which is a VS Code debugger context key for debug variable visualizations, not an Agda
  editor or keyboard-layout context. The remaining `[Backslash]` binding uses the normal Agda editor/input-method guards.

  Fixes #259