### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## v0.10.0 - 2026-06-07
+
+### Changed
+- #319: Publish the fixes from the 0.9.x pre-release line on the stable channel, including the fixed ALS download flow for stable users by [@banacorn](https://github.com/banacorn)
+- #318: Shorten VS Code test runner temp paths on Unix to avoid IPC socket limits during local test runs by [@banacorn](https://github.com/banacorn)
+
+### Fixed
+- #316/#317: Show a panel warning when a cached Agda load reports no goals even though the source file still contains holes by [@banacorn](https://github.com/banacorn)
+- #318: Fix input method slowdown by rebasing token offsets after document edits, including cross-file definition offsets for Unicode and CRLF files by [@banacorn](https://github.com/banacorn)
+
 ## v0.9.2 - 2026-05-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "agda-mode",
-	"version": "0.9.2",
+	"version": "0.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "agda-mode",
-			"version": "0.9.2",
+			"version": "0.10.0",
 			"dependencies": {
 				"@andy0130tw/binary-search-tree": "^5.3.2-fork.0",
 				"@glennsl/rescript-fetch": "^v0.2.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "agda-mode on vscode",
 	"icon": "asset/logo.png",
 	"publisher": "banacorn",
-	"version": "0.9.2",
+	"version": "0.10.0",
 	"engines": {
 		"vscode": "^1.94.0"
 	},


### PR DESCRIPTION

### Changed
- #319: Publish the fixes from the 0.9.x pre-release line on the stable channel, including the fixed ALS download flow for stable users by [@banacorn](https://github.com/banacorn)
- #318: Shorten VS Code test runner temp paths on Unix to avoid IPC socket limits during local test runs by [@banacorn](https://github.com/banacorn)

### Fixed
- #316/#317: Show a panel warning when a cached Agda load reports no goals even though the source file still contains holes by [@banacorn](https://github.com/banacorn)
- #318: Fix input method slowdown by rebasing token offsets after document edits, including cross-file definition offsets for Unicode and CRLF files by [@banacorn](https://github.com/banacorn)
